### PR TITLE
Vedtakshistorikk - Legger til støtte for nye felter som kan fjernes n…

### DIFF
--- a/src/frontend/App/typer/tilkjentytelse.ts
+++ b/src/frontend/App/typer/tilkjentytelse.ts
@@ -33,12 +33,16 @@ export interface AndelHistorikkEndring {
 
 export enum AndelEndringType {
     FJERNET = 'FJERNET',
+    ERSTATTET = 'ERSTATTET', // Deprecated
+    SPLITTET = 'SPLITTET', // Deprecated
     ENDRET = 'ENDRET',
     ENDRING_I_INNTEKT = 'ENDRING_I_INNTEKT',
 }
 
 export const AndelHistorikkTypeTilTekst: Record<AndelEndringType, string> = {
     FJERNET: 'Fjernet',
-    ENDRET: 'Endret',
-    ENDRING_I_INNTEKT: 'Endring i inntekt',
+    ERSTATTET: 'Erstattet',
+    SPLITTET: 'Splittet',
+    ENDRET: 'Endret', // Deprecated
+    ENDRING_I_INNTEKT: 'Endring i inntekt', // Deprecated
 };

--- a/src/frontend/Komponenter/Personoversikt/Vedtaksperioder.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Vedtaksperioder.tsx
@@ -25,8 +25,11 @@ const StyledTabell = styled.table`
 `;
 
 const Rad = styled.tr<{ type?: AndelEndringType }>`
-    opacity: ${(props) => (props.type === AndelEndringType.FJERNET ? '50%' : '100%')};
+    opacity: ${(props) => (skalMarkeresSomFjernet(props.type) ? '50%' : '100%')};
 `;
+
+const skalMarkeresSomFjernet = (type?: AndelEndringType) =>
+    type === AndelEndringType.FJERNET || type === AndelEndringType.ERSTATTET;
 
 const vedtakstidspunkt = (andel: AndelHistorikk) => (
     <Link


### PR DESCRIPTION
…år de er fjernet i backend

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-7256
Koblet til 
* https://github.com/navikt/familie-ef-sak/pull/1025 men kan deployes uavhengig denne. (men må deployes før)