### PR TITLE
Viser innflyttingsdato som årstall då datoet kanskje egentligen ikke …

### DIFF
--- a/src/frontend/App/utils/formatter.ts
+++ b/src/frontend/App/utils/formatter.ts
@@ -44,6 +44,10 @@ export const formaterIsoMåned = (dato: string): string => {
     return parseISO(dato).toLocaleDateString('no-NO', månedFormat);
 };
 
+export const formaterNullableIsoÅr = (dato?: string): number | undefined => {
+    return dato ? formaterIsoÅr(dato) : undefined;
+};
+
 export const formaterIsoÅr = (dato: string): number => {
     return parseISO(dato).getFullYear();
 };

--- a/src/frontend/Felles/Personopplysninger/InnvandringUtvandring.tsx
+++ b/src/frontend/Felles/Personopplysninger/InnvandringUtvandring.tsx
@@ -3,11 +3,36 @@ import { IInnflyttingTilNorge, IUtflyttingFraNorge } from '../../App/typer/perso
 import { BredTd, IngenData, KolonneTitler, TabellWrapper } from './TabellWrapper';
 import TabellOverskrift from './TabellOverskrift';
 import FlyMedSky from '../Ikoner/FlyMedSky';
+import { formaterNullableIsoÅr } from '../../App/utils/formatter';
+import Hjelpetekst from 'nav-frontend-hjelpetekst';
+import styled from 'styled-components';
 
 interface Props {
     innvandringer: IInnflyttingTilNorge[];
     utvandringer: IUtflyttingFraNorge[];
 }
+
+const StyledInnflyttetÅrHeader = styled.div`
+    padding-right: 1rem;
+`;
+
+const StyledHjelpetekst = styled(Hjelpetekst)`
+    .hjelpetekst__innhold {
+        max-width: 30rem;
+    }
+`;
+
+export const headerForInnflyttingTabell: React.ReactNode = (
+    <div style={{ display: 'flex' }}>
+        <StyledInnflyttetÅrHeader>Innflyttet år</StyledInnflyttetÅrHeader>
+        <StyledHjelpetekst>
+            Innflyttet år er basert på Folkeregisteret sitt gyldighetstidspunktet for innflytting.
+            Denne har nødvendigvis ikke noen sammenheng med når innflyttingen skjedde i
+            virkeligheten. Dersom man skal finne ut når en innflytting gjelder fra må man se på
+            andre opplysninger, feks den norske bostedsadressens fra dato.
+        </StyledHjelpetekst>
+    </div>
+);
 
 const InnvandringUtVandring: React.FC<Props> = ({ innvandringer, utvandringer }) => {
     if (innvandringer.length === 0 && utvandringer.length === 0) {
@@ -48,7 +73,7 @@ const Innvandring: React.FC<{ innvandringer: IInnflyttingTilNorge[]; dobbelTabel
 }) => {
     return (
         <table className={dobbelTabell ? 'tabell første-tabell' : 'tabell'}>
-            <KolonneTitler titler={['Innvandret fra', '', '', '']} />
+            <KolonneTitler titler={['Innvandret fra', headerForInnflyttingTabell, '', '']} />
             <tbody>
                 {innvandringer.map((innflytting, indeks) => {
                     return (
@@ -59,7 +84,7 @@ const Innvandring: React.FC<{ innvandringer: IInnflyttingTilNorge[]; dobbelTabel
                                         ? ', ' + innflytting.fraflyttingssted
                                         : '')}
                             </BredTd>
-                            <BredTd />
+                            <BredTd>{formaterNullableIsoÅr(innflytting.dato)}</BredTd>
                             <BredTd />
                             <BredTd />
                         </tr>

--- a/src/frontend/Felles/Personopplysninger/InnvandringUtvandring.tsx
+++ b/src/frontend/Felles/Personopplysninger/InnvandringUtvandring.tsx
@@ -29,7 +29,7 @@ export const headerForInnflyttingTabell: React.ReactNode = (
             Innflyttet år er basert på Folkeregisteret sitt gyldighetstidspunktet for innflytting.
             Denne har nødvendigvis ikke noen sammenheng med når innflyttingen skjedde i
             virkeligheten. Dersom man skal finne ut når en innflytting gjelder fra må man se på
-            andre opplysninger, feks den norske bostedsadressens fra dato.
+            andre opplysninger, f.eks. den norske bostedsadressens fra-dato.
         </StyledHjelpetekst>
     </div>
 );

--- a/src/frontend/Felles/Personopplysninger/TabellWrapper.tsx
+++ b/src/frontend/Felles/Personopplysninger/TabellWrapper.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import React from 'react';
-import { Element, Normaltekst } from 'nav-frontend-typografi';
+import { Normaltekst } from 'nav-frontend-typografi';
 
 export const BredTd = styled.td`
     width: ${(props) => props.width ?? '25%'};
@@ -21,6 +21,9 @@ export const TabellWrapper = styled.div<{ erDobbelTabell?: boolean }>`
             ? "'. ikon tittel .' '. . første-tabell .' '. . andre-tabell .'"
             : "'. ikon tittel .' '. . innhold .'"};
     .tabell {
+        .columnHeader {
+            font-weight: bold;
+        }
         grid-area: innhold;
         td {
             padding-left: 0;
@@ -39,13 +42,15 @@ export const StyledInnholdWrapper = styled.div`
     grid-area: innhold;
 `;
 
-export const KolonneTitler: React.FC<{ titler: string[] }> = ({ titler }) => {
+type Kolonnetittel = string | React.ReactNode;
+
+export const KolonneTitler: React.FC<{ titler: Kolonnetittel[] }> = ({ titler }) => {
     return (
         <thead>
             <tr>
                 {titler.map((tittel, indeks) => (
-                    <BredTd key={indeks} width={100 / titler.length}>
-                        <Element>{tittel}</Element>
+                    <BredTd key={indeks} width={100 / titler.length} className={'columnHeader'}>
+                        {tittel}
                     </BredTd>
                 ))}
             </tr>

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Medlemskap/InnflyttingUtflytting.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Medlemskap/InnflyttingUtflytting.tsx
@@ -5,10 +5,11 @@ import {
 } from '../../../../App/typer/personopplysninger';
 import { Element } from 'nav-frontend-typografi';
 import { Registergrunnlag } from '../../../../Felles/Ikoner/DataGrunnlagIkoner';
-import { formaterNullableIsoDato } from '../../../../App/utils/formatter';
+import { formaterNullableIsoDato, formaterNullableIsoÅr } from '../../../../App/utils/formatter';
 import { slåSammenTekst } from '../../../../App/utils/utils';
 import { Tabell } from '../NyttBarnSammePartner/Tabell';
 import { FlexDiv } from '../../../Oppgavebenk/OppgaveFiltrering';
+import { headerForInnflyttingTabell } from '../../../../Felles/Personopplysninger/InnvandringUtvandring';
 
 interface Props {
     innflytting: IInnflyttingTilNorge[];
@@ -35,9 +36,8 @@ const InnflyttingUtflytting: React.FC<Props> = ({ innflytting, utflytting }) => 
                             ),
                     },
                     {
-                        overskrift: 'Dato',
-                        tekstVerdi: (innflytting) =>
-                            formaterNullableIsoDato(innflytting.dato) || '',
+                        overskrift: headerForInnflyttingTabell,
+                        tekstVerdi: (innflytting) => formaterNullableIsoÅr(innflytting.dato) || '',
                     },
                 ]}
                 data={innflytting}

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/NyttBarnSammePartner/Tabell.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/NyttBarnSammePartner/Tabell.tsx
@@ -6,7 +6,7 @@ import navFarger from 'nav-frontend-core';
 interface Props<T> {
     data: T[];
     kolonner: {
-        overskrift: string;
+        overskrift: string | React.ReactNode;
         tekstVerdi: (data: T) => React.ReactNode;
     }[];
     onEmpty?: string;


### PR DESCRIPTION
…er helt riktig fra pdl. I tillegg vises det med hjelpetekst.

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-7176
https://github.com/navikt/familie-ef-sak/pull/959

Litt problemer med disse tabellene, ene bruker <td> for header, men er ikke helt mulig å endre då typescript for react/jsx ikke tillater width på th, men på td. Og width på kolonner må settes innen <thread> eller noe slik. 

![image](https://user-images.githubusercontent.com/937168/140937337-426a2b24-46dc-4a48-b883-cee93bc75587.png)
![image](https://user-images.githubusercontent.com/937168/140937386-79e41d78-91e1-40ca-af09-d166f7a807c0.png)
