### PR TITLE
Formatterer teksten for navn i sivilstand, då "med" ikke passer hvis …

### DIFF
--- a/src/frontend/komponenter/Behandling/Inngangsvilkår/Sivilstand/SivilstandInfo.tsx
+++ b/src/frontend/komponenter/Behandling/Inngangsvilkår/Sivilstand/SivilstandInfo.tsx
@@ -5,6 +5,7 @@ import { Registergrunnlag } from '../../../Felleskomponenter/Visning/DataGrunnla
 import { ISivilstandInngangsvilkår } from './typer';
 import { sivilstandTilTekst } from '../../../../typer/personopplysninger';
 import Søknadsinformasjon from './Søknadsinformasjon';
+import { formaterIsoDato } from '../../../../utils/formatter';
 
 interface Props {
     sivilstand: ISivilstandInngangsvilkår;
@@ -20,7 +21,8 @@ const SivilstandInfo: FC<Props> = ({ sivilstand }) => {
                 <Normaltekst>
                     {sivilstandTilTekst[registergrunnlag.type]}
                     {registergrunnlag.navn && ` - ${registergrunnlag.navn}`}
-                    {registergrunnlag.gyldigFraOgMed && ` (${registergrunnlag.gyldigFraOgMed})`}
+                    {registergrunnlag.gyldigFraOgMed &&
+                        ` (${formaterIsoDato(registergrunnlag.gyldigFraOgMed)})`}
                 </Normaltekst>
 
                 <Søknadsinformasjon

--- a/src/frontend/komponenter/Behandling/Inngangsvilkår/Sivilstand/SivilstandInfo.tsx
+++ b/src/frontend/komponenter/Behandling/Inngangsvilkår/Sivilstand/SivilstandInfo.tsx
@@ -19,8 +19,8 @@ const SivilstandInfo: FC<Props> = ({ sivilstand }) => {
                 <Normaltekst>Sivilstatus</Normaltekst>
                 <Normaltekst>
                     {sivilstandTilTekst[registergrunnlag.type]}
-                    {registergrunnlag.navn && ' med ' + registergrunnlag.navn}
-                    {registergrunnlag.gyldigFraOgMed && ' - ' + registergrunnlag.gyldigFraOgMed}
+                    {registergrunnlag.navn && ` - ${registergrunnlag.navn}`}
+                    {registergrunnlag.gyldigFraOgMed && ` (${registergrunnlag.gyldigFraOgMed})`}
                 </Normaltekst>
 
                 <Søknadsinformasjon


### PR DESCRIPTION
…man er skilt: "skilt med X"
Fiks av formattering for https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-4206

https://nav-it.slack.com/archives/C01087QRJ2U/p1619087723267300?thread_ts=1618999138.257600&cid=C01087QRJ2U

Kombinasjonene blir då
```
Gift
Gift - Bob Burger
Gift - Bob Burger (01.01.2020)
Gift (01.01.2020)
```