### PR TITLE
Legger til a-inntekt i csp for å kunne kalle a-inntekt api'et fra vår…

### DIFF
--- a/src/backend/headerUtils.ts
+++ b/src/backend/headerUtils.ts
@@ -1,0 +1,20 @@
+import { urlAInntekt } from './config';
+import { Response } from 'express';
+
+const cspHeaderName = 'Content-Security-Policy';
+const cspPrefix = "default-src 'self'";
+
+/**
+ * Legger til url til Ainntekt for å kunne kalle på a-inntekt-redirect for å generere custom url til a-inntekt
+ */
+export const customCspHeader = (res: Response): void => {
+    const cspHeader = res.getHeader(cspHeaderName);
+    if (typeof cspHeader === 'string') {
+        if (cspHeader.indexOf(cspPrefix) > -1) {
+            res.header(
+                cspHeaderName,
+                `${cspPrefix} ${urlAInntekt} ${cspHeader.substring(cspPrefix.length)}`
+            );
+        }
+    }
+};

--- a/src/backend/router.ts
+++ b/src/backend/router.ts
@@ -6,6 +6,7 @@ import { prometheusTellere } from './metrikker';
 import { slackNotify } from './slack/slack';
 import WebpackDevMiddleware from 'webpack-dev-middleware';
 import { LOG_LEVEL } from '@navikt/familie-logging';
+import { customCspHeader } from './headerUtils';
 
 // eslint-disable-next-line
 const packageJson = require('../../package.json');
@@ -63,6 +64,7 @@ export default (
     } else {
         router.get('*', ensureAuthenticated(authClient, false), (_req: Request, res: Response) => {
             prometheusTellere.appLoad.inc();
+            customCspHeader(res);
 
             res.sendFile('index.html', { root: path.join(__dirname, buildPath) });
         });


### PR DESCRIPTION
…et frontend

Egentlige litt hacky løsning, så liker den ikke helt
Alternativen var å endre csp i felles-frontend, og det føles litt feil.
Det andre alternativet er å gå via backend for å kalle på denne. Trenger då å kalle 
`frontend -> node-backend -> ef-sak -> ef-proxy -> a-inntekt `