### PR TITLE
Hvis man endrer periodetypen settes aktivitet til EAktivitet.IKKE_AKT…

### DIFF
--- a/src/frontend/komponenter/Behandling/VedtakOgBeregning/InnvilgeVedtak/VedtaksperiodeValg.tsx
+++ b/src/frontend/komponenter/Behandling/VedtakOgBeregning/InnvilgeVedtak/VedtaksperiodeValg.tsx
@@ -127,7 +127,19 @@ const VedtaksperiodeValg: React.FC<Props> = ({
         value: string | number | undefined
     ) => {
         const oppdatertListe = vedtaksperiodeData.vedtaksperiodeListe.map((vedtaksperiode, i) => {
-            return i === index ? { ...vedtaksperiode, [property]: value } : vedtaksperiode;
+            if (i !== index) {
+                return vedtaksperiode;
+            }
+            return {
+                ...vedtaksperiode,
+                [property]: value,
+                ...(property === EPeriodeProperty.periodeType && {
+                    [EPeriodeProperty.aktivitet]:
+                        value === EPeriodetype.PERIODE_FØR_FØDSEL
+                            ? EAktivitet.IKKE_AKTIVITETSPLIKT
+                            : undefined,
+                }),
+            };
         });
         settVedtaksperiodeData({
             ...vedtaksperiodeData,

--- a/src/frontend/komponenter/Behandling/VedtakOgBeregning/InnvilgeVedtak/VedtaksperiodeValg.tsx
+++ b/src/frontend/komponenter/Behandling/VedtakOgBeregning/InnvilgeVedtak/VedtaksperiodeValg.tsx
@@ -127,19 +127,18 @@ const VedtaksperiodeValg: React.FC<Props> = ({
         value: string | number | undefined
     ) => {
         const oppdatertListe = vedtaksperiodeData.vedtaksperiodeListe.map((vedtaksperiode, i) => {
-            if (i !== index) {
-                return vedtaksperiode;
-            }
-            return {
-                ...vedtaksperiode,
-                [property]: value,
-                ...(property === EPeriodeProperty.periodeType && {
-                    [EPeriodeProperty.aktivitet]:
-                        value === EPeriodetype.PERIODE_FØR_FØDSEL
-                            ? EAktivitet.IKKE_AKTIVITETSPLIKT
-                            : undefined,
-                }),
-            };
+            return i === index
+                ? {
+                      ...vedtaksperiode,
+                      [property]: value,
+                      ...(property === EPeriodeProperty.periodeType && {
+                          [EPeriodeProperty.aktivitet]:
+                              value === EPeriodetype.PERIODE_FØR_FØDSEL
+                                  ? EAktivitet.IKKE_AKTIVITETSPLIKT
+                                  : undefined,
+                      }),
+                  }
+                : vedtaksperiode;
         });
         settVedtaksperiodeData({
             ...vedtaksperiodeData,


### PR DESCRIPTION
…IVITETSPLIKT hvis periode_før_fødsel, hvis ikke resettes den til undefined

Problem: Når vi innvilger og velger periode før fødsel så ble aktivitet tom streng. Etter endringene i backend med enum i stedet for string så crashet det