### PR TITLE
Feilfiks. Etikett for fullmakt ble ikke vist då det var feilbruk av i…

### DIFF
--- a/src/frontend/App/utils/dato.ts
+++ b/src/frontend/App/utils/dato.ts
@@ -38,10 +38,14 @@ export const erEtterDagensDato = (dato: string | Date): boolean => {
     return erEtter(dato, new Date());
 };
 
+/**
+ * @param first date the date that should be after the other one to return true
+ * @param second dateToCompare the date to compare with
+ */
 export const erEtter = (first: string | Date, second: string | Date): boolean => {
     const d1: Date = typeof first === 'string' ? parseISO(first) : first;
     const d2: Date = typeof second === 'string' ? parseISO(second) : second;
-    return isAfter(d2, d1);
+    return isAfter(d1, d2);
 };
 
 export const gjelderÅr = (dato: string, år: number): boolean => {


### PR DESCRIPTION
…sAfter

![image](https://user-images.githubusercontent.com/937168/142410403-844d3101-2d11-4b11-962e-79cd79b1c6e4.png)
https://date-fns.org/v2.25.0/docs/isAfter