### PR TITLE
Hent brevmal fra mellomlager (Gjør at mellomlagring brev funker for alle brevmaler)

### DIFF
--- a/src/frontend/App/hooks/useMellomlagringBrev.ts
+++ b/src/frontend/App/hooks/useMellomlagringBrev.ts
@@ -32,20 +32,25 @@ export interface IMellomlagreBrevReuest {
     brevmal: string;
 }
 
+export interface IMellomlagretBrevResponse {
+    brevverdier?: string;
+    brevmal: string;
+}
+
 export const useMellomlagringBrev = (
-    behandlingId: string,
-    brevmal: string
+    behandlingId: string
 ): {
     mellomlagreBrev: (
         flettefelt: FlettefeltMedVerdi[],
         valgteFelt: ValgtFelt,
-        valgteDelmaler: ValgteDelmaler
+        valgteDelmaler: ValgteDelmaler,
+        brevmal: string
     ) => void;
-    mellomlagretBrev: Ressurs<string | undefined>;
+    mellomlagretBrev: Ressurs<IMellomlagretBrevResponse | undefined>;
 } => {
     const { axiosRequest } = useApp();
     const [mellomlagretBrevRessurs, settMellomlagretBrevRessurs] = useState<
-        Ressurs<string | undefined>
+        Ressurs<IMellomlagretBrevResponse | undefined>
     >(byggTomRessurs());
 
     const sanityVersjon = '1';
@@ -53,7 +58,8 @@ export const useMellomlagringBrev = (
     const mellomlagreBrev = (
         flettefelt: FlettefeltMedVerdi[],
         valgteFelt: ValgtFelt,
-        valgteDelmaler: ValgteDelmaler
+        valgteDelmaler: ValgteDelmaler,
+        brevmal: string
     ): void => {
         axiosRequest<string, IMellomlagretBrev>({
             method: 'POST',
@@ -78,13 +84,15 @@ export const useMellomlagringBrev = (
 
     const hentMellomlagretBrev = useCallback(
         () =>
-            axiosRequest<string | undefined, null>({
+            axiosRequest<IMellomlagretBrevResponse | undefined, null>({
                 method: 'GET',
                 url: `/familie-ef-sak/api/brev/mellomlager/${behandlingId}`,
-                params: { brevmal, sanityVersjon },
-            }).then((res: RessursSuksess<string | undefined> | RessursFeilet) => {
-                settMellomlagretBrevRessurs(res);
-            }),
+                params: { sanityVersjon },
+            }).then(
+                (res: RessursSuksess<IMellomlagretBrevResponse | undefined> | RessursFeilet) => {
+                    settMellomlagretBrevRessurs(res);
+                }
+            ),
         // eslint-disable-next-line
         [behandlingId]
     );

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
@@ -48,7 +48,7 @@ const BrevMenyDelmalWrapper = styled.div<{ førsteElement?: boolean }>`
 export interface BrevmenyVisningProps extends BrevmenyProps {
     brevStruktur: BrevStruktur;
     tilkjentYtelse?: TilkjentYtelse;
-    mellomlagretBrev?: string;
+    mellomlagretBrevVerdier?: string;
     brevMal: string;
     flettefeltStore: { [navn: string]: string };
 }
@@ -60,17 +60,17 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
     settKanSendesTilBeslutter,
     brevStruktur,
     tilkjentYtelse,
-    mellomlagretBrev,
+    mellomlagretBrevVerdier,
     brevMal,
     flettefeltStore,
 }) => {
     const { axiosRequest } = useApp();
-    const { mellomlagreBrev } = useMellomlagringBrev(behandlingId, brevMal);
+    const { mellomlagreBrev } = useMellomlagringBrev(behandlingId);
     const [alleFlettefelter, settAlleFlettefelter] = useState<FlettefeltMedVerdi[]>([]);
 
     useEffect(() => {
         const parsetMellomlagretBrev =
-            mellomlagretBrev && (JSON.parse(mellomlagretBrev) as IBrevverdier);
+            mellomlagretBrevVerdier && (JSON.parse(mellomlagretBrevVerdier) as IBrevverdier);
 
         const { flettefeltFraMellomlager, valgteFeltFraMellomlager, valgteDelmalerFraMellomlager } =
             parsetMellomlagretBrev || {};
@@ -81,7 +81,7 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
         if (valgteDelmalerFraMellomlager) {
             settValgteDelmaler(valgteDelmalerFraMellomlager);
         }
-    }, [brevStruktur, flettefeltStore, mellomlagretBrev]);
+    }, [brevStruktur, flettefeltStore, mellomlagretBrevVerdier]);
 
     const [valgteFelt, settValgteFelt] = useState<ValgtFelt>({});
     const [valgteDelmaler, settValgteDelmaler] = useState<ValgteDelmaler>({});
@@ -152,7 +152,7 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
     };
 
     const genererBrev = () => {
-        mellomlagreBrev(alleFlettefelter, valgteFelt, valgteDelmaler);
+        mellomlagreBrev(alleFlettefelter, valgteFelt, valgteDelmaler, brevMal);
         axiosRequest<string, unknown>({
             method: 'POST',
             url: `/familie-ef-sak/api/brev/${behandlingId}/${brevMal}`,


### PR DESCRIPTION
Fram til nå har en default brevmal vært hardkodet i brevfanen. Det gjorde at mellomlageret ble overskrevet hver gang man åpnet brevfanen.

Med denne PRen sjekker vi først om det finnes et mellomlagret brev, og hvis det gjør det setter vi brevmalen i brevmenyen til denne. Hvis ikke bruker vi den hardkoda brevmalen.

