### PR TITLE
Skal vise behandlinger fra tilbakekreving for fagsak

### DIFF
--- a/src/frontend/App/typer/tilbakekreving.ts
+++ b/src/frontend/App/typer/tilbakekreving.ts
@@ -1,0 +1,30 @@
+export interface TilbakekrevingBehandling {
+    behandlingId: string;
+    opprettetTidspunkt: string;
+    aktiv: boolean;
+    type: TilbakekrevingBehandlingstype;
+    status: TilbakekrevingBehandlingsstatus;
+    vedtaksdato?: string;
+    resultat?: TilbakekrevingBehandlingsresultatstype;
+}
+
+export enum TilbakekrevingBehandlingsstatus {
+    AVSLUTTET,
+    FATTER_VEDTAK,
+    IVERKSETTER_VEDTAK,
+    OPPRETTET,
+    UTREDES,
+}
+
+export enum TilbakekrevingBehandlingstype {
+    TILBAKEKREVING = 'Tilbakekreving',
+    REVURDERING_TILBAKEKREVING = 'Tilbakekreving revurdering',
+}
+
+export enum TilbakekrevingBehandlingsresultatstype {
+    IKKE_FASTSATT,
+    INGEN_TILBAKEBETALING,
+    DELVIS_TILBAKEBETALING,
+    FULL_TILBAKEBETALING,
+    HENLAGT,
+}

--- a/src/frontend/Komponenter/Personoversikt/Behandlingsoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Behandlingsoversikt.tsx
@@ -18,6 +18,8 @@ import { Knapp } from 'nav-frontend-knapper';
 import { Systemtittel } from 'nav-frontend-typografi';
 import { BehandlingStatus } from '../../App/typer/behandlingstatus';
 import RevurderingModal from './RevurderingModal';
+import { TilbakekrevingBehandling } from '../../App/typer/tilbakekreving';
+import { TilbakekrevingBehandlingerTabell } from './TilbakekrevingBehandlingerTabell';
 
 const StyledTable = styled.table`
     width: 40%;
@@ -40,6 +42,9 @@ const Behandlingsoversikt: React.FC<{ fagsakId: string }> = ({ fagsakId }) => {
     const [tekniskOpphørFeilet, settTekniskOpphørFeilet] = useState<boolean>(false);
     const [kanStarteRevurdering, settKanStarteRevurdering] = useState<boolean>(false);
     const [visRevurderingvalg, settVisRevurderingvalg] = useState<boolean>(false);
+    const [tilbakekrevingBehandlinger, settTilbakekrevingbehandlinger] = useState<
+        Ressurs<TilbakekrevingBehandling[]>
+    >(byggTomRessurs());
     const { axiosRequest } = useApp();
     const { toggles } = useToggles();
 
@@ -48,6 +53,12 @@ const Behandlingsoversikt: React.FC<{ fagsakId: string }> = ({ fagsakId }) => {
             method: 'GET',
             url: `/familie-ef-sak/api/fagsak/${fagsakId}`,
         }).then((response) => settFagsak(response));
+
+    const hentTilbakekrevingBehandlinger = () =>
+        axiosRequest<TilbakekrevingBehandling[], null>({
+            method: 'GET',
+            url: `/familie-ef-sak/api/tilbakekreving/behandlinger/${fagsakId}`,
+        }).then((response) => settTilbakekrevingbehandlinger(response));
 
     const gjørTekniskOpphør = () => {
         axiosRequest<Ressurs<void>, null>({
@@ -68,6 +79,7 @@ const Behandlingsoversikt: React.FC<{ fagsakId: string }> = ({ fagsakId }) => {
     useEffect(() => {
         if (fagsakId) {
             hentFagsak();
+            hentTilbakekrevingBehandlinger();
         }
         // eslint-disable-next-line
     }, [fagsakId]);
@@ -89,13 +101,16 @@ const Behandlingsoversikt: React.FC<{ fagsakId: string }> = ({ fagsakId }) => {
     }
 
     return (
-        <DataViewer response={{ fagsak }}>
-            {({ fagsak }) => (
+        <DataViewer response={{ fagsak, tilbakekrevingBehandlinger }}>
+            {({ fagsak, tilbakekrevingBehandlinger }) => (
                 <>
                     <StyledSystemtittel tag="h3">
                         Fagsak: {formatterEnumVerdi(fagsak.stønadstype)}
                     </StyledSystemtittel>
                     <BehandlingsoversiktTabell behandlinger={fagsak.behandlinger} />
+                    <TilbakekrevingBehandlingerTabell
+                        tilbakekrevingBehandlinger={tilbakekrevingBehandlinger}
+                    />
 
                     {kanStarteRevurdering && (
                         <KnappMedMargin onClick={() => settVisRevurderingvalg(true)}>

--- a/src/frontend/Komponenter/Personoversikt/TilbakekrevingBehandlingerTabell.tsx
+++ b/src/frontend/Komponenter/Personoversikt/TilbakekrevingBehandlingerTabell.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { TilbakekrevingBehandling } from '../../App/typer/tilbakekreving';
+import styled from 'styled-components';
+import { formaterIsoDatoTid, formaterNullableIsoDato } from '../../App/utils/formatter';
+
+const StyledTable = styled.table`
+    width: 40%;
+    padding: 2rem;
+    margin-left: 1rem;
+`;
+
+export const TilbakekrevingBehandlingerTabell: React.FC<{
+    tilbakekrevingBehandlinger: TilbakekrevingBehandling[];
+}> = ({ tilbakekrevingBehandlinger }) => {
+    return (
+        <>
+            <h3>Fagsak: Tilbakekrevinger</h3>
+            <StyledTable className="tabell">
+                <thead>
+                    <tr>
+                        <td>Opprettet</td>
+                        <td>Type</td>
+                        <td>Status</td>
+                        <td>Vedtaksdato</td>
+                        <td>Resultat</td>
+                    </tr>
+                </thead>
+                <tbody>
+                    {tilbakekrevingBehandlinger.map((tilbakekreving) => {
+                        return (
+                            <tr>
+                                <td>{formaterIsoDatoTid(tilbakekreving.opprettetTidspunkt)}</td>
+                                <td>{tilbakekreving.type}</td>
+                                <td>{tilbakekreving.status}</td>
+                                <td>{formaterNullableIsoDato(tilbakekreving.vedtaksdato)}</td>
+                                <td>{tilbakekreving.resultat}</td>
+                            </tr>
+                        );
+                    })}
+                </tbody>
+            </StyledTable>
+        </>
+    );
+};


### PR DESCRIPTION
Minimumsløsning for visning av behandlinger fra tilbakekreving i behandlingsoversikt.

Lager foreløpig en egen tabell for tilbakekreving, men mulig vi ønsker å slå den sammen med den eksisterende fagsaktabellen senere. Derfor lar vi stylingen være som den er.

![image](https://user-images.githubusercontent.com/21220467/137878022-8b06e079-831a-4907-a6d2-06e76425190f.png)
