### PR TITLE
Endringer etter feedback medlemskap og opphold

### DIFF
--- a/src/frontend/komponenter/Behandling/Inngangsvilkår/Medlemskap/InnflyttingUtflytting.tsx
+++ b/src/frontend/komponenter/Behandling/Inngangsvilkår/Medlemskap/InnflyttingUtflytting.tsx
@@ -22,7 +22,7 @@ const InnflyttingUtflytting: React.FC<Props> = ({ innflytting, utflytting }) => 
             <Tabell
                 kolonner={[
                     {
-                        overskrift: 'Innflytting til',
+                        overskrift: 'Innflytting fra',
                         tekstVerdi: (innflytting) =>
                             slåSammenTekst(
                                 innflytting.fraflyttingsland,
@@ -40,7 +40,7 @@ const InnflyttingUtflytting: React.FC<Props> = ({ innflytting, utflytting }) => 
             <Tabell
                 kolonner={[
                     {
-                        overskrift: 'Utflytting fra',
+                        overskrift: 'Utflytting til',
                         tekstVerdi: (utflytting) =>
                             slåSammenTekst(
                                 utflytting.tilflyttingsland,

--- a/src/frontend/komponenter/Behandling/Inngangsvilkår/Medlemskap/Utenlandsopphold.tsx
+++ b/src/frontend/komponenter/Behandling/Inngangsvilkår/Medlemskap/Utenlandsopphold.tsx
@@ -15,16 +15,16 @@ const Utenlandsopphold: FC<Props> = ({ utenlandsopphold }) => (
         verdier={utenlandsopphold}
         kolonner={[
             {
-                overskrift: 'Årsak',
-                tekstVerdi: (d) => d.årsak,
-            },
-            {
                 overskrift: 'Fra',
                 tekstVerdi: (d) => formaterNullableIsoDato(d.fraDato),
             },
             {
                 overskrift: 'Til',
                 tekstVerdi: (d) => formaterNullableIsoDato(d.tilDato),
+            },
+            {
+                overskrift: 'Årsak',
+                tekstVerdi: (d) => d.årsak,
             },
         ]}
     />

--- a/src/frontend/komponenter/Behandling/Inngangsvilkår/Opphold/OppholdVisning.tsx
+++ b/src/frontend/komponenter/Behandling/Inngangsvilkår/Opphold/OppholdVisning.tsx
@@ -11,10 +11,10 @@ import Lesmerpanel from 'nav-frontend-lesmerpanel';
 import { StyledLesmerpanel } from '../../../Felleskomponenter/Visning/StyledNavKomponenter';
 import { VilkårStatus, VilkårStatusIkon } from '../../../Felleskomponenter/Visning/VilkårOppfylt';
 import { IMedlemskap } from '../Medlemskap/typer';
-import Statsborgerskap from '../Medlemskap/Statsborgerskap';
 import Oppholdstillatelse from '../Medlemskap/Oppholdstillatelse';
 import Utenlandsopphold from '../Medlemskap/Utenlandsopphold';
 import InnflyttingUtflytting from '../Medlemskap/InnflyttingUtflytting';
+import FolkeregisterPersonstatus from '../Medlemskap/FolkeregisterPersonstatus';
 
 interface Props {
     medlemskap: IMedlemskap;
@@ -49,7 +49,9 @@ const OppholdVisning: FC<Props> = ({ medlemskap, vilkårStatus }) => {
 
             <StyledLesmerpanel>
                 <Lesmerpanel apneTekst={'Vis info om opphold'} lukkTekst={'Lukk info om opphold'}>
-                    <Statsborgerskap statsborgerskap={registergrunnlag.statsborgerskap} />
+                    <FolkeregisterPersonstatus
+                        status={registergrunnlag.folkeregisterpersonstatus}
+                    />
                     {finnesOppholdsstatus && (
                         <Oppholdstillatelse oppholdsstatus={registergrunnlag.oppholdstatus} />
                     )}

--- a/src/frontend/komponenter/Behandling/Vurdering/GenerellVurdering.tsx
+++ b/src/frontend/komponenter/Behandling/Vurdering/GenerellVurdering.tsx
@@ -58,7 +58,11 @@ const GenerellVurdering: FC<{
                 />
             )}
             <Textarea
-                label="Begrunnelse"
+                label={
+                    config.begrunnelsePåkrevdHvisOppfylt
+                        ? 'Begrunnelse'
+                        : 'Begrunnelse (hvis aktuelt)'
+                }
                 maxLength={0}
                 placeholder="Skriv inn tekst"
                 value={vurdering.begrunnelse || ''}


### PR DESCRIPTION
Småendringer etter funksjonell testing av medlemskap og opphold. Endringene står beskrevet under "Funksjonell test" på 
[favro kortet](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-2972) 

Endringer:
1. Rekkefølge på til/fra og årsak i `<Utenlandsopphold ... />` er byttet. Til/fra skal komme før årsak
2. Legger på "(Hvis aktuelt)" på frivillige begrunnelsefelt
3. Legger til `<FolkeregisterPersonStatus ... />` i Opphold
4. Fjerner `<Statsborgerskap ... />` i Opphold
5. Tekstendringer: "Innflytting til" -> "Innflytting fra" og "Utflytting fra" -> "Utflytting til"