### PR TITLE
Saksbehandler som har behandlet behandling skal kunne se brev som er …

### DIFF
--- a/src/frontend/komponenter/Behandling/Brev/Brev.tsx
+++ b/src/frontend/komponenter/Behandling/Brev/Brev.tsx
@@ -8,7 +8,7 @@ import Brevmeny from './Brevmeny';
 import DataViewer from '../../Felleskomponenter/DataViewer/DataViewer';
 import { useApp } from '../../../context/AppContext';
 import { TotrinnskontrollStatus } from '../../../typer/totrinnskontroll';
-import { Steg } from '../../Høyremeny/Steg';
+
 const StyledBrev = styled.div`
     background-color: #f2f2f2;
     padding: 3rem 5rem 3rem 5rem;
@@ -34,13 +34,9 @@ const Brev: React.FC<Props> = ({ behandlingId }) => {
     const {
         behandlingErRedigerbar,
         personopplysningerResponse,
-        behandling,
         totrinnskontroll,
     } = useBehandling();
     const [kanSendesTilBeslutter, settKanSendesTilBeslutter] = useState<boolean>(false);
-    const kanFatteVedtak =
-        totrinnskontroll.status === RessursStatus.SUKSESS &&
-        totrinnskontroll.data.status === TotrinnskontrollStatus.KAN_FATTE_VEDTAK;
 
     const lagBeslutterBrev = () => {
         axiosRequest<string, null>({
@@ -70,9 +66,8 @@ const Brev: React.FC<Props> = ({ behandlingId }) => {
     useEffect(() => {
         if (!behandlingErRedigerbar) {
             if (
-                behandling.status === RessursStatus.SUKSESS &&
-                behandling.data.steg === Steg.BESLUTTE_VEDTAK &&
-                kanFatteVedtak
+                totrinnskontroll.status === RessursStatus.SUKSESS &&
+                totrinnskontroll.data.status === TotrinnskontrollStatus.KAN_FATTE_VEDTAK
             ) {
                 lagBeslutterBrev();
             } else {
@@ -80,7 +75,7 @@ const Brev: React.FC<Props> = ({ behandlingId }) => {
             }
         }
         // eslint-disable-next-line
-    }, [behandlingErRedigerbar, behandling]);
+    }, [behandlingErRedigerbar, totrinnskontroll]);
 
     return (
         <>

--- a/src/frontend/komponenter/Behandling/Brev/Brev.tsx
+++ b/src/frontend/komponenter/Behandling/Brev/Brev.tsx
@@ -7,8 +7,8 @@ import { useBehandling } from '../../../context/BehandlingContext';
 import Brevmeny from './Brevmeny';
 import DataViewer from '../../Felleskomponenter/DataViewer/DataViewer';
 import { useApp } from '../../../context/AppContext';
+import { TotrinnskontrollStatus } from '../../../typer/totrinnskontroll';
 import { Steg } from '../../Høyremeny/Steg';
-
 const StyledBrev = styled.div`
     background-color: #f2f2f2;
     padding: 3rem 5rem 3rem 5rem;
@@ -31,8 +31,16 @@ interface Props {
 const Brev: React.FC<Props> = ({ behandlingId }) => {
     const { axiosRequest } = useApp();
     const [brevRessurs, settBrevRessurs] = useState<Ressurs<string>>(byggTomRessurs());
-    const { behandlingErRedigerbar, personopplysningerResponse, behandling } = useBehandling();
+    const {
+        behandlingErRedigerbar,
+        personopplysningerResponse,
+        behandling,
+        totrinnskontroll,
+    } = useBehandling();
     const [kanSendesTilBeslutter, settKanSendesTilBeslutter] = useState<boolean>(false);
+    const kanFatteVedtak =
+        totrinnskontroll.status === RessursStatus.SUKSESS &&
+        totrinnskontroll.data.status === TotrinnskontrollStatus.KAN_FATTE_VEDTAK;
 
     const lagBeslutterBrev = () => {
         axiosRequest<string, null>({
@@ -63,7 +71,8 @@ const Brev: React.FC<Props> = ({ behandlingId }) => {
         if (!behandlingErRedigerbar) {
             if (
                 behandling.status === RessursStatus.SUKSESS &&
-                behandling.data.steg === Steg.BESLUTTE_VEDTAK
+                behandling.data.steg === Steg.BESLUTTE_VEDTAK &&
+                kanFatteVedtak
             ) {
                 lagBeslutterBrev();
             } else {


### PR DESCRIPTION
…sendt til totrinn. Andre saksbehandlere som ikke har beslutterrolle skal kunne se brev. Saksbehandlere med beslutterrolle skal kunne lage beslutterbrev dersom kanFatteVedtak er true.

Tror jeg kan ta bort de to gamle testene i if'en: 
 behandling.status === RessursStatus.SUKSESS &&
                behandling.data.steg === Steg.BESLUTTE_VEDTAK &&
=>
`if (kanFatteVedtak) {
                lagBeslutterBrev();`
                
Hva tror du @blommish  - dette dekkes vel av kanFatteVedtak?