### PR TITLE
Småendringer i dokumentlistevisningen

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@navikt/boxed-list-with-links": "^1.0.4",
     "@navikt/familie-backend": "5.0.10",
-    "@navikt/familie-dokumentliste": "^1.0.12",
+    "@navikt/familie-dokumentliste": "^1.0.13",
     "@navikt/familie-form-elements": "^2.2.17",
     "@navikt/familie-header": "^3.0.13",
     "@navikt/familie-ikoner": "^3.1.10",

--- a/src/frontend/komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/komponenter/Behandling/BehandlingContainer.tsx
@@ -29,7 +29,7 @@ const HøyreMenyWrapper = styled.div`
     border-left: 2px solid ${navFarger.navGra40};
     overflow-x: hidden;
     max-width: 20rem;
-    overflow-y: scroll;
+    overflow-y: auto;
 `;
 
 const InnholdWrapper = styled.div`

--- a/src/frontend/komponenter/Høyremeny/Dokumentoversikt.tsx
+++ b/src/frontend/komponenter/Høyremeny/Dokumentoversikt.tsx
@@ -13,7 +13,7 @@ import { useParams } from 'react-router';
 import { IBehandlingParams } from '../../typer/routing';
 import hiddenIf from '../Felleskomponenter/HiddenIf/hiddenIf';
 import styled from 'styled-components';
-import { formaterNullableIsoDato } from '../../utils/formatter';
+import { formaterNullableIsoDatoTid } from '../../utils/formatter';
 
 const StyledDokumentliste = styled(Dokumentliste)`
     .typo-element,
@@ -68,7 +68,7 @@ const Dokumentoversikt: React.FC = () => {
                 {({ dokumentResponse }) => {
                     const dokumenterMedFormatertDato = dokumentResponse.map((dokument) => ({
                         ...dokument,
-                        dato: formaterNullableIsoDato(dokument.dato),
+                        dato: formaterNullableIsoDatoTid(dokument.dato),
                     }));
                     return (
                         <StyledDokumentliste

--- a/src/frontend/komponenter/Høyremeny/Dokumentoversikt.tsx
+++ b/src/frontend/komponenter/Høyremeny/Dokumentoversikt.tsx
@@ -13,6 +13,7 @@ import { useParams } from 'react-router';
 import { IBehandlingParams } from '../../typer/routing';
 import hiddenIf from '../Felleskomponenter/HiddenIf/hiddenIf';
 import styled from 'styled-components';
+import { formaterNullableIsoDato } from '../../utils/formatter';
 
 const StyledDokumentliste = styled(Dokumentliste)`
     .typo-element,
@@ -65,9 +66,13 @@ const Dokumentoversikt: React.FC = () => {
             {lastNedDokumentFeilet && <AlertStripeFeil>{lastNedDokumentFeilet}</AlertStripeFeil>}
             <DataViewer response={{ dokumentResponse }}>
                 {({ dokumentResponse }) => {
+                    const dokumenterMedFormatertDato = dokumentResponse.map((dokument) => ({
+                        ...dokument,
+                        dato: formaterNullableIsoDato(dokument.dato),
+                    }));
                     return (
                         <StyledDokumentliste
-                            dokumenter={dokumentResponse}
+                            dokumenter={dokumenterMedFormatertDato}
                             onClick={lastNedDokument}
                         />
                     );

--- a/src/frontend/komponenter/Høyremeny/Dokumentoversikt.tsx
+++ b/src/frontend/komponenter/Høyremeny/Dokumentoversikt.tsx
@@ -12,6 +12,14 @@ import { useDataHenter } from '../../hooks/felles/useDataHenter';
 import { useParams } from 'react-router';
 import { IBehandlingParams } from '../../typer/routing';
 import hiddenIf from '../Felleskomponenter/HiddenIf/hiddenIf';
+import styled from 'styled-components';
+
+const StyledDokumentliste = styled(Dokumentliste)`
+    .typo-element,
+    .typo-undertekst {
+        text-align: left;
+    }
+`;
 
 const Dokumentoversikt: React.FC = () => {
     const { axiosRequest } = useApp();
@@ -58,7 +66,10 @@ const Dokumentoversikt: React.FC = () => {
             <DataViewer response={{ dokumentResponse }}>
                 {({ dokumentResponse }) => {
                     return (
-                        <Dokumentliste dokumenter={dokumentResponse} onClick={lastNedDokument} />
+                        <StyledDokumentliste
+                            dokumenter={dokumentResponse}
+                            onClick={lastNedDokument}
+                        />
                     );
                 }}
             </DataViewer>

--- a/src/frontend/utils/formatter.ts
+++ b/src/frontend/utils/formatter.ts
@@ -15,6 +15,10 @@ export const formaterIsoDato = (dato: string): string => {
 export const formaterIsoDatoTid = (dato: string): string => {
     return format(parseISO(dato), "dd.MM.yyyy 'kl'.HH:mm");
 };
+
+export const formaterNullableIsoDatoTid = (dato?: string): string | undefined => {
+    return dato && format(parseISO(dato), "dd.MM.yyyy 'kl'.HH:mm");
+};
 export const formaterNullableMånedÅr = (dato?: string): string | undefined =>
     dato && format(parseISO(dato), 'MM.yyyy');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -660,10 +660,10 @@
     nav-frontend-knapper-style "^1.1.2"
     react-tooltip "^4.2.15"
 
-"@navikt/familie-dokumentliste@^1.0.12":
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/@navikt/familie-dokumentliste/-/familie-dokumentliste-1.0.12.tgz#2897f1692b4ef215b947f15fbc2b47e07b39ca4e"
-  integrity sha512-6eStqCBX3nTmlzru64hh08dTP8wlbvhpU/YvQzLuf/tQRzM72oEKILGlXIKWBBfji86vdGf6PzvVUly1zBksfA==
+"@navikt/familie-dokumentliste@^1.0.13":
+  version "1.0.13"
+  resolved "https://registry.yarnpkg.com/@navikt/familie-dokumentliste/-/familie-dokumentliste-1.0.13.tgz#62310a8450c7cffc4a9af831a1b10e5daf00f080"
+  integrity sha512-b6WeLhlkGf1gJi+lsJCCUyrxoqn0VhIdW19g/a6d3By7ehAZS9khBjFeFZQ2BD+D6bxWsETwEBTA9k1L7L53Ow==
   dependencies:
     "@navikt/familie-ikoner" "^3.1.11"
     "@navikt/familie-typer" "^3.0.13"


### PR DESCRIPTION
Endrer overflow-y til auto for å fjerne scrollbaren som alltid visas
Venstrejustert tekst i dokumentlistevisningen
Formatering av dato i visning av dokumentelement

![Skjermbilde 2021-05-26 kl  15 17 03](https://user-images.githubusercontent.com/10879817/119666786-f81b1280-be35-11eb-9c8e-0cfef2296d9c.png)
