### PR TITLE
Splitter opp tabeller for bostedsadresse og andre adresser. I tillegg…

### DIFF
--- a/src/frontend/Felles/Personopplysninger/Adressehistorikk.tsx
+++ b/src/frontend/Felles/Personopplysninger/Adressehistorikk.tsx
@@ -131,7 +131,7 @@ const Innhold: React.FC<{ adresser: IAdresse[]; fagsakId: string }> = ({ adresse
                             <Td>
                                 {formaterNullableIsoDato(
                                     adresse.type === AdresseType.BOSTEDADRESSE
-                                        ? adresse.angittFlyttedato
+                                        ? adresse.angittFlyttedato || adresse.gyldigFraOgMed
                                         : adresse.gyldigFraOgMed
                                 )}
                             </Td>

--- a/src/frontend/Felles/Personopplysninger/Adressehistorikk.tsx
+++ b/src/frontend/Felles/Personopplysninger/Adressehistorikk.tsx
@@ -33,9 +33,29 @@ const Adressehistorikk: React.FC<{ adresser: IAdresse[]; fagsakId: string }> = (
     adresser,
     fagsakId,
 }) => {
+    return (
+        <>
+            <AdressehistorikkMedLesMerKnapp
+                fagsakId={fagsakId}
+                adresser={adresser.filter((adresse) => adresse.type === AdresseType.BOSTEDADRESSE)}
+                type={AdresseType.BOSTEDADRESSE}
+            />
+            <AdressehistorikkMedLesMerKnapp
+                fagsakId={fagsakId}
+                adresser={adresser.filter((adresse) => adresse.type !== AdresseType.BOSTEDADRESSE)}
+            />
+        </>
+    );
+};
+
+const AdressehistorikkMedLesMerKnapp: React.FC<{
+    adresser: IAdresse[];
+    fagsakId: string;
+    type?: AdresseType;
+}> = ({ adresser, fagsakId, type }) => {
     const [isClosed, setIsClosed] = useState<boolean>(true);
     if (adresser.length <= MAX_LENGDE_ADRESSER) {
-        return <Adresser adresser={adresser} fagsakId={fagsakId} />;
+        return <Adresser adresser={adresser} fagsakId={fagsakId} type={type} />;
     } else {
         const introAdresser = adresser.slice(0, MAX_LENGDE_ADRESSER);
         return (
@@ -43,11 +63,15 @@ const Adressehistorikk: React.FC<{ adresser: IAdresse[]; fagsakId: string }> = (
                 onOpen={() => setIsClosed(false)}
                 onClose={() => setIsClosed(true)}
                 className={'adresser'}
-                intro={isClosed && <Adresser adresser={introAdresser} fagsakId={fagsakId} />}
+                intro={
+                    isClosed && (
+                        <Adresser adresser={introAdresser} fagsakId={fagsakId} type={type} />
+                    )
+                }
                 apneTekst={'Vis flere adresser'}
                 lukkTekst={'Skjul adresser'}
             >
-                <Adresser adresser={adresser} fagsakId={fagsakId} />
+                <Adresser adresser={adresser} fagsakId={fagsakId} type={type} />
             </StyledLesmer>
         );
     }
@@ -59,17 +83,29 @@ const Kolonnetittel: React.FC<{ text: string; width: number }> = ({ text, width 
     </Td>
 );
 
-const Adresser: React.FC<{ adresser: IAdresse[]; fagsakId: string }> = ({ adresser, fagsakId }) => {
+const Adresser: React.FC<{ adresser: IAdresse[]; fagsakId: string; type?: AdresseType }> = ({
+    adresser,
+    fagsakId,
+    type,
+}) => {
     return (
         <TabellWrapper>
-            <TabellOverskrift Ikon={Bygning} tittel={'Adressehistorikk'} />
+            <TabellOverskrift
+                Ikon={Bygning}
+                tittel={type === AdresseType.BOSTEDADRESSE ? 'Bostedsadresser' : 'Andre adresser'}
+            />
             <table className="tabell">
                 <thead>
                     <tr>
                         <Kolonnetittel text={'Adresse'} width={35} />
-                        <Kolonnetittel text={'Adressetype'} width={15} />
-                        <Kolonnetittel text={'Angitt flyttedato'} width={15} />
-                        <Kolonnetittel text={'Fra'} width={15} />
+                        <Kolonnetittel
+                            text={type === AdresseType.BOSTEDADRESSE ? '' : 'Adressetype'}
+                            width={15}
+                        />
+                        <Kolonnetittel
+                            text={type === AdresseType.BOSTEDADRESSE ? 'Angitt flyttedato' : 'Fra'}
+                            width={15}
+                        />
                         <Kolonnetittel text={'Til'} width={20} />
                     </tr>
                 </thead>
@@ -91,9 +127,14 @@ const Innhold: React.FC<{ adresser: IAdresse[]; fagsakId: string }> = ({ adresse
                     return (
                         <tr key={indeks}>
                             <Td>{adresse.visningsadresse}</Td>
-                            <Td>{adresse.type}</Td>
-                            <Td>{formaterNullableIsoDato(adresse.angittFlyttedato)}</Td>
-                            <Td>{formaterNullableIsoDato(adresse.gyldigFraOgMed)}</Td>
+                            <Td>{adresse.type !== AdresseType.BOSTEDADRESSE && adresse.type}</Td>
+                            <Td>
+                                {formaterNullableIsoDato(
+                                    adresse.type === AdresseType.BOSTEDADRESSE
+                                        ? adresse.angittFlyttedato
+                                        : adresse.gyldigFraOgMed
+                                )}
+                            </Td>
                             <Td>
                                 <StyledFlexDiv>
                                     <div style={{ margin: 'auto 0' }}>


### PR DESCRIPTION
… endres fra-dato, som nå kun viser angittFlytteDato for bostedsadresse som tidligere viste 2 ulike datoer. Det er mulig det blir endret senere på nytt, men akkurat nå er den veldig forvirrende for saksbehandlere

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-7106

Denne PR endrer litt mer enn den favro-oppgaven. Lars hadde nevnt att saksbehandlarna ønsker att vi splitter bostedsadresser og andre adresser. Og endring av visning av fra-dato måtte inn før/etter men kunde fint komme med i samme runde.
![image](https://user-images.githubusercontent.com/937168/140510399-63ff4823-7f1f-4a7d-b772-933552cf80d5.png)
