### PR TITLE
Tar i bruk ghcr og sletter att man bygger image i build-dev

### DIFF
--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -2,7 +2,6 @@ name: Build app
 
 on: [pull_request, workflow_dispatch]
 env:
-  IMAGE: docker.pkg.github.com/${{ github.repository }}/familie-ef-sak-frontend:${{ github.sha }}
 
 jobs:
   build:
@@ -14,9 +13,3 @@ jobs:
         run: |
           yarn
           yarn build
-      - name: Bygg Docker image
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          docker build . -t ${IMAGE}
-          docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}

--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -1,7 +1,6 @@
 name: Build app
 
 on: [pull_request, workflow_dispatch]
-env:
 
 jobs:
   build:

--- a/.github/workflows/build_n_deploy_dev.yaml
+++ b/.github/workflows/build_n_deploy_dev.yaml
@@ -2,7 +2,7 @@ name: Build, push, and deploy app to dev
 
 on: [workflow_dispatch]
 env:
-  IMAGE: docker.pkg.github.com/${{ github.repository }}/familie-ef-sak-frontend:${{ github.sha }}
+  IMAGE: ghcr.io/navikt/familie-ef-sak-frontend:${{ github.sha }}
 
 jobs:
   build:
@@ -10,14 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Yarn build
+        run: |
+          yarn
+          yarn build
       - name: Build and publish Docker image
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          yarn
-          yarn build
           docker build . -t ${IMAGE}
-          docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
+          echo ${GITHUB_TOKEN} | docker login ghcr.io --username ${GITHUB_REPOSITORY} --password-stdin
           docker push ${IMAGE}
   deploy:
     name: Deploy to NAIS

--- a/.github/workflows/build_n_deploy_prod.yaml
+++ b/.github/workflows/build_n_deploy_prod.yaml
@@ -6,8 +6,8 @@ on:
       - 'master'
 
 env:
-  IMAGE: docker.pkg.github.com/${{ github.repository }}/familie-ef-sak-frontend:${{ github.sha }}
-  IMAGE_LATEST: docker.pkg.github.com/${{ github.repository }}/familie-ef-sak-frontend:latest
+  IMAGE: ghcr.io/navikt/familie-ef-sak-frontend:${{ github.sha }}
+  IMAGE_LATEST: ghcr.io/navikt/familie-ef-sak-frontend:latest
 
 jobs:
   build:
@@ -15,14 +15,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
+      - name: Yarn build
+        run: |
+          yarn
+          yarn build
       - name: Build and publish Docker image
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          yarn
-          yarn build
           docker build . -t ${IMAGE} -t ${IMAGE_LATEST}
-          docker login docker.pkg.github.com -u ${GITHUB_REPOSITORY} -p ${GITHUB_TOKEN}
+          echo ${GITHUB_TOKEN} | docker login ghcr.io --username ${GITHUB_REPOSITORY} --password-stdin
           docker push ${IMAGE}
           docker push ${IMAGE_LATEST}
       - name: Post build failures to Slack


### PR DESCRIPTION
Github skal fase ut deres (docker) "Package Registry (GPR)" til fordel for deres "GitHub Container Registry (GHCR)".
https://nav-it.slack.com/archives/C01DE3M9YBV/p1613039240045100

Notere att jeg sletter build image i `build_dev`, ser ikke helt att vi har noe behov for det? 