### PR TITLE
Legg til "lag blankett" knapp

### DIFF
--- a/dev-server/mock/hent-oppgave.json
+++ b/dev-server/mock/hent-oppgave.json
@@ -1,88 +1,104 @@
 {
-	"data": {
-		"antallTreffTotalt": 7572,
-		"oppgaver": [{
-			"id": 45060,
-			"journalpostId": "12345",
-			"identer": [{
-				"ident": "11111111111",
-				"gruppe": "FOLKEREGISTERIDENT"
-			}, {
-				"ident": "2195875492274",
-				"gruppe": "AKTOERID"
-			}],
-			"tildeltEnhetsnr": "4833",
-			"saksreferanse": "1024923",
-			"aktoerId": "2195875492274",
-			"beskrivelse": "Det har gått mindre enn fem måneder siden forrige barn ble født.\n----- Opprettet av familie-ba-sak 2020-09-24T21:09:24.913845 --- \nhttps://barnetrygd.nais.adeo.no/fagsak/1024923",
-			"tema": "ENF",
-			"behandlingstema": "ab0071",
-			"oppgavetype": "JFR",
-			"versjon": 1,
-			"fristFerdigstillelse": "2020-09-24",
-			"aktivDato": "2020-09-24",
-			"opprettetTidspunkt": "2020-09-24T21:09:24.96+02:00",
-			"opprettetAv": "srvfamilie-ks-opps",
-			"mappeId": "100000035",
-			"prioritet": "NORM",
-			"status": "OPPRETTET",
-			"metadata": {}
-		}, {
-			"id": 45059,
-			"journalpostId": "12345",
-			"identer": [{
-				"ident": "11111111111",
-				"gruppe": "FOLKEREGISTERIDENT"
-			}, {
-				"ident": "2215826550106",
-				"gruppe": "AKTOERID"
-			}],
-			"tildeltEnhetsnr": "4833",
-			"saksreferanse": "1024921",
-			"aktoerId": "2215826550106",
-			"beskrivelse": "Det er registrert dødsdato på mor.\n----- Opprettet av familie-ba-sak 2020-09-24T21:06:54.912747 --- \nhttps://barnetrygd.nais.adeo.no/fagsak/1024921",
-			"tema": "ENF",
-			"behandlingstema": "ab0071",
-			"oppgavetype": "BEH_SAK",
-			"versjon": 1,
-			"fristFerdigstillelse": "2020-09-24",
-			"aktivDato": "2020-09-24",
-			"opprettetTidspunkt": "2020-09-24T21:06:54.971+02:00",
-			"opprettetAv": "srvfamilie-ks-opps",
-			"mappeId": "100000035",
-			"prioritet": "NORM",
-			"status": "OPPRETTET",
-			"metadata": {}
-		}, {
-			"id": 45058,
-			"journalpostId": "12345",
-			"identer": [{
-				"ident": "11111111111",
-				"gruppe": "FOLKEREGISTERIDENT"
-			}, {
-				"ident": "2926951485035",
-				"gruppe": "AKTOERID"
-			}],
-			"tildeltEnhetsnr": "4833",
-			"saksreferanse": "1024910",
-			"aktoerId": "2926951485035",
-			"beskrivelse": "Vurdert og satt automatisk\n\t- Mor har ikke lovlig opphold - EØS borger. Mor er ikke registrert med arbeidsforhold. Det er ikke registrert medforelder på barnet. Mor har ikke hatt bostedsadresse i Norge i mer enn fem år.\n----- Opprettet av familie-ba-sak 2020-09-24T21:04:24.623183 --- \nhttps://barnetrygd.nais.adeo.no/fagsak/1024910",
-			"tema": "ENF",
-			"behandlingstema": "ab0071",
-			"oppgavetype": "BEH_SAK",
-			"versjon": 1,
-			"fristFerdigstillelse": "2020-09-24",
-			"aktivDato": "2020-09-24",
-			"opprettetTidspunkt": "2020-09-24T21:04:24.656+02:00",
-			"opprettetAv": "srvfamilie-ks-opps",
-			"mappeId": "100000037",
-			"prioritet": "NORM",
-			"status": "OPPRETTET",
-			"metadata": {}
-		}]
-	},
-	"status": "SUKSESS",
-	"melding": "Finn oppgaver OK",
-	"frontendFeilmelding": null,
-	"stacktrace": null
+  "data": {
+    "antallTreffTotalt": 7572,
+    "oppgaver": [
+      {
+        "id": 45060,
+        "journalpostId": "12345",
+        "identer": [
+          {
+            "ident": "11111111111",
+            "gruppe": "FOLKEREGISTERIDENT"
+          },
+          {
+            "ident": "2195875492274",
+            "gruppe": "AKTOERID"
+          }
+        ],
+        "tildeltEnhetsnr": "4833",
+        "saksreferanse": "1024923",
+        "aktoerId": "2195875492274",
+        "beskrivelse": "Det har gått mindre enn fem måneder siden forrige barn ble født.\n----- Opprettet av familie-ba-sak 2020-09-24T21:09:24.913845 --- \nhttps://barnetrygd.nais.adeo.no/fagsak/1024923",
+        "tema": "ENF",
+        "behandlingstema": "ab0071",
+        "oppgavetype": "JFR",
+        "versjon": 1,
+        "fristFerdigstillelse": "2020-09-24",
+        "aktivDato": "2020-09-24",
+        "opprettetTidspunkt": "2020-09-24T21:09:24.96+02:00",
+        "opprettetAv": "srvfamilie-ks-opps",
+        "mappeId": "100000035",
+        "prioritet": "NORM",
+        "status": "OPPRETTET",
+        "metadata": {},
+        "kanStarteBlankettbehandling": false
+      },
+      {
+        "id": 45059,
+        "journalpostId": "12345",
+        "identer": [
+          {
+            "ident": "11111111111",
+            "gruppe": "FOLKEREGISTERIDENT"
+          },
+          {
+            "ident": "2215826550106",
+            "gruppe": "AKTOERID"
+          }
+        ],
+        "tildeltEnhetsnr": "4833",
+        "saksreferanse": "1024921",
+        "aktoerId": "2215826550106",
+        "beskrivelse": "Det er registrert dødsdato på mor.\n----- Opprettet av familie-ba-sak 2020-09-24T21:06:54.912747 --- \nhttps://barnetrygd.nais.adeo.no/fagsak/1024921",
+        "tema": "ENF",
+        "behandlingstema": "ab0071",
+        "oppgavetype": "BEH_SAK",
+        "versjon": 1,
+        "fristFerdigstillelse": "2020-09-24",
+        "aktivDato": "2020-09-24",
+        "opprettetTidspunkt": "2020-09-24T21:06:54.971+02:00",
+        "opprettetAv": "srvfamilie-ks-opps",
+        "mappeId": "100000035",
+        "prioritet": "NORM",
+        "status": "OPPRETTET",
+        "metadata": {},
+        "kanStarteBlankettbehandling": false
+      },
+      {
+        "id": 45058,
+        "journalpostId": "12345",
+        "identer": [
+          {
+            "ident": "11111111111",
+            "gruppe": "FOLKEREGISTERIDENT"
+          },
+          {
+            "ident": "2926951485035",
+            "gruppe": "AKTOERID"
+          }
+        ],
+        "tildeltEnhetsnr": "4833",
+        "saksreferanse": "1024910",
+        "aktoerId": "2926951485035",
+        "beskrivelse": "Vurdert og satt automatisk\n\t- Mor har ikke lovlig opphold - EØS borger. Mor er ikke registrert med arbeidsforhold. Det er ikke registrert medforelder på barnet. Mor har ikke hatt bostedsadresse i Norge i mer enn fem år.\n----- Opprettet av familie-ba-sak 2020-09-24T21:04:24.623183 --- \nhttps://barnetrygd.nais.adeo.no/fagsak/1024910",
+        "tema": "ENF",
+        "behandlingstema": "ab0071",
+        "oppgavetype": "BEH_SAK",
+        "versjon": 1,
+        "fristFerdigstillelse": "2020-09-24",
+        "aktivDato": "2020-09-24",
+        "opprettetTidspunkt": "2020-09-24T21:04:24.656+02:00",
+        "opprettetAv": "srvfamilie-ks-opps",
+        "mappeId": "100000037",
+        "prioritet": "NORM",
+        "status": "OPPRETTET",
+        "metadata": {},
+        "kanStarteBlankettbehandling": true
+      }
+    ]
+  },
+  "status": "SUKSESS",
+  "melding": "Finn oppgaver OK",
+  "frontendFeilmelding": null,
+  "stacktrace": null
 }

--- a/src/frontend/komponenter/Oppgavebenk/OppgaveRad.tsx
+++ b/src/frontend/komponenter/Oppgavebenk/OppgaveRad.tsx
@@ -70,16 +70,25 @@ const OppgaveRad: React.FC<Props> = ({ oppgave }) => {
                 <td>{oppgave.tilordnetRessurs || 'Ikke tildelt'}</td>
                 <td>
                     <Flatknapp
+                        hidden={!oppgave.kanStarteBlankettbehandling}
+                        onClick={startBlankettBehandling}
+                    >
+                        Lag blankett
+                    </Flatknapp>
+                    <Flatknapp
                         hidden={!kanJournalføres(oppgave.behandlingstema, oppgave.oppgavetype)}
                         onClick={gåTilJournalføring}
                     >
                         Gå til journalpost
                     </Flatknapp>
                     <Flatknapp
-                        hidden={!kanBehandles(oppgave.behandlingstema, oppgave.oppgavetype)}
+                        hidden={
+                            !kanBehandles(oppgave.behandlingstema, oppgave.oppgavetype) ||
+                            oppgave.kanStarteBlankettbehandling
+                        }
                         onClick={gåTilBehandleSakOppgave}
                     >
-                        Behandle sak
+                        Start Behandling
                     </Flatknapp>
                 </td>
             </tr>
@@ -92,7 +101,6 @@ const OppgaveRad: React.FC<Props> = ({ oppgave }) => {
                 }}
             >
                 <Normaltekst>{feilmelding}</Normaltekst>
-                <Flatknapp onClick={startBlankettBehandling}>Opprett blankettbehandling</Flatknapp>
             </UIModalWrapper>
         </>
     );

--- a/src/frontend/komponenter/Oppgavebenk/oppgave.ts
+++ b/src/frontend/komponenter/Oppgavebenk/oppgave.ts
@@ -35,4 +35,5 @@ export interface IOppgave {
     endretTidspunkt?: string;
     prioritet?: Prioritet; //OppgavePrioritet
     status?: string; //StatusEnum
+    kanStarteBlankettbehandling: boolean;
 }


### PR DESCRIPTION
NB! <Backendfyr lager frontendkode!> 

Dersom en oppgave har kanStarteBlankettbehandling=true bør vi ikke kunne journalføre, eller starte en vanlig behandling. Denne tilhører allerede infotrygd. 

Kanskje unødvendig med "||   oppgave.kanStarteBlankettbehandling" på "Start behandling"?
Kanskje burde vi også legge denne på journalføring? 