### PR TITLE
Fjerner flyktningstatus fra dummy-inngangsvilkår og tekster

### DIFF
--- a/dev-server/mock/inngangsvilkår-1.json
+++ b/dev-server/mock/inngangsvilkår-1.json
@@ -14,10 +14,6 @@
           {
             "type": "TRE_ÅRS_MEDLEMSKAP",
             "resultat": "IKKE_VURDERT"
-          },
-          {
-            "type": "DOKUMENTERT_FLYKTNINGSTATUS",
-            "resultat": "IKKE_VURDERT"
           }
         ]
       },

--- a/src/frontend/komponenter/Behandling/Inngangsvilkår/vilkår.ts
+++ b/src/frontend/komponenter/Behandling/Inngangsvilkår/vilkår.ts
@@ -70,7 +70,6 @@ export const vilkårTypeTilTekst: Record<VilkårType, string> = {
 
 export enum DelvilkårType {
     TRE_ÅRS_MEDLEMSKAP = 'TRE_ÅRS_MEDLEMSKAP',
-    DOKUMENTERT_FLYKTNINGSTATUS = 'DOKUMENTERT_FLYKTNINGSTATUS',
     BOR_OG_OPPHOLDER_SEG_I_NORGE = 'BOR_OG_OPPHOLDER_SEG_I_NORGE',
     DOKUMENTERT_EKTESKAP = 'DOKUMENTERT_EKTESKAP',
     DOKUMENTERT_SEPARASJON_ELLER_SKILSMISSE = 'DOKUMENTERT_SEPARASJON_ELLER_SKILSMISSE',
@@ -81,7 +80,6 @@ export enum DelvilkårType {
 
 export const delvilkårTypeTilTekst: Record<DelvilkårType, string> = {
     TRE_ÅRS_MEDLEMSKAP: 'Har bruker vært medlem i folketrygden i de siste 3 årene?',
-    DOKUMENTERT_FLYKTNINGSTATUS: 'Er flyktningstatus dokumentert?',
     BOR_OG_OPPHOLDER_SEG_I_NORGE: 'Bor og oppholder bruker og barna seg i Norge?',
     DOKUMENTERT_EKTESKAP: 'Foreligger det dokumentasjon på ekteskap?',
     DOKUMENTERT_SEPARASJON_ELLER_SKILSMISSE:


### PR DESCRIPTION
Flyktningstatus skal ikke lenger vurderes og derfor fjerner jeg det fra dummy-inngangsvilkårene og tekstene våre. Endringene er allerede merget i backend, så ingen ting skal brekke. 