### PR TITLE
Brevtype skal ikke ha noen default i brevbygger

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
@@ -96,12 +96,11 @@ const Brevmeny: React.FC<BrevmenyProps> = (props) => {
     }, [hentVedtak]);
 
     useEffect(() => {
-        if (mellomlagretBrev.status === RessursStatus.SUKSESS) {
-            settBrevmal(
-                mellomlagretBrev.data?.brevtype === Brevtype.SANITYBREV
-                    ? mellomlagretBrev.data.brevmal
-                    : fritekstmal
-            );
+        if (
+            mellomlagretBrev.status === RessursStatus.SUKSESS &&
+            mellomlagretBrev.data?.brevtype === Brevtype.SANITYBREV
+        ) {
+            settBrevmal(mellomlagretBrev.data.brevmal);
         }
     }, [mellomlagretBrev]);
 


### PR DESCRIPTION
Fritekstbrev har tidligere vært valgt som default første gang brevfanen åpnes i en behandling. Det skal den ikke. 