### PR TITLE
Forhåndsinnfylling av tittel i fritekstbrev skal nå fungere

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/FritekstBrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/FritekstBrev.tsx
@@ -199,12 +199,15 @@ const FritekstBrev: React.FC<Props> = ({ oppdaterBrevressurs, behandlingId, fags
     };
 
     const forhåndsfyllBrevoverskrift = (brevType: FrittståendeBrevType) => {
-        if (brevType === FrittståendeBrevType.MANGELBREV) {
-            if (overskrift === infobrevTittel || overskrift === '')
-                settOverskrift(mangelbrevTittel);
-        } else if (brevType === FrittståendeBrevType.INFOBREV) {
-            if (overskrift === mangelbrevTittel || overskrift === '')
-                settOverskrift(infobrevTittel);
+        switch (brevType) {
+            case FrittståendeBrevType.MANGELBREV:
+                if (overskrift === infobrevTittel || overskrift === '')
+                    settOverskrift(mangelbrevTittel);
+                break;
+            case FrittståendeBrevType.INFOBREV:
+                if (overskrift === mangelbrevTittel || overskrift === '')
+                    settOverskrift(infobrevTittel);
+                break;
         }
     };
 


### PR DESCRIPTION
Skal løse denne:
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-6665

Logikken er som følger: 
Når man velger 'infobrev' som brevtype blir tittelen satt til "Vi vil informere deg om...' dersom tittelen tidligere var tom eller 'Vi trenger informasjon fra deg'

Når man velger 'mangelbrev' som brevtype blir tittelen satt til 'Vi trenger informasjon fra deg' dersom tittelen tidligere var tom eller 'Vi vil informere deg om...'

Altså: Dersom bruker ikke har modifisert tittelen selv vil den forhåndsutfylles ved bytte av brevtype :)