### PR TITLE
Erstatter fraOgMedDato og tilDato i IBeløpsperiode med periode

### DIFF
--- a/src/frontend/komponenter/Behandling/VedtakOgBeregning/InnvilgeVedtak/Utregningstabell.tsx
+++ b/src/frontend/komponenter/Behandling/VedtakOgBeregning/InnvilgeVedtak/Utregningstabell.tsx
@@ -24,8 +24,8 @@ const Utregningstabell: React.FC<Props> = ({ beregnetStønad }) => {
                                     overskrift: 'Periode',
                                     tekstVerdi: (d) =>
                                         `${formaterNullableMånedÅr(
-                                            d.fraOgMedDato
-                                        )} - ${formaterNullableMånedÅr(d.tilDato)}`,
+                                            d.periode.fradato
+                                        )} - ${formaterNullableMånedÅr(d.periode.tildato)}`,
                                 },
                                 {
                                     overskrift: 'Inntekt (år)',

--- a/src/frontend/typer/vedtak.ts
+++ b/src/frontend/typer/vedtak.ts
@@ -23,8 +23,7 @@ export interface IInntektsperiode {
 }
 
 export interface IBeløpsperiode {
-    fraOgMedDato: string;
-    tilDato: string;
+    periode: { fradato: string; tildato: string };
     beregningsgrunnlag: IBeregningsgrunnlag;
     beløp: number;
 }


### PR DESCRIPTION
Endret responsobjektet (i.e. Beløpsperiode) i denna pr:en https://github.com/navikt/familie-ef-sak/pull/635 og dærfør må endre her for att perioder ska vises riktigt i frontend :) 