### PR TITLE
oppdatert visning av adresser med visFlere/Skjul knappen

### DIFF
--- a/src/frontend/komponenter/Behandling/Personopplysninger/Adressehistorikk.tsx
+++ b/src/frontend/komponenter/Behandling/Personopplysninger/Adressehistorikk.tsx
@@ -6,6 +6,7 @@ import UIModalWrapper from '../../Felleskomponenter/Modal/UIModalWrapper';
 import { BredTd, KolonneTitler, TabellWrapper } from './TabellWrapper';
 import styled from 'styled-components';
 import { Knapp } from 'nav-frontend-knapper';
+import Lesmerpanel from 'nav-frontend-lesmerpanel';
 
 const StyledKnapp = styled(Knapp)`
     margin-left: 1rem;
@@ -16,49 +17,87 @@ const StyledFlexDiv = styled.div`
     justify-content: space-between;
 `;
 
+const StyledLesmer = styled(Lesmerpanel)`
+    .lesMerPanel__mer {
+        padding-top: 0rem;
+    }
+`;
+
+const StyledTabellWrapper = styled(TabellWrapper)`
+    padding-top: 0rem;
+`;
+
+const MAX_LENGDE_ADRESSER = 5;
+
 const Adressehistorikk: React.FC<{ adresser: IAdresse[] }> = ({ adresser }) => {
-    const [visBeboereModal, settVisBeboereModal] = useState(false);
+    if (adresser.length <= MAX_LENGDE_ADRESSER) {
+        return <Adresser adresser={adresser} />;
+    } else {
+        const introAdresser = adresser.slice(0, MAX_LENGDE_ADRESSER);
+        const visMerAdresser = adresser.slice(MAX_LENGDE_ADRESSER, adresser.length);
+        return (
+            <StyledLesmer
+                className={'adresser'}
+                intro={<Adresser adresser={introAdresser} />}
+                apneTekst={'Vis flere adresser'}
+                lukkTekst={'Skjul adresser'}
+            >
+                <StyledTabellWrapper>
+                    <table className="tabell" style={{ borderTopStyle: 'hidden' }}>
+                        <Innhold adresser={visMerAdresser} />
+                    </table>
+                </StyledTabellWrapper>
+            </StyledLesmer>
+        );
+    }
+};
+
+const Adresser: React.FC<{ adresser: IAdresse[] }> = ({ adresser }) => {
     return (
         <TabellWrapper>
             <TabellOverskrift Ikon={Bygning} tittel={'Adressehistorikk'} />
             <table className="tabell">
                 <KolonneTitler titler={['Adresse', 'Adressetype', 'Fra', 'Til']} />
-                <tbody>
-                    {adresser.map((adresse, indeks) => {
-                        return (
-                            <tr key={indeks}>
-                                <BredTd>{adresse.visningsadresse}</BredTd>
-                                <BredTd>{adresse.type}</BredTd>
-                                <BredTd>{adresse.gyldigFraOgMed}</BredTd>
-                                <BredTd>
-                                    <StyledFlexDiv>
-                                        <div>{adresse.gyldigTilOgMed}</div>
-                                        {adresse.type === AdresseType.BOSTEDADRESSE && (
-                                            <StyledKnapp
-                                                onClick={() => settVisBeboereModal(true)}
-                                                mini
-                                            >
-                                                Se Beboere
-                                            </StyledKnapp>
-                                        )}
-                                        <UIModalWrapper
-                                            modal={{
-                                                tittel: 'Beboere',
-                                                lukkKnapp: true,
-                                                visModal: visBeboereModal,
-                                                onClose: () => settVisBeboereModal(false),
-                                            }}
-                                        >
-                                            *Ikke implementert. Venter på adressesøk i PDL*
-                                        </UIModalWrapper>
-                                    </StyledFlexDiv>
-                                </BredTd>
-                            </tr>
-                        );
-                    })}
-                </tbody>
+                <Innhold adresser={adresser} />
             </table>
         </TabellWrapper>
+    );
+};
+
+const Innhold: React.FC<{ adresser: IAdresse[] }> = ({ adresser }) => {
+    const [visBeboereModal, settVisBeboereModal] = useState(false);
+    return (
+        <tbody>
+            {adresser.map((adresse, indeks) => {
+                return (
+                    <tr key={indeks}>
+                        <BredTd>{adresse.visningsadresse}</BredTd>
+                        <BredTd>{adresse.type}</BredTd>
+                        <BredTd>{adresse.gyldigFraOgMed}</BredTd>
+                        <BredTd>
+                            <StyledFlexDiv>
+                                <div>{adresse.gyldigTilOgMed}</div>
+                                {adresse.type === AdresseType.BOSTEDADRESSE && (
+                                    <StyledKnapp onClick={() => settVisBeboereModal(true)} mini>
+                                        Se Beboere
+                                    </StyledKnapp>
+                                )}
+                                <UIModalWrapper
+                                    modal={{
+                                        tittel: 'Beboere',
+                                        lukkKnapp: true,
+                                        visModal: visBeboereModal,
+                                        onClose: () => settVisBeboereModal(false),
+                                    }}
+                                >
+                                    *Ikke implementert. Venter på adressesøk i PDL*
+                                </UIModalWrapper>
+                            </StyledFlexDiv>
+                        </BredTd>
+                    </tr>
+                );
+            })}
+        </tbody>
     );
 };
 


### PR DESCRIPTION
Har oppdatert Adressehistorikk slik at når det er flere enn 5 adresser så vises "Vis flere adresser" knappen. Ved trykk av knappen vises flere adresser. 

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-3081

<img width="1315" alt="Skjermbilde 2021-01-25 kl  12 48 22" src="https://user-images.githubusercontent.com/8692658/105712869-baa38880-5f1a-11eb-8fbc-e3e6f74e2b1b.png">


<img width="1315" alt="Skjermbilde 2021-01-25 kl  12 38 40" src="https://user-images.githubusercontent.com/8692658/105712756-8c25ad80-5f1a-11eb-8b00-a7d2b37e06e9.png">


<img width="1315" alt="Skjermbilde 2021-01-25 kl  12 39 14" src="https://user-images.githubusercontent.com/8692658/105712844-b1b2b700-5f1a-11eb-88ec-2b1665a93533.png">
