### PR TITLE
Skal redirecte til oppgavebenk og vise toast når vedtak underkjennes

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -16,6 +16,7 @@ import UgyldigSesjon from './Felles/Modal/SesjonUtløpt';
 import UlagretDataModal from './Komponenter/Behandling/Fanemeny/UlagretDataModal';
 import EksternRedirectContainer from './Komponenter/EksternRedirect/EksternRedirectContainer';
 import UttrekkArbeidssøker from './Komponenter/Uttrekk/UttrekkArbeidssøker';
+import { Toast } from './Felles/Toast/Toast';
 
 Modal.setAppElement(document.getElementById('modal-a11y-wrapper'));
 
@@ -92,6 +93,7 @@ const AppInnhold: React.FC<{ innloggetSaksbehandler?: ISaksbehandler }> = ({
                 <Redirect from="/" to="/oppgavebenk" />
             </Switch>
             <UlagretDataModal />
+            <Toast />
         </>
     );
 };

--- a/src/frontend/App/context/AppContext.tsx
+++ b/src/frontend/App/context/AppContext.tsx
@@ -5,6 +5,7 @@ import { håndterFeil, håndterRessurs, preferredAxios } from '../api/axios';
 import { Ressurs, RessursFeilet, RessursSuksess } from '../typer/ressurs';
 import { ISaksbehandler } from '../typer/saksbehandler';
 import constate from 'constate';
+import { EToast } from '../typer/toast';
 
 interface IProps {
     autentisertSaksbehandler: ISaksbehandler | undefined;
@@ -21,6 +22,7 @@ const [AppProvider, useApp] = constate(({ autentisertSaksbehandler }: IProps) =>
     const [valgtSide, settValgtSide] = useState<string | undefined>();
     const [visUlagretDataModal, settVisUlagretDataModal] = useState(false);
     const [byttUrl, settByttUrl] = useState(false);
+    const [toast, settToast] = useState<EToast | undefined>();
 
     useEffect(
         () => settUlagretData(ikkePersisterteKomponenter.size > 0),
@@ -90,6 +92,8 @@ const [AppProvider, useApp] = constate(({ autentisertSaksbehandler }: IProps) =>
         settVisUlagretDataModal,
         byttUrl,
         settByttUrl,
+        toast,
+        settToast,
     };
 });
 

--- a/src/frontend/App/typer/toast.ts
+++ b/src/frontend/App/typer/toast.ts
@@ -1,0 +1,7 @@
+export enum EToast {
+    VEDTAK_UNDERKJENT = 'VEDTAK_UNDERKJENT',
+}
+
+export const toastTilTekst: Record<EToast, string> = {
+    VEDTAK_UNDERKJENT: 'Vedtak underkjent',
+};

--- a/src/frontend/Felles/Toast/Toast.tsx
+++ b/src/frontend/Felles/Toast/Toast.tsx
@@ -1,0 +1,31 @@
+import React, { useEffect } from 'react';
+
+import styled from 'styled-components';
+
+import { AlertStripeSuksess } from 'nav-frontend-alertstriper';
+import { useApp } from '../../App/context/AppContext';
+import { toastTilTekst } from '../../App/typer/toast';
+
+const Container = styled.div`
+    z-index: 9999;
+    position: fixed;
+    right: 2rem;
+    top: 4rem;
+`;
+
+export const Toast: React.FC = () => {
+    const { toast, settToast } = useApp();
+
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            settToast(undefined);
+        }, 5000);
+        return () => clearTimeout(timer);
+    });
+
+    return toast ? (
+        <Container>
+            <AlertStripeSuksess>{toastTilTekst[toast]}</AlertStripeSuksess>
+        </Container>
+    ) : null;
+};


### PR DESCRIPTION
For å unngå at beslutter skal saksbehandle vedtaket de nettop har underkjent redirecter vi dem til oppgavebenken med en toast som bekrefter at vedtaket ble underkjent. Dette fikser feilene av typen `VedtaksbrevService.hentBeslutterbrevEllerRekonstruerSaksbehandlerBrev`

![image](https://user-images.githubusercontent.com/21220467/145002235-471575b4-a63e-4ce6-853d-3b1c7c0be537.png)

https://user-images.githubusercontent.com/21220467/145002321-8e6e7261-6072-47f5-a967-d0f6600f9b71.mp4


