### PR TITLE
Valgfritt begrunnelsefelt

### DIFF
--- a/src/frontend/komponenter/Behandling/Inngangsvilkår/Sivilstand/SivilstandHelper.ts
+++ b/src/frontend/komponenter/Behandling/Inngangsvilkår/Sivilstand/SivilstandHelper.ts
@@ -1,0 +1,29 @@
+import { SivilstandType } from '../../../../typer/personopplysninger';
+import { DelvilkårType, IDelvilkår, Vilkårsresultat } from '../vilkår';
+
+export const erSkiltEllerUgift = (sivilstandType: SivilstandType): boolean =>
+    sivilstandType === SivilstandType.UGIFT ||
+    sivilstandType === SivilstandType.SKILT ||
+    sivilstandType === SivilstandType.SKILT_PARTNER ||
+    sivilstandType === SivilstandType.UOPPGITT;
+
+export const erEnkeEllerEnkemann = (sivilstandType: SivilstandType): boolean =>
+    sivilstandType === SivilstandType.ENKE_ELLER_ENKEMANN ||
+    sivilstandType === SivilstandType.GJENLEVENDE_PARTNER;
+
+export const erEnkeEllerGjenlevendePartner = (sivilstandType: SivilstandType): boolean =>
+    sivilstandType === SivilstandType.ENKE_ELLER_ENKEMANN ||
+    sivilstandType === SivilstandType.GJENLEVENDE_PARTNER;
+
+export const erIkkeUformeltGiftEllerSeparert = (
+    erUformeltGift: boolean | undefined,
+    erUformeltSeparertEllerSkilt: boolean | undefined
+): boolean => !erUformeltGift || !erUformeltSeparertEllerSkilt;
+
+export const erKravForSivilstandOppfylt = (delvilkår: IDelvilkår[]): boolean => {
+    const delvilkårKravSivilstand: IDelvilkår | undefined = delvilkår.find(
+        (delvilkår) => delvilkår.type === DelvilkårType.KRAV_SIVILSTAND
+    );
+
+    return delvilkårKravSivilstand?.resultat === Vilkårsresultat.JA;
+};

--- a/src/frontend/komponenter/Behandling/Inngangsvilkår/Sivilstand/SivilstandHelper.ts
+++ b/src/frontend/komponenter/Behandling/Inngangsvilkår/Sivilstand/SivilstandHelper.ts
@@ -7,10 +7,6 @@ export const erSkiltEllerUgift = (sivilstandType: SivilstandType): boolean =>
     sivilstandType === SivilstandType.SKILT_PARTNER ||
     sivilstandType === SivilstandType.UOPPGITT;
 
-export const erEnkeEllerEnkemann = (sivilstandType: SivilstandType): boolean =>
-    sivilstandType === SivilstandType.ENKE_ELLER_ENKEMANN ||
-    sivilstandType === SivilstandType.GJENLEVENDE_PARTNER;
-
 export const erEnkeEllerGjenlevendePartner = (sivilstandType: SivilstandType): boolean =>
     sivilstandType === SivilstandType.ENKE_ELLER_ENKEMANN ||
     sivilstandType === SivilstandType.GJENLEVENDE_PARTNER;

--- a/src/frontend/komponenter/Behandling/Inngangsvilkår/Sivilstand/SivilstandVurdering.tsx
+++ b/src/frontend/komponenter/Behandling/Inngangsvilkår/Sivilstand/SivilstandVurdering.tsx
@@ -11,7 +11,6 @@ import {
 } from '../../Vurdering/VurderingUtil';
 import Unntak from '../../Vurdering/Unntak';
 import {
-    erEnkeEllerEnkemann,
     erEnkeEllerGjenlevendePartner,
     erIkkeUformeltGiftEllerSeparert,
     erKravForSivilstandOppfylt,
@@ -57,7 +56,7 @@ const SivilstandVurdering: FC<{ props: VurderingProps }> = ({ props }) => {
 
     const visBegrunnelse: boolean =
         harBesvartPåAlleDelvilkår(delvilkårsvurderinger) &&
-        (!erEnkeEllerEnkemann || vurdering.unntak !== null);
+        (!erEnkeEllerGjenlevendePartner(sivilstandType) || vurdering.unntak !== null);
 
     return (
         <>

--- a/src/frontend/komponenter/Behandling/Vurdering/VurderingUtil.ts
+++ b/src/frontend/komponenter/Behandling/Vurdering/VurderingUtil.ts
@@ -2,6 +2,7 @@ import { IDelvilkår, IVurdering, VilkårGruppe, Vilkårsresultat } from '../Inn
 import { IVilkårConfig, VurderingConfig } from '../Inngangsvilkår/config/VurderingConfig';
 import { SivilstandType } from '../../../typer/personopplysninger';
 import { VilkårStatus } from '../../Felleskomponenter/Visning/VilkårOppfylt';
+import { erEnkeEllerEnkemann } from '../Inngangsvilkår/Sivilstand/SivilstandHelper';
 
 export const alleErOppfylte = (vurderinger: IVurdering[]): boolean =>
     vurderinger.filter((vurdering) => vurdering.resultat !== Vilkårsresultat.JA).length === 0;
@@ -66,12 +67,9 @@ export const skalViseLagreKnappSivilstand = (
     if (manglerBegrunnelse(begrunnelse)) {
         return false;
     }
-    const erEnkeEllerEnkemann =
-        sivilstandType === SivilstandType.ENKE_ELLER_ENKEMANN ||
-        sivilstandType === SivilstandType.GJENLEVENDE_PARTNER;
 
     if (harBesvartPåAlleDelvilkår(delvilkårsvurderinger)) {
-        return erEnkeEllerEnkemann ? !!vurdering.unntak : true;
+        return erEnkeEllerEnkemann(sivilstandType) ? !!vurdering.unntak : true;
     }
     return false;
 };

--- a/src/frontend/komponenter/Behandling/Vurdering/VurderingUtil.ts
+++ b/src/frontend/komponenter/Behandling/Vurdering/VurderingUtil.ts
@@ -2,7 +2,7 @@ import { IDelvilkår, IVurdering, VilkårGruppe, Vilkårsresultat } from '../Inn
 import { IVilkårConfig, VurderingConfig } from '../Inngangsvilkår/config/VurderingConfig';
 import { SivilstandType } from '../../../typer/personopplysninger';
 import { VilkårStatus } from '../../Felleskomponenter/Visning/VilkårOppfylt';
-import { erEnkeEllerEnkemann } from '../Inngangsvilkår/Sivilstand/SivilstandHelper';
+import { erEnkeEllerGjenlevendePartner } from '../Inngangsvilkår/Sivilstand/SivilstandHelper';
 
 export const alleErOppfylte = (vurderinger: IVurdering[]): boolean =>
     vurderinger.filter((vurdering) => vurdering.resultat !== Vilkårsresultat.JA).length === 0;
@@ -71,7 +71,7 @@ export const skalViseLagreKnappSivilstand = (
     }
 
     if (harBesvartPåAlleDelvilkår(delvilkårsvurderinger)) {
-        return erEnkeEllerEnkemann(sivilstandType) ? !!vurdering.unntak : true;
+        return erEnkeEllerGjenlevendePartner(sivilstandType) ? !!vurdering.unntak : true;
     }
     return false;
 };

--- a/src/frontend/komponenter/Behandling/Vurdering/VurderingUtil.ts
+++ b/src/frontend/komponenter/Behandling/Vurdering/VurderingUtil.ts
@@ -31,6 +31,7 @@ export const filtrerVurderinger = (
         }
         return config.vilkårGruppe === vilkårGruppe;
     });
+
 export const harBesvartPåAlleDelvilkår = (delvilkårsvurderinger: IDelvilkår[]): boolean =>
     !delvilkårsvurderinger.some((delvilkår) => delvilkår.resultat === Vilkårsresultat.IKKE_VURDERT);
 
@@ -60,11 +61,12 @@ export const skalViseLagreKnapp = (vurdering: IVurdering, config: IVilkårConfig
 
 export const skalViseLagreKnappSivilstand = (
     vurdering: IVurdering,
-    sivilstandType: SivilstandType
+    sivilstandType: SivilstandType,
+    erBegrunnelseFeltValgfritt: boolean
 ): boolean => {
     const { begrunnelse, delvilkårsvurderinger } = vurdering;
 
-    if (manglerBegrunnelse(begrunnelse)) {
+    if (manglerBegrunnelse(begrunnelse) && !erBegrunnelseFeltValgfritt) {
         return false;
     }
 


### PR DESCRIPTION
**Gjør begrunnelsefelt valgfritt (med beskrivende tekst) hvis:**
- Søker er **skilt** eller **ugift**
- Søker er **ikke** uformelt gift, skilt eller separert i utlandet (linje 52 og 55 i confluence) 
- Vilkår er oppfylt ("ja" på "er krav oppfylt?")

[Tilhørende favro-kort](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-2195)

![valgfrittBegrunnelseFelt](https://user-images.githubusercontent.com/8249453/104359783-62c75380-5510-11eb-8fef-26bbe01b33e5.gif)

![image](https://user-images.githubusercontent.com/8249453/104359982-a9b54900-5510-11eb-9196-36c3ced97a8b.png)


