### PR TITLE
Forhåndsvisning av varselbrev - tilbakekreving

### DIFF
--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -5,5 +5,5 @@ export interface Toggles {
 export enum ToggleName {
     journalfoer = 'familie.ef.sak.journalfoer',
     TEKNISK_OPPHØR = 'familie.ef.sak.tekniskopphor',
-    visTilbakekrevingsVarselToggle = 'familie.ef.sak.frontend-vis-tilbakereving-varsel',
+    visTilbakekrevingsVarselToggle = 'familie.ef.sak.frontend-vis-tilbakekreving-varsel',
 }

--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -5,4 +5,5 @@ export interface Toggles {
 export enum ToggleName {
     journalfoer = 'familie.ef.sak.journalfoer',
     TEKNISK_OPPHØR = 'familie.ef.sak.tekniskopphor',
+    visTilbakekrevingsVarselToggle = 'familie.ef.sak.frontend-vis-tilbakereving-varsel',
 }

--- a/src/frontend/Komponenter/Behandling/Simulering/Tilbakekreving.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/Tilbakekreving.tsx
@@ -9,6 +9,7 @@ import NavFrontendSpinner from 'nav-frontend-spinner';
 import { useBehandling } from '../../../App/context/BehandlingContext';
 import { VisTilbakekreving } from './VisTilbakekreving';
 import { TilbakekrevingSkjema } from './TilbakekrevingSkjema';
+import { BehandlingStatus } from '../../../App/typer/behandlingstatus';
 
 export enum ITilbakekrevingsvalg {
     OPPRETT_MED_VARSEL = 'OPPRETT_MED_VARSEL',
@@ -36,7 +37,7 @@ const enum ÅpenTilbakekrevingStatus {
 
 export const Tilbakekreving: React.FC = () => {
     const { axiosRequest, nullstillIkkePersisterteKomponenter } = useApp();
-    const { behandlingErRedigerbar } = useBehandling();
+    const { behandlingErRedigerbar, behandling } = useBehandling();
     const { behandlingId } = useParams<IBehandlingParams>();
     const history = useHistory();
     const [tilbakekrevingsvalg, settTilbakekrevingsvalg] = useState<ITilbakekrevingsvalg>();
@@ -44,9 +45,16 @@ export const Tilbakekreving: React.FC = () => {
     const [begrunnelse, settBegrunnelse] = useState<string>('');
     const [feilmelding, settFeilmelding] = useState<string>();
     const [låsKnapp, settLåsKnapp] = useState<boolean>(false);
+    const [kanForhåndsvise, settKanForhåndsvise] = useState<boolean>(false);
 
     const [åpenTilbakekrevingStatus, settÅpenTilbakekrevingStatus] =
         useState<ÅpenTilbakekrevingStatus>(ÅpenTilbakekrevingStatus.LASTER);
+
+    useEffect(() => {
+        if (behandling.status === RessursStatus.SUKSESS) {
+            settKanForhåndsvise(behandling.data.status !== BehandlingStatus.FERDIGSTILT);
+        }
+    }, [behandling]);
 
     useEffect(() => {
         axiosRequest<boolean, null>({
@@ -155,6 +163,7 @@ export const Tilbakekreving: React.FC = () => {
                             endreBegrunnelse={endreBegrunnelse}
                             lagreTilbakekrevingsValg={lagreTilbakekrevingsvalg}
                             låsKnapp={låsKnapp}
+                            behandlingId={behandlingId}
                         />
                     )}
                     {!behandlingErRedigerbar && (
@@ -162,6 +171,8 @@ export const Tilbakekreving: React.FC = () => {
                             tilbakekrevingsvalg={tilbakekrevingsvalg as ITilbakekrevingsvalg}
                             begrunnelse={begrunnelse}
                             varseltekst={varseltekst}
+                            kanForhåndsvise={kanForhåndsvise}
+                            behandlingId={behandlingId}
                         />
                     )}
                     {feilmelding && <AlertStripeFeil>{feilmelding}</AlertStripeFeil>}

--- a/src/frontend/Komponenter/Behandling/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/TilbakekrevingSkjema.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Radio } from 'nav-frontend-skjema';
 import { EnsligTextArea } from '../../../Felles/Input/TekstInput/EnsligTextArea';
 import { FamilieRadioGruppe } from '@navikt/familie-form-elements';
@@ -8,6 +8,9 @@ import IkonKnapp from '../../../Felles/Knapper/IkonKnapp';
 import styled from 'styled-components';
 import { ITilbakekrevingsvalg } from './Tilbakekreving';
 import { useApp } from '../../../App/context/AppContext';
+import { Ressurs, RessursStatus } from '../../../App/typer/ressurs';
+import { base64toBlob, åpnePdfIEgenTab } from '../../../App/utils/utils';
+import { AlertStripeFeil } from 'nav-frontend-alertstriper';
 
 const VarselValg = styled.div`
     margin-bottom: 1rem;
@@ -22,6 +25,7 @@ interface Props {
     endreBegrunnelse: (nyBegrunnelse: string) => void;
     lagreTilbakekrevingsValg: () => void;
     låsKnapp: boolean;
+    behandlingId: string;
 }
 
 export const TilbakekrevingSkjema: React.FC<Props> = ({
@@ -33,8 +37,33 @@ export const TilbakekrevingSkjema: React.FC<Props> = ({
     endreBegrunnelse,
     lagreTilbakekrevingsValg,
     låsKnapp,
+    behandlingId,
 }) => {
-    const { settIkkePersistertKomponent } = useApp();
+    const { settIkkePersistertKomponent, axiosRequest } = useApp();
+
+    const [forhåndsvisningsFeil, settForhåndsvisningsFeil] = useState<string>();
+
+    const åpneBrevINyFane = () => {
+        axiosRequest<string, { varseltekst: string }>({
+            method: 'POST',
+            url: `familie-ef-sak/api/tilbakekreving/${behandlingId}/brev/generer`,
+            data: { varseltekst },
+        }).then((respons: Ressurs<string>) => {
+            if (respons.status === RessursStatus.SUKSESS) {
+                åpnePdfIEgenTab(
+                    base64toBlob(respons.data, 'application/pdf'),
+                    'Forhåndsvisning av varselbrev'
+                );
+            } else if (
+                respons.status === RessursStatus.IKKE_TILGANG ||
+                respons.status === RessursStatus.FEILET ||
+                respons.status === RessursStatus.FUNKSJONELL_FEIL
+            ) {
+                settForhåndsvisningsFeil(respons.frontendFeilmelding);
+            }
+        });
+    };
+
     return (
         <>
             <FamilieRadioGruppe erLesevisning={false} legend={<h2>Tilbakekreving</h2>}>
@@ -63,13 +92,14 @@ export const TilbakekrevingSkjema: React.FC<Props> = ({
                             kompakt={true}
                             mini={true}
                             erLesevisning={false}
-                            onClick={() => {
-                                console.log('hurra');
-                            }}
+                            onClick={åpneBrevINyFane}
                             knappPosisjon={'venstre'}
                             ikon={<Søknad />}
                             label={'Forhåndsvis varsel'}
                         />
+                        {forhåndsvisningsFeil && (
+                            <AlertStripeFeil>{forhåndsvisningsFeil}</AlertStripeFeil>
+                        )}
                     </VarselValg>
                 )}
                 <Radio

--- a/src/frontend/Komponenter/Behandling/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/TilbakekrevingSkjema.tsx
@@ -11,6 +11,8 @@ import { useApp } from '../../../App/context/AppContext';
 import { Ressurs, RessursStatus } from '../../../App/typer/ressurs';
 import { base64toBlob, åpnePdfIEgenTab } from '../../../App/utils/utils';
 import { AlertStripeFeil } from 'nav-frontend-alertstriper';
+import { ToggleName } from '../../../App/context/toggles';
+import { useToggles } from '../../../App/context/TogglesContext';
 
 const VarselValg = styled.div`
     margin-bottom: 1rem;
@@ -42,6 +44,8 @@ export const TilbakekrevingSkjema: React.FC<Props> = ({
     const { settIkkePersistertKomponent, axiosRequest } = useApp();
 
     const [forhåndsvisningsFeil, settForhåndsvisningsFeil] = useState<string>();
+
+    const { toggles } = useToggles();
 
     const åpneBrevINyFane = () => {
         axiosRequest<string, { varseltekst: string }>({
@@ -88,18 +92,21 @@ export const TilbakekrevingSkjema: React.FC<Props> = ({
                                 endreVarseltekst(e.target.value);
                             }}
                         />
-                        <IkonKnapp
-                            kompakt={true}
-                            mini={true}
-                            erLesevisning={false}
-                            onClick={åpneBrevINyFane}
-                            knappPosisjon={'venstre'}
-                            ikon={<Søknad />}
-                            label={'Forhåndsvis varsel'}
-                        />
-                        {forhåndsvisningsFeil && (
-                            <AlertStripeFeil>{forhåndsvisningsFeil}</AlertStripeFeil>
+                        {toggles[ToggleName.visTilbakekrevingsVarselToggle] && (
+                            <IkonKnapp
+                                kompakt={true}
+                                mini={true}
+                                erLesevisning={false}
+                                onClick={åpneBrevINyFane}
+                                knappPosisjon={'venstre'}
+                                ikon={<Søknad />}
+                                label={'Forhåndsvis varsel'}
+                            />
                         )}
+                        {toggles[ToggleName.visTilbakekrevingsVarselToggle] &&
+                            forhåndsvisningsFeil && (
+                                <AlertStripeFeil>{forhåndsvisningsFeil}</AlertStripeFeil>
+                            )}
                     </VarselValg>
                 )}
                 <Radio

--- a/src/frontend/Komponenter/Behandling/Simulering/VisTilbakekreving.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/VisTilbakekreving.tsx
@@ -8,6 +8,8 @@ import { useApp } from '../../../App/context/AppContext';
 import { base64toBlob, åpnePdfIEgenTab } from '../../../App/utils/utils';
 import { Ressurs, RessursStatus } from '../../../App/typer/ressurs';
 import { AlertStripeFeil } from 'nav-frontend-alertstriper';
+import { ToggleName } from '../../../App/context/toggles';
+import { useToggles } from '../../../App/context/TogglesContext';
 
 const VisningsContainer = styled.div`
     margin-top: 1rem;
@@ -33,6 +35,7 @@ export const VisTilbakekreving: React.FC<Props> = ({
     behandlingId,
 }) => {
     const { axiosRequest } = useApp();
+    const { toggles } = useToggles();
 
     const [forhåndsvisningsFeil, settForhåndsvisningsFeil] = useState<string>();
 
@@ -67,7 +70,7 @@ export const VisTilbakekreving: React.FC<Props> = ({
                 <>
                     <UnderOverskrfit>Fritekst i varselet</UnderOverskrfit>
                     <Normaltekst>{varseltekst}</Normaltekst>
-                    {kanForhåndsvise && (
+                    {toggles[ToggleName.visTilbakekrevingsVarselToggle] && kanForhåndsvise && (
                         <IkonKnapp
                             erLesevisning={false}
                             ikon={<Søknad />}
@@ -77,7 +80,7 @@ export const VisTilbakekreving: React.FC<Props> = ({
                             onClick={visBrevINyFane}
                         />
                     )}
-                    {forhåndsvisningsFeil && (
+                    {toggles[ToggleName.visTilbakekrevingsVarselToggle] && forhåndsvisningsFeil && (
                         <AlertStripeFeil>{forhåndsvisningsFeil}</AlertStripeFeil>
                     )}
                 </>

--- a/src/frontend/Komponenter/Behandling/Simulering/VisTilbakekreving.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/VisTilbakekreving.tsx
@@ -1,7 +1,13 @@
-import React from 'react';
+import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Element, Normaltekst } from 'nav-frontend-typografi';
 import { ITilbakekrevingsvalg, TilbakekrevingsvalgTilTekst } from './Tilbakekreving';
+import IkonKnapp from '../../../Felles/Knapper/IkonKnapp';
+import Søknad from '../../../Felles/Ikoner/Søknad';
+import { useApp } from '../../../App/context/AppContext';
+import { base64toBlob, åpnePdfIEgenTab } from '../../../App/utils/utils';
+import { Ressurs, RessursStatus } from '../../../App/typer/ressurs';
+import { AlertStripeFeil } from 'nav-frontend-alertstriper';
 
 const VisningsContainer = styled.div`
     margin-top: 1rem;
@@ -15,13 +21,41 @@ interface Props {
     tilbakekrevingsvalg: ITilbakekrevingsvalg;
     varseltekst: string;
     begrunnelse: string;
+    kanForhåndsvise: boolean;
+    behandlingId: string;
 }
 
 export const VisTilbakekreving: React.FC<Props> = ({
     tilbakekrevingsvalg,
     varseltekst,
     begrunnelse,
+    kanForhåndsvise,
+    behandlingId,
 }) => {
+    const { axiosRequest } = useApp();
+
+    const [forhåndsvisningsFeil, settForhåndsvisningsFeil] = useState<string>();
+
+    const visBrevINyFane = () => {
+        axiosRequest<string, null>({
+            method: 'GET',
+            url: `familie-ef-sak/api/tilbakekreving/${behandlingId}/brev`,
+        }).then((respons: Ressurs<string>) => {
+            if (respons.status === RessursStatus.SUKSESS) {
+                åpnePdfIEgenTab(
+                    base64toBlob(respons.data, 'application/pdf'),
+                    'Forhåndsvisning av varselbrev'
+                );
+            } else if (
+                respons.status === RessursStatus.IKKE_TILGANG ||
+                respons.status === RessursStatus.FEILET ||
+                respons.status === RessursStatus.FUNKSJONELL_FEIL
+            ) {
+                settForhåndsvisningsFeil(respons.frontendFeilmelding);
+            }
+        });
+    };
+
     return (
         <VisningsContainer>
             <h2>Tilbakekreving</h2>
@@ -33,6 +67,19 @@ export const VisTilbakekreving: React.FC<Props> = ({
                 <>
                     <UnderOverskrfit>Fritekst i varselet</UnderOverskrfit>
                     <Normaltekst>{varseltekst}</Normaltekst>
+                    {kanForhåndsvise && (
+                        <IkonKnapp
+                            erLesevisning={false}
+                            ikon={<Søknad />}
+                            label={'Forhåndsvis varselbrev'}
+                            kompakt={true}
+                            mini={true}
+                            onClick={visBrevINyFane}
+                        />
+                    )}
+                    {forhåndsvisningsFeil && (
+                        <AlertStripeFeil>{forhåndsvisningsFeil}</AlertStripeFeil>
+                    )}
                 </>
             )}
             <UnderOverskrfit>Begrunnelse (internt notat):</UnderOverskrfit>


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-6474

Hent (visning), generer (saksbehandler)
Skal kun hentes/genereres desom behandlingen ikke er ferdigstilt. Dersom et brev er sendt må man finne det i dokumentoversikten/tilbekekrevings-applikasjonen.

Testet i preprod: 

**Saksbehandler:**
![image](https://user-images.githubusercontent.com/53942238/141981367-f10ec56c-1e2d-42ac-bcbf-efd13455e818.png)

Deler av brev:
![image](https://user-images.githubusercontent.com/53942238/141981566-d6b58a57-3c5d-40c0-b527-f8aaf235633d.png)

**Beslutter:**
![image](https://user-images.githubusercontent.com/53942238/141982359-ebbd4276-206e-4f12-b565-1d3f93c39449.png)

(forhondsvisning med besluttersignatur) 
![image](https://user-images.githubusercontent.com/53942238/141982827-c2498a43-0b8e-4129-8978-76f48541e766.png)

Co-authored-by: Charlie Midtlyng <charlie.midtlyng@bekk.no>