### PR TITLE
Skjul forhåndsutfylte avsnitt i fritekstbrevbygger

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
@@ -67,6 +67,7 @@ export interface DokumentNavn {
 export interface IAvsnitt {
     deloverskrift: string;
     innhold: string;
+    skalSkjulesIBrevbygger?: boolean;
 }
 
 export type AvsnittMedId = IAvsnitt & { id: string };

--- a/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
@@ -102,3 +102,6 @@ export const initielleAvsnittEllerMellomlager = (
     mellomlagretFritekstbrev
         ? mellomlagretFritekstbrev.avsnitt.map((avsnitt) => ({ ...avsnitt, id: uuidv4() }))
         : initielleAvsnitt;
+
+export const skjulAvsnittIBrevbygger = (avsnitt: AvsnittMedId[]): AvsnittMedId[] =>
+    avsnitt.map((avsnitt) => ({ ...avsnitt, skalSkjulesIBrevbygger: true }));


### PR DESCRIPTION
Forhåndsutfylte avsnitt (f.eks. avslutningstekst) skal ikke vises i fritekst-brevbyggeren til venstre. Legger til felt for å skjule disse.

**Før:**
![image](https://user-images.githubusercontent.com/21220467/139959780-494d1a8e-fb55-4695-bca8-ba780e499375.png)


**Etter:**
![image](https://user-images.githubusercontent.com/21220467/139959698-fbd3671c-f799-412e-94d8-a4001949d58a.png)


