### PR TITLE
Smalere kolonnebredde ved flere enn 3 kolonner

### DIFF
--- a/src/frontend/komponenter/Felleskomponenter/Visning/StyledTabell.tsx
+++ b/src/frontend/komponenter/Felleskomponenter/Visning/StyledTabell.tsx
@@ -5,7 +5,7 @@ export const GridTabell = styled.div<{ kolonner?: number; underTabellMargin?: nu
     display: grid;
     grid-template-columns: 21px 250px repeat(
             ${(props) => (props.kolonner ? props.kolonner - 2 : 2)},
-            300px
+            ${(props) => (props.kolonner && props.kolonner > 3 ? '150px' : '300px')}
         );
     grid-auto-rows: min-content;
     grid-gap: 0.5rem;


### PR DESCRIPTION
[Favro.](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-4126)

Gjør kolonnebredden smalere ved 4 kolonner, slik at ikke høyresiden blir dyttet ut av syne pga "Nytt barn samme partner"