### PR TITLE
Minske zindex slik att behandlingstatus popovern havnar på topp

### DIFF
--- a/src/frontend/Felleskomponenter/Sticky.tsx
+++ b/src/frontend/Felleskomponenter/Sticky.tsx
@@ -4,5 +4,5 @@ export const Sticky = styled.div`
     position: sticky;
     position: -webkit-sticky;
     top: 0;
-    z-index: 999;
+    z-index: 21;
 `;


### PR DESCRIPTION
Popover har z-index på 100, så sticky måste ha < 100

![Skjermbilde 2021-07-07 kl  18 37 39](https://user-images.githubusercontent.com/10879817/124797420-8533aa00-df52-11eb-8f7c-f32c142ab89b.png)
