### PR TITLE
Mindre padding mellom elementer på vedtak-og-beregning siden

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/InnvilgeVedtak/InnvilgeVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/InnvilgeVedtak/InnvilgeVedtak.tsx
@@ -29,10 +29,15 @@ import { validerVedtaksperioder } from '../vedtaksvalidering';
 import AlertStripeFeilPreWrap from '../../../../Felles/Visningskomponenter/AlertStripeFeilPreWrap';
 import { EnsligTextArea } from '../../../../Felles/Input/TekstInput/EnsligTextArea';
 import { VEDTAK_OG_BEREGNING } from '../konstanter';
+import styled from 'styled-components';
 
 const Hovedknapp = hiddenIf(HovedknappNAV);
 
 export type InnvilgeVedtakForm = Omit<IInnvilgeVedtak, 'resultatType'>;
+
+const Wrapper = styled.section`
+    padding-top: 1rem;
+`;
 
 export const InnvilgeVedtak: React.FC<{
     behandling: Behandling;
@@ -195,7 +200,7 @@ export const InnvilgeVedtak: React.FC<{
 
     return (
         <form onSubmit={formState.onSubmit(handleSubmit)}>
-            <section className={'blokk-xl'}>
+            <Wrapper>
                 <Undertittel className={'blokk-s'}>Vedtaksperiode</Undertittel>
                 <VedtaksperiodeValg
                     vedtaksperiodeListe={vedtaksperiodeState}
@@ -216,7 +221,7 @@ export const InnvilgeVedtak: React.FC<{
                         erLesevisning={!behandlingErRedigerbar}
                     />
                 )}
-            </section>
+            </Wrapper>
             <section>
                 <Undertittel className={'blokk-s'}>Inntekt</Undertittel>
                 <InntektsperiodeValg

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/SelectVedtaksresultat.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/SelectVedtaksresultat.tsx
@@ -27,7 +27,7 @@ const SelectVedtaksresultat = (props: Props): JSX.Element => {
     const { resultatType, settResultatType } = props;
     const opphørMulig = props.behandling.type === Behandlingstype.REVURDERING;
     return (
-        <section className="blokk-xl">
+        <section>
             <Undertittel className={'blokk-s'}>Vedtak</Undertittel>
             <StyledSelect
                 value={resultatType}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/VedtakOgBeregning.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/VedtakOgBeregning.tsx
@@ -13,7 +13,7 @@ interface Props {
 }
 
 const Wrapper = styled.div`
-    padding: 4rem 2rem;
+    padding: 1rem 2rem;
 `;
 const VedtakOgBeregning: FC<Props> = ({ behandling }) => {
     const behandlingId = behandling.id;

--- a/src/frontend/Komponenter/Behandling/Vilkårresultat/ResultatVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Vilkårresultat/ResultatVisning.tsx
@@ -7,7 +7,9 @@ import { FlexDiv } from '../../Oppgavebenk/OppgaveFiltrering';
 import { VilkårsresultatIkon } from '../../../Felles/Ikoner/VilkårsresultatIkon';
 
 const Container = styled.div`
-    padding: 2rem 1rem;
+    padding-top: 1rem;
+    padding-left: 1rem;
+    padding-right: 1rem;
 `;
 
 export const resultatTilTekst: Record<string, string> = {

--- a/src/frontend/Komponenter/Behandling/Vilkårresultat/VilkårsresultatOppsummering.tsx
+++ b/src/frontend/Komponenter/Behandling/Vilkårresultat/VilkårsresultatOppsummering.tsx
@@ -47,7 +47,7 @@ export const VilkårsresultatOppsummering: React.FC<{ behandlingId: string }> = 
                 return (
                     <Container>
                         <InnerContainer>
-                            <div style={{ padding: '2rem 1rem' }}>
+                            <div style={{ padding: '0rem 1rem' }}>
                                 <Undertittel className="blokk-xs">
                                     Tidligere stønadsperioder
                                 </Undertittel>

--- a/src/frontend/Komponenter/Behandling/Vilkårresultat/VilkårsresultatOppsummering.tsx
+++ b/src/frontend/Komponenter/Behandling/Vilkårresultat/VilkårsresultatOppsummering.tsx
@@ -18,6 +18,10 @@ const InnerContainer = styled.div`
     padding: 1rem;
 `;
 
+const TekstWrapper = styled.div`
+    padding: 0rem 1rem;
+`;
+
 export const VilkårsresultatOppsummering: React.FC<{ behandlingId: string }> = ({
     behandlingId,
 }) => {
@@ -47,12 +51,12 @@ export const VilkårsresultatOppsummering: React.FC<{ behandlingId: string }> = 
                 return (
                     <Container>
                         <InnerContainer>
-                            <div style={{ padding: '0rem 1rem' }}>
+                            <TekstWrapper>
                                 <Undertittel className="blokk-xs">
                                     Tidligere vedtaksperioder
                                 </Undertittel>
                                 <Normaltekst>Søker har ingen tidligere stønadsperioder</Normaltekst>
-                            </div>
+                            </TekstWrapper>
                             <ResultatVisning
                                 vilkårsvurderinger={inngangsvilkår}
                                 tittel="Inngangsvilkår"

--- a/src/frontend/Komponenter/Behandling/Vilkårresultat/VilkårsresultatOppsummering.tsx
+++ b/src/frontend/Komponenter/Behandling/Vilkårresultat/VilkårsresultatOppsummering.tsx
@@ -49,7 +49,7 @@ export const VilkårsresultatOppsummering: React.FC<{ behandlingId: string }> = 
                         <InnerContainer>
                             <div style={{ padding: '0rem 1rem' }}>
                                 <Undertittel className="blokk-xs">
-                                    Tidligere stønadsperioder
+                                    Tidligere vedtaksperioder
                                 </Undertittel>
                                 <Normaltekst>Søker har ingen tidligere stønadsperioder</Normaltekst>
                             </div>


### PR DESCRIPTION
Skal løse denne: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-6638
Og denne: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-6659


Slik er det nå:
![Skjermbilde 2021-10-06 kl  11 08 27](https://user-images.githubusercontent.com/32769446/136173954-5873ed35-de5b-44fa-8ff6-132de02a9647.png)

