### PR TITLE
Luft over tekst er lagt til

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/VedtakOgBeregningSide.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/VedtakOgBeregningSide.tsx
@@ -11,6 +11,7 @@ import DataViewer from '../../../Felles/DataViewer/DataViewer';
 
 const AlertStripeLeft = styled(AlertStripe)`
     margin-left: 2rem;
+    margin-top: 1rem;
 `;
 
 const AlertStripeIkkeFerdigBehandletVilkår = (): JSX.Element => (

--- a/src/frontend/Komponenter/Personoversikt/Behandlingsoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Behandlingsoversikt.tsx
@@ -29,6 +29,11 @@ const KnappMedMargin = styled(Knapp)`
     margin: 1rem;
 `;
 
+const StyledSystemtittel = styled(Systemtittel)`
+    margin-top: 1.5rem;
+    margin-bottom: 0.5rem;
+`;
+
 const Behandlingsoversikt: React.FC<{ fagsakId: string }> = ({ fagsakId }) => {
     const [fagsak, settFagsak] = useState<Ressurs<Fagsak>>(byggTomRessurs());
     const [tekniskOpphørFeilet, settTekniskOpphørFeilet] = useState<boolean>(false);
@@ -97,9 +102,9 @@ const Behandlingsoversikt: React.FC<{ fagsakId: string }> = ({ fagsakId }) => {
         <DataViewer response={{ fagsak }}>
             {({ fagsak }) => (
                 <>
-                    <Systemtittel tag="h3">
+                    <StyledSystemtittel tag="h3">
                         Fagsak: {formatterEnumVerdi(fagsak.stønadstype)}
-                    </Systemtittel>
+                    </StyledSystemtittel>
                     <BehandlingsoversiktTabell behandlinger={fagsak.behandlinger} />
 
                     {kanStarteRevurdering && (
@@ -161,46 +166,48 @@ const BehandlingsoversiktTabell: React.FC<Pick<Fagsak, 'behandlinger'>> = ({ beh
     );
 
     return (
-        <StyledTable className="tabell">
-            <thead>
-                <tr>
-                    {Object.entries(TabellData).map(([felt, tekst]) => (
-                        <SorteringsHeader
-                            rekkefolge={
-                                sortConfig?.sorteringsfelt === felt
-                                    ? sortConfig?.rekkefolge
-                                    : undefined
-                            }
-                            tekst={tekst}
-                            onClick={() => settSortering(felt as keyof Behandling)}
-                        />
-                    ))}
-                </tr>
-            </thead>
-            <tbody>
-                {sortertListe.map((behandling) => {
-                    return (
-                        <tr key={behandling.id}>
-                            <td>{formaterIsoDatoTid(behandling.opprettet)}</td>
-                            <td>{formatterEnumVerdi(behandling.type)}</td>
-                            <td>{formatterEnumVerdi(behandling.status)}</td>
-                            <td>
-                                {behandling.type === Behandlingstype.TEKNISK_OPPHØR ? (
-                                    <span>{formatterEnumVerdi(behandling.resultat)}</span>
-                                ) : (
-                                    <Link
-                                        className="lenke"
-                                        to={{ pathname: `/behandling/${behandling.id}` }}
-                                    >
-                                        {formatterEnumVerdi(behandling.resultat)}
-                                    </Link>
-                                )}
-                            </td>
-                        </tr>
-                    );
-                })}
-            </tbody>
-        </StyledTable>
+        <>
+            <StyledTable className="tabell">
+                <thead>
+                    <tr>
+                        {Object.entries(TabellData).map(([felt, tekst]) => (
+                            <SorteringsHeader
+                                rekkefolge={
+                                    sortConfig?.sorteringsfelt === felt
+                                        ? sortConfig?.rekkefolge
+                                        : undefined
+                                }
+                                tekst={tekst}
+                                onClick={() => settSortering(felt as keyof Behandling)}
+                            />
+                        ))}
+                    </tr>
+                </thead>
+                <tbody>
+                    {sortertListe.map((behandling) => {
+                        return (
+                            <tr key={behandling.id}>
+                                <td>{formaterIsoDatoTid(behandling.opprettet)}</td>
+                                <td>{formatterEnumVerdi(behandling.type)}</td>
+                                <td>{formatterEnumVerdi(behandling.status)}</td>
+                                <td>
+                                    {behandling.type === Behandlingstype.TEKNISK_OPPHØR ? (
+                                        <span>{formatterEnumVerdi(behandling.resultat)}</span>
+                                    ) : (
+                                        <Link
+                                            className="lenke"
+                                            to={{ pathname: `/behandling/${behandling.id}` }}
+                                        >
+                                            {formatterEnumVerdi(behandling.resultat)}
+                                        </Link>
+                                    )}
+                                </td>
+                            </tr>
+                        );
+                    })}
+                </tbody>
+            </StyledTable>
+        </>
     );
 };
 

--- a/src/frontend/Komponenter/Personoversikt/Behandlingsoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Behandlingsoversikt.tsx
@@ -166,48 +166,46 @@ const BehandlingsoversiktTabell: React.FC<Pick<Fagsak, 'behandlinger'>> = ({ beh
     );
 
     return (
-        <>
-            <StyledTable className="tabell">
-                <thead>
-                    <tr>
-                        {Object.entries(TabellData).map(([felt, tekst]) => (
-                            <SorteringsHeader
-                                rekkefolge={
-                                    sortConfig?.sorteringsfelt === felt
-                                        ? sortConfig?.rekkefolge
-                                        : undefined
-                                }
-                                tekst={tekst}
-                                onClick={() => settSortering(felt as keyof Behandling)}
-                            />
-                        ))}
-                    </tr>
-                </thead>
-                <tbody>
-                    {sortertListe.map((behandling) => {
-                        return (
-                            <tr key={behandling.id}>
-                                <td>{formaterIsoDatoTid(behandling.opprettet)}</td>
-                                <td>{formatterEnumVerdi(behandling.type)}</td>
-                                <td>{formatterEnumVerdi(behandling.status)}</td>
-                                <td>
-                                    {behandling.type === Behandlingstype.TEKNISK_OPPHØR ? (
-                                        <span>{formatterEnumVerdi(behandling.resultat)}</span>
-                                    ) : (
-                                        <Link
-                                            className="lenke"
-                                            to={{ pathname: `/behandling/${behandling.id}` }}
-                                        >
-                                            {formatterEnumVerdi(behandling.resultat)}
-                                        </Link>
-                                    )}
-                                </td>
-                            </tr>
-                        );
-                    })}
-                </tbody>
-            </StyledTable>
-        </>
+        <StyledTable className="tabell">
+            <thead>
+                <tr>
+                    {Object.entries(TabellData).map(([felt, tekst]) => (
+                        <SorteringsHeader
+                            rekkefolge={
+                                sortConfig?.sorteringsfelt === felt
+                                    ? sortConfig?.rekkefolge
+                                    : undefined
+                            }
+                            tekst={tekst}
+                            onClick={() => settSortering(felt as keyof Behandling)}
+                        />
+                    ))}
+                </tr>
+            </thead>
+            <tbody>
+                {sortertListe.map((behandling) => {
+                    return (
+                        <tr key={behandling.id}>
+                            <td>{formaterIsoDatoTid(behandling.opprettet)}</td>
+                            <td>{formatterEnumVerdi(behandling.type)}</td>
+                            <td>{formatterEnumVerdi(behandling.status)}</td>
+                            <td>
+                                {behandling.type === Behandlingstype.TEKNISK_OPPHØR ? (
+                                    <span>{formatterEnumVerdi(behandling.resultat)}</span>
+                                ) : (
+                                    <Link
+                                        className="lenke"
+                                        to={{ pathname: `/behandling/${behandling.id}` }}
+                                    >
+                                        {formatterEnumVerdi(behandling.resultat)}
+                                    </Link>
+                                )}
+                            </td>
+                        </tr>
+                    );
+                })}
+            </tbody>
+        </StyledTable>
     );
 };
 


### PR DESCRIPTION
Fikser følgende kort: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-6644

Luft over tekst er lagt til:
![Skjermbilde 2021-10-05 kl  17 34 25](https://user-images.githubusercontent.com/32769446/136055595-50469fb1-125c-4f79-b015-f4bdd56136f1.png)

![Skjermbilde 2021-10-05 kl  17 34 10](https://user-images.githubusercontent.com/32769446/136055670-f39fe37b-0650-400c-8b3a-b33bf943782a.png)
 
