### PR TITLE
Når muligeÅr er en tom liste, så settes år til infinity

### DIFF
--- a/src/frontend/Komponenter/Behandling/Simulering/SimuleringTabellWrapper.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/SimuleringTabellWrapper.tsx
@@ -34,7 +34,9 @@ const SimuleringTabellWrapper: React.FC<{ simuleringsresultat: ISimulering }> = 
 }) => {
     const muligeÅr = [...new Set(simuleringsresultat.perioder.map((p) => formaterIsoÅr(p.fom)))];
 
-    const [år, settÅr] = useState(Math.max(...muligeÅr));
+    const [år, settÅr] = useState(
+        muligeÅr.length ? Math.max(...muligeÅr) : new Date().getFullYear()
+    );
 
     const simuleringTabellRader = mapSimuleringstabellRader(simuleringsresultat, år);
 


### PR DESCRIPTION
Når man simulerer frem i tid og simulering returnerer en tom liste så settes år til -ininity, med denne kommer man få dagens år i stedet - hvis det nå gir mer mening? Simulering gir resultat maks 1 måned frem i tid
![image](https://user-images.githubusercontent.com/937168/133391590-e08528dd-ec30-4b59-8960-dbf204b93d20.png)
