### PR TITLE
Fjern status fra Visittkort

### DIFF
--- a/src/frontend/Felles/Visittkort/Visittkort.tsx
+++ b/src/frontend/Felles/Visittkort/Visittkort.tsx
@@ -17,7 +17,6 @@ import { IFagsaksøk } from '../../App/typer/fagsaksøk';
 import Lenke from 'nav-frontend-lenker';
 import { IPersonIdent } from '../../App/typer/felles';
 import Alertstripe from 'nav-frontend-alertstriper';
-import { EtikettInfo } from 'nav-frontend-etiketter';
 
 export const VisittkortWrapper = styled(Sticky)`
     display: flex;
@@ -30,10 +29,6 @@ export const VisittkortWrapper = styled(Sticky)`
 `;
 const ElementWrapper = styled.div`
     margin-left: 1rem;
-`;
-
-const StyledEtikettInfo = styled(EtikettInfo)`
-    margin-top: 0.5rem;
 `;
 
 const VisittkortComponent: FC<{ data: IPersonopplysninger; behandling?: Behandling }> = ({
@@ -54,7 +49,6 @@ const VisittkortComponent: FC<{ data: IPersonopplysninger; behandling?: Behandli
     const { axiosRequest, gåTilUrl } = useApp();
     const [fagsakId, settFagsakId] = useState('');
     const [feilFagsakHenting, settFeilFagsakHenting] = useState<string>();
-    const [erLøpende, settErLøpende] = useState<boolean>(false);
 
     useEffect(() => {
         const hentFagsak = (personIdent: string): void => {
@@ -68,7 +62,6 @@ const VisittkortComponent: FC<{ data: IPersonopplysninger; behandling?: Behandli
                 if (respons.status === RessursStatus.SUKSESS) {
                     if (respons.data?.fagsaker?.length) {
                         settFagsakId(respons.data.fagsaker[0].fagsakId);
-                        settErLøpende(respons.data.fagsaker[0].erLøpende);
                     }
                 } else if (
                     respons.status === RessursStatus.FEILET ||
@@ -129,11 +122,6 @@ const VisittkortComponent: FC<{ data: IPersonopplysninger; behandling?: Behandli
                     </ElementWrapper>
                 )}
             </Visittkort>
-            {erLøpende && (
-                <ElementWrapper>
-                    <StyledEtikettInfo mini>Løpende</StyledEtikettInfo>
-                </ElementWrapper>
-            )}
             {behandling && <Behandlingsinfo behandling={behandling} />}
         </VisittkortWrapper>
     );


### PR DESCRIPTION
Fjerner "løpende"-status fra Visittkort etter tilbakemelding fra Lars. Reverterer en av endringene i [denne Favro-saken](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-4918).