### PR TITLE
Automatiske flettefelt skal overskrive verdier fra mellomlager

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
@@ -54,8 +54,8 @@ export const initFlettefelterMedVerdi = (
     brevStruktur.flettefelter.flettefeltReferanse.map((flettefeltReferanse) => ({
         _ref: flettefeltReferanse._id,
         verdi:
-            hentVerdiFraMellomlagerEllerNull(flettefeltFraMellomlager, flettefeltReferanse._id) ||
-            flettefeltStore[flettefeltReferanse.felt],
+            flettefeltStore[flettefeltReferanse.felt] ||
+            hentVerdiFraMellomlagerEllerNull(flettefeltFraMellomlager, flettefeltReferanse._id),
     }));
 
 export const initValgteFeltMedMellomlager = (


### PR DESCRIPTION
Dette gjør vi for at datoene skal forbli riktig hvis nytt vedtak lagres