### PR TITLE
endret ftekstfarge på deaktiverte faner til lysere farge

### DIFF
--- a/src/frontend/Komponenter/Behandling/Fanemeny/Fane.tsx
+++ b/src/frontend/Komponenter/Behandling/Fanemeny/Fane.tsx
@@ -35,7 +35,7 @@ const StyledNavLink = styled(NavLink)`
 
 const StyledTekst = styled(Normaltekst)`
     border-bottom: 5px solid white;
-    color: ${navFarger.navGra60};
+    color: ${navFarger.navGra20};
     text-align: center;
     text-decoration: none;
     width: 100%;


### PR DESCRIPTION
Etter samtale med Lars ble det utrykt et ønske om at det skal gjøres tydeligere at fanene er deaktiverte - gjerne med en lysere farge.

Før: 
![Skjermbilde 2021-12-09 kl  16 02 48](https://user-images.githubusercontent.com/32769446/145546306-1d6c6aaa-02bb-477b-8dee-84e508e8dd50.png)

Etter:
![Skjermbilde 2021-12-10 kl  09 52 39](https://user-images.githubusercontent.com/32769446/145546323-7490abaf-fbb7-4bcd-8e51-e680a44fafab.png)

