### PR TITLE
Genererer a-inntekt url via proxy då CSP stopper kall mot annen url

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -10,6 +10,7 @@ const Environment = () => {
             sakProxyUrl: 'http://localhost:8093',
             brevProxyUrl: 'http://localhost:8001',
             aInntekt: 'https://arbeid-og-inntekt.dev.adeo.no',
+            efProxy: 'https://familie-ef-proxy.dev.intern.nav.no',
         };
     } else if (process.env.ENV === 'e2e') {
         return {
@@ -18,6 +19,7 @@ const Environment = () => {
             sakProxyUrl: 'http://familie-ef-sak:8093',
             brevProxyUrl: '', // TODO
             aInntekt: 'https://arbeid-og-inntekt.dev.adeo.no',
+            efProxy: '',
             //Har ikke satt opp redis
         };
     } else if (process.env.ENV === 'preprod') {
@@ -27,6 +29,7 @@ const Environment = () => {
             sakProxyUrl: 'http://familie-ef-sak',
             brevProxyUrl: 'http://familie-brev',
             aInntekt: 'https://arbeid-og-inntekt.dev.adeo.no',
+            efProxy: 'https://familie-ef-proxy.dev-fss-pub.nais.io',
             redisUrl: 'familie-ef-sak-frontend-redis',
         };
     }
@@ -37,6 +40,7 @@ const Environment = () => {
         sakProxyUrl: 'http://familie-ef-sak',
         brevProxyUrl: 'http://familie-brev',
         aInntekt: 'https://arbeid-og-inntekt.nais.adeo.no',
+        efProxy: 'https://familie-ef-proxy.prod-fss-pub.nais.io',
         redisUrl: 'familie-ef-sak-frontend-redis',
     };
 };
@@ -65,3 +69,4 @@ export const sakProxyUrl = env.sakProxyUrl;
 export const brevProxyUrl = env.brevProxyUrl;
 export const namespace = env.namespace;
 export const urlAInntekt = env.aInntekt;
+export const efProxyUrl = env.efProxy;

--- a/src/backend/efProxyRouter.ts
+++ b/src/backend/efProxyRouter.ts
@@ -1,0 +1,26 @@
+import { Request, Response, Router } from 'express';
+import axios, { AxiosError, AxiosResponse } from 'axios';
+import { efProxyUrl } from './config';
+import { logError } from '@navikt/familie-logging';
+
+export const registretEfProxyEndpoints = (router: Router): void => {
+    router.post('/api/generer-ainmtekt-url', (_req: Request, _res: Response) => {
+        axios
+            .post(
+                `${efProxyUrl}/api/ainntekt/generer-url`,
+                { ident: _req.body.ident },
+                {
+                    headers: {
+                        accept: 'text/plain',
+                    },
+                }
+            )
+            .then((result: AxiosResponse<string>) => {
+                _res.status(200).type('text/plain').send(result.data);
+            })
+            .catch((error: AxiosError<string>) => {
+                logError(`Feilet kall for å hente url mot a-inntekt ${error}`);
+                _res.status(500).end();
+            });
+    });
+};

--- a/src/backend/router.ts
+++ b/src/backend/router.ts
@@ -6,6 +6,7 @@ import { prometheusTellere } from './metrikker';
 import { slackNotify } from './slack/slack';
 import WebpackDevMiddleware from 'webpack-dev-middleware';
 import { LOG_LEVEL } from '@navikt/familie-logging';
+import { registretEfProxyEndpoints } from './efProxyRouter';
 
 // eslint-disable-next-line
 const packageJson = require('../../package.json');
@@ -23,6 +24,8 @@ export default (
     router.get('/env', (_req: Request, res: Response) => {
         res.status(200).send({ aInntekt: urlAInntekt }).end();
     });
+
+    registretEfProxyEndpoints(router);
 
     router.get('/error', (_req: Request, res: Response) => {
         prometheusTellere.errorRoute.inc();

--- a/src/frontend/Felles/Linker/AInntekt/AInntektLink.ts
+++ b/src/frontend/Felles/Linker/AInntekt/AInntektLink.ts
@@ -1,21 +1,16 @@
-import { apiLoggFeil, preferredAxios } from '../../../App/api/axios';
+import { preferredAxios } from '../../../App/api/axios';
 import { AxiosError, AxiosResponse } from 'axios';
 import { AppEnv } from '../../../App/api/env';
 
-const errorMelding = 'Noe feilet vid henting av link mot a-inntekt';
-
 export const lagAInntektLink = async (appEnv: AppEnv, personIdent: string): Promise<string> => {
     return await preferredAxios
-        .get(`${appEnv.aInntekt}/api/v2/redirect/sok/a-inntekt`, {
-            headers: {
-                'Nav-Personident': personIdent,
-            },
+        .post(`/api/generer-ainmtekt-url`, {
+            ident: personIdent,
         })
         .then((response: AxiosResponse<string>) => {
             return response.data;
         })
-        .catch((error: AxiosError<string>) => {
-            apiLoggFeil(`${errorMelding} ${error}`);
+        .catch((_: AxiosError<string>) => {
             return appEnv.aInntekt;
         });
 };


### PR DESCRIPTION
Pga Content Security Policy så får vi ikke kalle på arbeid og inntekt…
… fra frontend, går då via ef-proxy for å hente denne url

* Logger error i backend
* Legger til api i node-backend for å hente url, og ikke proxy då jeg ikke ønsker å åpne opp hele proxy fra frontend
* https://github.com/navikt/familie-ef-sak-frontend/pull/716 fiks for denne

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-7485