### PR TITLE
Skal vise infostripe om valgte brevmottakere på brevfanen

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
@@ -8,6 +8,8 @@ import Brevmeny from './Brevmeny';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { useApp } from '../../../App/context/AppContext';
 import { TotrinnskontrollStatus } from '../../../App/typer/totrinnskontroll';
+import { IBrevmottakere } from '../Brevmottakere/typer';
+import { InfostripeBrevmottakere } from './InfostripeBrevmottakere';
 
 const StyledBrev = styled.div`
     background-color: #f2f2f2;
@@ -34,6 +36,9 @@ const Brev: React.FC<Props> = ({ behandlingId }) => {
     const { behandlingErRedigerbar, personopplysningerResponse, totrinnskontroll } =
         useBehandling();
     const [kanSendesTilBeslutter, settKanSendesTilBeslutter] = useState<boolean>(false);
+    const [brevmottakereRessurs, settBrevMottakereRessurs] = useState(
+        byggTomRessurs<IBrevmottakere | undefined>()
+    );
 
     const lagBeslutterBrev = () => {
         axiosRequest<string, null>({
@@ -74,8 +79,28 @@ const Brev: React.FC<Props> = ({ behandlingId }) => {
         // eslint-disable-next-line
     }, [behandlingErRedigerbar, totrinnskontroll]);
 
+    useEffect(() => {
+        const hentBrevmottakere = () => {
+            axiosRequest<IBrevmottakere | undefined, null>({
+                url: `familie-ef-sak/api/brevmottakere/${behandlingId}`,
+                method: 'GET',
+            }).then((resp: Ressurs<IBrevmottakere | undefined>) => {
+                settBrevMottakereRessurs(resp);
+            });
+        };
+
+        hentBrevmottakere();
+    }, [axiosRequest, behandlingId, settBrevMottakereRessurs]);
+
     return (
         <>
+            <DataViewer response={{ brevmottakereRessurs }}>
+                {({ brevmottakereRessurs }) =>
+                    brevmottakereRessurs && (
+                        <InfostripeBrevmottakere brevmottakere={brevmottakereRessurs} />
+                    )
+                }
+            </DataViewer>
             <StyledBrev>
                 {behandlingErRedigerbar && (
                     <DataViewer response={{ personopplysningerResponse }}>

--- a/src/frontend/Komponenter/Behandling/Brev/InfostripeBrevmottakere.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/InfostripeBrevmottakere.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { IBrevmottakere } from '../Brevmottakere/typer';
+import { AlertStripeInfo } from 'nav-frontend-alertstriper';
+
+export const InfostripeBrevmottakere: React.FC<{ brevmottakere: IBrevmottakere }> = ({
+    brevmottakere,
+}) => {
+    const brevmottakereStreng =
+        [
+            ...brevmottakere.personer.map(
+                (mottaker) => `${mottaker.navn}  (${mottaker.mottakerRolle.toLowerCase()})`
+            ),
+            ...brevmottakere.organisasjoner.map(
+                (mottaker) =>
+                    `${mottaker.navnHosOrganisasjon} (${mottaker.mottakerRolle.toLowerCase()})`
+            ),
+        ].join(', ') + '.';
+
+    return <AlertStripeInfo>Mottakere av brev: {brevmottakereStreng}</AlertStripeInfo>;
+};


### PR DESCRIPTION
Legger til en inforstripe øverst i brevfanen når brevmottakere er satt.
Fra design spesifisert her: https://www.figma.com/file/JEmXg4WqG0DFItNGpoX696/Skisser-EF-sak?node-id=6008%3A120634

![image](https://user-images.githubusercontent.com/21220467/148386781-fbb2ace6-f4af-49b1-a676-6c82747c98cb.png)
