### PR TITLE
Uttrekk arbeidsssøker med ident navn

### DIFF
--- a/src/frontend/Komponenter/Uttrekk/UttrekkArbeidssøker.tsx
+++ b/src/frontend/Komponenter/Uttrekk/UttrekkArbeidssøker.tsx
@@ -13,8 +13,6 @@ import { useApp } from '../../App/context/AppContext';
 import DataViewer from '../../Felles/DataViewer/DataViewer';
 import { Element, Sidetittel, Systemtittel } from 'nav-frontend-typografi';
 import Lenke from 'nav-frontend-lenker';
-import { useHistory } from 'react-router-dom';
-import { useQueryParams } from '../../App/hooks/felles/useQueryParams';
 import { Checkbox } from 'nav-frontend-skjema';
 import { Flatknapp, Knapp } from 'nav-frontend-knapper';
 import { KopierbartNullableFødselsnummer } from '../../Felles/Fødselsnummer/KopierbartNullableFødselsnummer';
@@ -77,14 +75,8 @@ const settArbeidssøkereTilKontrollert = (
     };
 };
 
-const QUERY_PARAM_KONTROLLERTE = 'kontrollerte';
-
 const UttrekkArbeidssøker: React.FC = () => {
-    const query = useQueryParams();
-    const history = useHistory();
-
-    const visKontrollerte = query.get(QUERY_PARAM_KONTROLLERTE) === 'true';
-
+    const [visKontrollerte, settVisKontrollerte] = useState<boolean>(false);
     const [arbeidssøkere, settArbeidssøkere] = useState<Ressurs<UttrekkArbeidssøkere>>(
         byggTomRessurs()
     );
@@ -100,6 +92,7 @@ const UttrekkArbeidssøker: React.FC = () => {
                     visKontrollerte,
                 },
             }).then((respons: RessursSuksess<UttrekkArbeidssøkere> | RessursFeilet) => {
+                settArbeidssøkere(byggTomRessurs());
                 if (respons.status === RessursStatus.SUKSESS) {
                     settArbeidssøkere(respons);
                 } else {
@@ -156,10 +149,7 @@ const UttrekkArbeidssøker: React.FC = () => {
                             />
                             <Checkbox
                                 label={'Vis kontrollerte'}
-                                onChange={() => {
-                                    query.set(QUERY_PARAM_KONTROLLERTE, String(!visKontrollerte));
-                                    history.push(`${window.location.pathname}?${query.toString()}`);
-                                }}
+                                onChange={() => settVisKontrollerte((prevState) => !prevState)}
                                 checked={visKontrollerte}
                             />
                             <UttrekkArbeidssøkerTabell

--- a/src/frontend/Komponenter/Uttrekk/UttrekkArbeidssøker.tsx
+++ b/src/frontend/Komponenter/Uttrekk/UttrekkArbeidssøker.tsx
@@ -27,6 +27,9 @@ const StyledTable = styled.table`
     width: 60%;
     padding: 2rem;
     margin-left: 1rem;
+    td {
+        padding: 0.75rem;
+    }
 `;
 
 const StyledPagination = styled(Pagination)`
@@ -194,11 +197,14 @@ const Infoboks: React.FC<{ visKontrollerte: boolean; arbeidssøkere: UttrekkArbe
         ? arbeidssøkere.antallTotalt
         : arbeidssøkere.antallTotalt + arbeidssøkere.antallKontrollert;
     const antallManglerKontroll = antallTotalt - arbeidssøkere.antallKontrollert;
+    const rødMarkertTekst = arbeidssøkere.antallManglerTilgang > 0 ? { color: 'red' } : {};
     return (
         <div>
             <div>Disse tallene blir ikke oppdatert før man laster om siden på nytt</div>
             <div>Antall mangler kontroll: {antallManglerKontroll}</div>
-            <div>Antall mangler tilgang: {arbeidssøkere.antallManglerTilgang}</div>
+            <div style={rødMarkertTekst}>
+                Antall mangler tilgang: {arbeidssøkere.antallManglerTilgang}
+            </div>
         </div>
     );
 };

--- a/src/frontend/Komponenter/Uttrekk/UttrekkArbeidssøker.tsx
+++ b/src/frontend/Komponenter/Uttrekk/UttrekkArbeidssøker.tsx
@@ -18,6 +18,8 @@ import { useQueryParams } from '../../App/hooks/felles/useQueryParams';
 import { Checkbox } from 'nav-frontend-skjema';
 import { Flatknapp, Knapp } from 'nav-frontend-knapper';
 import { KopierbartNullableFødselsnummer } from '../../Felles/Fødselsnummer/KopierbartNullableFødselsnummer';
+import AdressebeskyttelseVarsel from '../../Felles/Varsel/AdressebeskyttelseVarsel';
+import { Adressebeskyttelse } from '../../App/typer/personopplysninger';
 
 const UttrekkArbeidssøkerContent = styled.div`
     padding: 1rem;
@@ -47,6 +49,7 @@ interface UttrekkArbeidssøker {
     behandlingIdForVedtak: string;
     personIdent: string;
     navn: string;
+    adressebeskyttelse?: Adressebeskyttelse;
     kontrollert: boolean;
     kontrollertTid?: string;
     kontrollertAv?: string;
@@ -224,6 +227,11 @@ const UttrekkArbeidssøkerTabell: React.FC<{
                                     <KopierbartNullableFødselsnummer
                                         fødselsnummer={arbeidssøker.personIdent}
                                     />
+                                    {arbeidssøker.adressebeskyttelse && (
+                                        <AdressebeskyttelseVarsel
+                                            adressebeskyttelse={arbeidssøker.adressebeskyttelse}
+                                        />
+                                    )}
                                 </div>
                             </td>
                             <td>

--- a/src/frontend/Komponenter/Uttrekk/UttrekkArbeidssøkerTabell.tsx
+++ b/src/frontend/Komponenter/Uttrekk/UttrekkArbeidssøkerTabell.tsx
@@ -7,6 +7,7 @@ import { Flatknapp, Knapp } from 'nav-frontend-knapper';
 import { formaterNullableIsoDatoTid } from '../../App/utils/formatter';
 import { IUttrekkArbeidssøker } from './UttrekkArbeidssøker';
 import styled from 'styled-components';
+import { useApp } from '../../App/context/AppContext';
 
 const StyledTable = styled.table`
     width: 70%;
@@ -20,9 +21,8 @@ const StyledTable = styled.table`
 const UttrekkArbeidssøkerTabell: React.FC<{
     arbeidssøkere: IUttrekkArbeidssøker[];
     settKontrollert: (id: string, kontrollert: boolean) => void;
-    gåTilUrl: (url: string) => void;
-}> = ({ arbeidssøkere, settKontrollert, gåTilUrl }) => {
-    console.log('table');
+}> = ({ arbeidssøkere, settKontrollert }) => {
+    const { gåTilUrl } = useApp();
     return (
         <StyledTable className="tabell">
             <thead>

--- a/src/frontend/Komponenter/Uttrekk/UttrekkArbeidssøkerTabell.tsx
+++ b/src/frontend/Komponenter/Uttrekk/UttrekkArbeidssøkerTabell.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import Lenke from 'nav-frontend-lenker';
+import { Element } from 'nav-frontend-typografi';
+import { KopierbartNullableFødselsnummer } from '../../Felles/Fødselsnummer/KopierbartNullableFødselsnummer';
+import AdressebeskyttelseVarsel from '../../Felles/Varsel/AdressebeskyttelseVarsel';
+import { Flatknapp, Knapp } from 'nav-frontend-knapper';
+import { formaterNullableIsoDatoTid } from '../../App/utils/formatter';
+import { IUttrekkArbeidssøker } from './UttrekkArbeidssøker';
+import styled from 'styled-components';
+
+const StyledTable = styled.table`
+    width: 70%;
+    padding: 2rem;
+    margin-left: 1rem;
+    td {
+        padding: 0.75rem;
+    }
+`;
+
+const UttrekkArbeidssøkerTabell: React.FC<{
+    arbeidssøkere: IUttrekkArbeidssøker[];
+    settKontrollert: (id: string, kontrollert: boolean) => void;
+    gåTilUrl: (url: string) => void;
+}> = ({ arbeidssøkere, settKontrollert, gåTilUrl }) => {
+    console.log('table');
+    return (
+        <StyledTable className="tabell">
+            <thead>
+                <tr>
+                    <th>Person</th>
+                    <th>Kontrollert</th>
+                </tr>
+            </thead>
+            <tbody>
+                {arbeidssøkere.map((arbeidssøker) => {
+                    return (
+                        <tr key={arbeidssøker.id}>
+                            <td>
+                                <div style={{ display: 'flex' }}>
+                                    <Lenke
+                                        role={'link'}
+                                        href={'#'}
+                                        onClick={() => {
+                                            gåTilUrl(`/fagsak/${arbeidssøker.fagsakId}`);
+                                        }}
+                                        style={{ marginRight: '1rem' }}
+                                    >
+                                        <Element>{arbeidssøker.navn}</Element>
+                                    </Lenke>
+                                    <KopierbartNullableFødselsnummer
+                                        fødselsnummer={arbeidssøker.personIdent}
+                                    />
+                                    {arbeidssøker.adressebeskyttelse && (
+                                        <AdressebeskyttelseVarsel
+                                            adressebeskyttelse={arbeidssøker.adressebeskyttelse}
+                                        />
+                                    )}
+                                </div>
+                            </td>
+                            <td>
+                                {!arbeidssøker.kontrollert ? (
+                                    <Knapp
+                                        onClick={() =>
+                                            settKontrollert(
+                                                arbeidssøker.id,
+                                                !arbeidssøker.kontrollert
+                                            )
+                                        }
+                                    >
+                                        Sett kontrollert
+                                    </Knapp>
+                                ) : (
+                                    <>
+                                        {formaterNullableIsoDatoTid(arbeidssøker.kontrollertTid)} (
+                                        {arbeidssøker.kontrollertAv})
+                                        <Flatknapp
+                                            mini
+                                            style={{ marginLeft: '1rem' }}
+                                            onClick={() =>
+                                                settKontrollert(
+                                                    arbeidssøker.id,
+                                                    !arbeidssøker.kontrollert
+                                                )
+                                            }
+                                        >
+                                            Tilbakestill
+                                        </Flatknapp>
+                                    </>
+                                )}
+                            </td>
+                        </tr>
+                    );
+                })}
+            </tbody>
+        </StyledTable>
+    );
+};
+
+export default UttrekkArbeidssøkerTabell;

--- a/src/frontend/Komponenter/Uttrekk/UttrekkArbeidssøkerTabell.tsx
+++ b/src/frontend/Komponenter/Uttrekk/UttrekkArbeidssøkerTabell.tsx
@@ -60,6 +60,7 @@ const UttrekkArbeidssøkerTabell: React.FC<{
                             <td>
                                 {!arbeidssøker.kontrollert ? (
                                     <Knapp
+                                        mini
                                         onClick={() =>
                                             settKontrollert(
                                                 arbeidssøker.id,


### PR DESCRIPTION
Fortsetting på uttrekk arbeidssøkere
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-7136
https://github.com/navikt/familie-ef-sak/pull/1015

Det ble en utsplitting av tabellen, se gjerne på all kode i begge disse filene. Ble litt mye endringer så kan være fint å base på den oppdaterte

Det i den venstre kolonnen er egentlige <fornavn mellomnavn etternavn (ident)>

![image](https://user-images.githubusercontent.com/937168/144591295-49ea8c0f-2dfe-4c24-82d1-41e3e22dc641.png)

