### PR TITLE
Sivilstand styling endringer

### DIFF
--- a/src/frontend/komponenter/Behandling/Inngangsvilkår/Sivilstand/SivilstandVisning.tsx
+++ b/src/frontend/komponenter/Behandling/Inngangsvilkår/Sivilstand/SivilstandVisning.tsx
@@ -14,7 +14,7 @@ interface Props {
 const SivilstandVisning: FC<Props> = ({ sivilstand, erOppfylt }) => {
     const { registergrunnlag, søknadsgrunnlag } = sivilstand;
     const sivilstatusOgDato = registergrunnlag.gyldigFraOgMed
-        ? `${sivilstandTilTekst[registergrunnlag.type]}. ${registergrunnlag.gyldigFraOgMed}`
+        ? `${sivilstandTilTekst[registergrunnlag.type]} ${registergrunnlag.gyldigFraOgMed}`
         : sivilstandTilTekst[registergrunnlag.type];
 
     return (

--- a/src/frontend/komponenter/Behandling/Inngangsvilkår/Sivilstand/Søknadsinformasjon.tsx
+++ b/src/frontend/komponenter/Behandling/Inngangsvilkår/Sivilstand/Søknadsinformasjon.tsx
@@ -4,6 +4,7 @@ import { Søknadsgrunnlag } from '../../../Felleskomponenter/Visning/DataGrunnla
 import { Normaltekst } from 'nav-frontend-typografi';
 import { ISivilstandSøknadsgrunnlag } from './typer';
 import { BooleanTekst } from '../../../Felleskomponenter/Visning/StyledTekst';
+import { hentBooleanTekst } from '../utils';
 
 interface Props {
     sivilstandtype: SivilstandType;
@@ -35,13 +36,19 @@ const Søknadsinformasjon: FC<Props> = ({ sivilstandtype, søknad }) => {
                 <>
                     <Søknadsgrunnlag />
                     <Normaltekst>Søkt separasjon, skilsmisse eller reist sak</Normaltekst>
-                    {søknad.søktOmSkilsmisseSeparasjon && (
-                        <BooleanTekst value={søknad.søktOmSkilsmisseSeparasjon} />
+                    {søknad.søktOmSkilsmisseSeparasjon !== undefined && (
+                        <Normaltekst>
+                            {`${hentBooleanTekst(søknad.søktOmSkilsmisseSeparasjon)}, 
+                            ${søknad.datoSøktSeparasjon} `}
+                        </Normaltekst>
                     )}
-
-                    <Søknadsgrunnlag />
-                    <Normaltekst>Dato</Normaltekst>
-                    <Normaltekst>{søknad.datoSøktSeparasjon}</Normaltekst>
+                    {søknad.fraflytningsdato && (
+                        <>
+                            <Søknadsgrunnlag />
+                            <Normaltekst>Dato for fraflytting</Normaltekst>
+                            <Normaltekst>{søknad.fraflytningsdato}</Normaltekst>
+                        </>
+                    )}
                 </>
             );
         case SivilstandType.SEPARERT:

--- a/src/frontend/komponenter/Behandling/Inngangsvilkår/utils.ts
+++ b/src/frontend/komponenter/Behandling/Inngangsvilkår/utils.ts
@@ -1,0 +1,1 @@
+export const hentBooleanTekst = (value: boolean): string => (value ? 'Ja' : 'Nei');

--- a/src/frontend/komponenter/Felleskomponenter/Visning/StyledTabell.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Visning/StyledTabell.tsx
@@ -11,6 +11,10 @@ export const StyledTabell = styled.div`
     grid-gap: 0.5rem;
     margin-bottom: 3rem;
 
+    > .typo-normal {
+        padding-right: 2.5rem;
+    }
+
     svg {
         max-height: 24px;
         grid-column: 1/2;


### PR DESCRIPTION
Løser stylingendringer **2,3,6, og 7** (_bla ned til tabellen_) fått fra Lars og Mirja - les mer på [favrokortet](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-2195): 


**Diskusjon:**
Mirja ønsker at begrunnelsefeltet dersom søker er skilt eller hvis ugift og svart nei på spørsmål om gift/separert i utlandet (linje 52 og 55 i confluence) skal være valgfritt om vilkår er oppfylt (ja).

### Skjermbilde: 
![Skjermbilde 2021-01-06 kl  20 21 51](https://user-images.githubusercontent.com/8249453/103811194-d70b7e00-505c-11eb-8600-1c79a40e9113.png)

^ Her vil ikke Lagre-knappen dukke opp før noe er skrevet inn i feltet. Det jeg mener å kan huske er at dette var det vi endte opp med etter en liknende diskusjon med valgfrie kommentarfelter og spm som kun dukket opp "hvis hvis". 
Lurer på om vi diskuterte om vi ikke skulle ha et felt til som bestemte om feltet var valgfritt eller ikke sendt inn fra BE. 🤔  Noen som husker noe om dette? @charliemidtlyng 

 ^ Hvis vi likevel går for dette, trekker jeg det ut i egen branch. Men skal vi ha denne "hvis hvis" logikken fra BE eller FE? I FE vil du mest sannsynligvis ha en funksjon som sjekker. I BE, burde man legge til en attributt av no slag som sier om feltet skal være valgfritt eller ikke? 