### PR TITLE
Infotrygdperioder oversikt

### DIFF
--- a/src/frontend/App/typer/fagsak.ts
+++ b/src/frontend/App/typer/fagsak.ts
@@ -12,6 +12,7 @@ export interface Fagsak {
     stønadstype: Stønadstype;
     behandlinger: Behandling[];
     erLøpende: boolean;
+    erMigrert: boolean;
 }
 
 export interface Behandling {

--- a/src/frontend/App/typer/infotrygd.ts
+++ b/src/frontend/App/typer/infotrygd.ts
@@ -1,0 +1,132 @@
+export interface InfotrygdPerioderResponse {
+    overgangsstønad: Perioder;
+    barnetilsyn: Perioder;
+    skolepenger: Perioder;
+}
+
+export interface Perioder {
+    perioder: InfotrygdPeriode[];
+    summert: SummertPeriode[];
+}
+
+export interface SummertPeriode {
+    stønadFom: string;
+    stønadTom: string;
+    beløp: number;
+    inntektsreduksjon: number;
+    samordningsfradrag: number;
+}
+
+export interface InfotrygdPeriode {
+    vedtakId: number;
+    vedtakstidspunkt: string;
+
+    stønadFom: string;
+    stønadTom: string;
+    opphørsdato?: string;
+
+    beløp: number;
+    inntektsgrunnlag: number;
+    samordningsfradrag: number;
+
+    kode: Kode;
+    sakstype: Sakstype;
+    kodeOvergangsstønad?: InfotrygdOvergangsstønadKode;
+    aktivitetstype?: InfotrygdAktivitetstype;
+    brukerId: string;
+}
+
+enum Kode {
+    ANNULERT = 'ANNULERT',
+    ENDRING_BEREGNINGSGRUNNLAG = 'ENDRING_BEREGNINGSGRUNNLAG',
+    FØRSTEGANGSVEDTAK = 'FØRSTEGANGSVEDTAK',
+    G_REGULERING = 'G_REGULERING',
+    NY = 'NY',
+    OPPHØRT = 'OPPHØRT',
+    SATSENDRING = 'SATSENDRING',
+    UAKTUELL = 'UAKTUELL',
+    OVERTFØRT_NY_LØSNING = 'OVERTFØRT_NY_LØSNING',
+}
+
+export const kodeTilTekst: Record<Kode, string> = {
+    ANNULERT: 'Annullert (AN)',
+    ENDRING_BEREGNINGSGRUNNLAG: 'Endring i beregningsgrunnlag (E)',
+    FØRSTEGANGSVEDTAK: 'Førstegangsvedtak (F)',
+    G_REGULERING: 'G-regulering (G)',
+    NY: 'Ny (NY)',
+    OPPHØRT: 'Opphørt (O)',
+    SATSENDRING: 'Satsendring (S)',
+    UAKTUELL: 'Uaktuell (UA)',
+    OVERTFØRT_NY_LØSNING: 'Overf ny løsning (OO)',
+};
+
+enum Sakstype {
+    KLAGE = 'KLAGE',
+    MASKINELL_G_OMREGNING = 'MASKINELL_G_OMREGNING',
+    REVURDERING = 'REVURDERING',
+    GRUNNBELØP_OMREGNING = 'GRUNNBELØP_OMREGNING',
+    KONVERTERING = 'KONVERTERING',
+    MASKINELL_SATSOMREGNING = 'MASKINELL_SATSOMREGNING',
+    ANKE = 'ANKE',
+    SØKNAD = 'SØKNAD',
+    SØKNAD_ØKNING_ENDRING = 'SØKNAD_ØKNING_ENDRING',
+}
+
+export const sakstypeTilTekst: Record<Sakstype, string> = {
+    KLAGE: 'Klage (K)',
+    MASKINELL_G_OMREGNING: 'Maskinell G-omregning (MG)',
+    REVURDERING: 'Revurdering (R)',
+    GRUNNBELØP_OMREGNING: 'Grunnbeløp omregning (GO)',
+    KONVERTERING: 'Konvertering (KO)',
+    MASKINELL_SATSOMREGNING: 'Maskinell satsomregning (MS)',
+    ANKE: 'Anke (A)',
+    SØKNAD: 'Søknad (S)',
+    SØKNAD_ØKNING_ENDRING: 'Søknad om økning/endring (SØ)',
+};
+
+enum InfotrygdOvergangsstønadKode {
+    BARN_UNDER_1_3_ÅR = 'BARN_UNDER_1_3_ÅR',
+    YRKESRETTET_AKTIVITET_BARN_FYLT_1_3_ÅR = 'YRKESRETTET_AKTIVITET_BARN_FYLT_1_3_ÅR',
+    UNNTAK_FRA_KRAV_TIL_YRKESRETTET_AKTIVITET = 'UNNTAK_FRA_KRAV_TIL_YRKESRETTET_AKTIVITET',
+    UTVIDELSE_NØDVENDIG_UTDANNING = 'UTVIDELSE_NØDVENDIG_UTDANNING',
+    PÅVENTE_SKOLESTART_ARBEID_TILSYNSPLASS = 'PÅVENTE_SKOLESTART_ARBEID_TILSYNSPLASS',
+    YRKESRETTET_AKTIVITET = 'YRKESRETTET_AKTIVITET',
+    FORBIGÅENDE_SYKDOM = 'FORBIGÅENDE_SYKDOM',
+    SÆRLIG_TILSSYNSKREVENDE_BARN = 'SÆRLIG_TILSSYNSKREVENDE_BARN',
+    ETABLERER_EGEN_VIRKSOMHET = 'ETABLERER_EGEN_VIRKSOMHET',
+    FORTSATT_INNVILGET_TROSS_VARSEL_OM_OPPHØR_PGA_SAMBOER = 'FORTSATT_INNVILGET_TROSS_VARSEL_OM_OPPHØR_PGA_SAMBOER',
+}
+
+export const overgangsstønadKodeTilTekst: Record<InfotrygdOvergangsstønadKode, string> = {
+    BARN_UNDER_1_3_ÅR: 'Barn under 1 år / 3 år (gamle tilfeller)',
+    YRKESRETTET_AKTIVITET_BARN_FYLT_1_3_ÅR:
+        'Er i yrkesrettet aktivitet - barn har fylt 1 år / 3 år (gamle tilfeller)',
+    UNNTAK_FRA_KRAV_TIL_YRKESRETTET_AKTIVITET:
+        'Unntak fra krav til yrkesr. aktivitet når barn har fylt 1 år / år (gamle tilfeller)',
+    UTVIDELSE_NØDVENDIG_UTDANNING: 'Utvidelse på grunn av nødvendig utdanning jf 15-6. 3. ledd',
+    PÅVENTE_SKOLESTART_ARBEID_TILSYNSPLASS:
+        'I påvente av skolestart/arbeid/tilsynsplass 15-6. 4. ledd',
+    YRKESRETTET_AKTIVITET: 'Er i yrkesrettet aktivitet - i omstillingstid',
+    FORBIGÅENDE_SYKDOM: 'Forbig. sykdom hos forsørger eller barnet 15-6. 6. ledd',
+    SÆRLIG_TILSSYNSKREVENDE_BARN: 'Har særlig tilssynskrevende barn',
+    ETABLERER_EGEN_VIRKSOMHET: 'Etablerer egen virksomhet',
+    FORTSATT_INNVILGET_TROSS_VARSEL_OM_OPPHØR_PGA_SAMBOER: 'Fortsatt innvilget tro',
+};
+
+enum InfotrygdAktivitetstype {
+    I_ARBEID = 'I_ARBEID',
+    I_UTDANNING = 'I_UTDANNING',
+    TILMELDT_SOM_REELL_ARBEIDSSØKER = 'TILMELDT_SOM_REELL_ARBEIDSSØKER',
+    KURS = 'KURS',
+    BRUKERKONTAKT = 'BRUKERKONTAKT',
+    IKKE_I_AKTIVITET = 'IKKE_I_AKTIVITET',
+}
+
+export const aktivitetstypeTilTekst: Record<InfotrygdAktivitetstype, string> = {
+    I_ARBEID: 'I arbeid (A)',
+    I_UTDANNING: 'I utdanning (U)',
+    TILMELDT_SOM_REELL_ARBEIDSSØKER: 'Tilmeldt som reell arbeidssøker (S)',
+    KURS: 'Kurs o.l. (K)',
+    BRUKERKONTAKT: 'Brukerkontakt (B)',
+    IKKE_I_AKTIVITET: 'Ikke i aktivitet (N)',
+};

--- a/src/frontend/Komponenter/Personoversikt/Infotrygdperioderoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Infotrygdperioderoversikt.tsx
@@ -28,6 +28,9 @@ const StyledTabell = styled.table`
 const Rad = styled.tr``;
 
 const SummertePerioder: React.FC<{ perioder: SummertPeriode[] }> = ({ perioder }) => {
+    if (perioder.length === 0) {
+        return <>Ingen vedtaksperioder i Infotrygd</>;
+    }
     return (
         <StyledTabell className="tabell">
             <thead>
@@ -57,6 +60,9 @@ const SummertePerioder: React.FC<{ perioder: SummertPeriode[] }> = ({ perioder }
 };
 
 const InfotrygdPerioder: React.FC<{ perioder: InfotrygdPeriode[] }> = ({ perioder }) => {
+    if (perioder.length === 0) {
+        return <>Ingen vedtaksperioder i Infotrygd</>;
+    }
     return (
         <StyledTabell className="tabell">
             <thead>
@@ -120,15 +126,22 @@ const InfotrygdEllerSummertePerioder: React.FC<{ perioder: InfotrygdPerioderResp
         );
     };
 
+    const skalViseCheckbox =
+        perioder.overgangsstønad.perioder.length > 0 ||
+        perioder.barnetilsyn.perioder.length > 0 ||
+        perioder.skolepenger.perioder.length > 0;
+
     return (
         <>
-            <Checkbox
-                label={'Vis summerte perioder'}
-                onClick={() => {
-                    settVisSummert((prevState) => !prevState);
-                }}
-                checked={visSummert}
-            />
+            {skalViseCheckbox && (
+                <Checkbox
+                    label={'Vis summerte perioder'}
+                    onClick={() => {
+                        settVisSummert((prevState) => !prevState);
+                    }}
+                    checked={visSummert}
+                />
+            )}
             <h1>Overgangsstønad</h1>
             {visPerioder(visSummert, perioder.overgangsstønad)}
 

--- a/src/frontend/Komponenter/Personoversikt/Infotrygdperioderoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Infotrygdperioderoversikt.tsx
@@ -20,12 +20,21 @@ import {
     sakstypeTilTekst,
     SummertPeriode,
 } from '../../App/typer/infotrygd';
+import { AlertStripeInfo } from 'nav-frontend-alertstriper';
 
 const StyledTabell = styled.table`
     margin-top: 2rem;
 `;
 
 const Rad = styled.tr``;
+
+const StyledAlertStripe = styled(AlertStripeInfo)`
+    margin: 1rem 0;
+    max-width: 51rem;
+    .alertstripe__tekst {
+        max-width: 51rem;
+    }
+`;
 
 const SummertePerioder: React.FC<{ perioder: SummertPeriode[] }> = ({ perioder }) => {
     if (perioder.length === 0) {
@@ -133,6 +142,10 @@ const InfotrygdEllerSummertePerioder: React.FC<{ perioder: InfotrygdPerioderResp
 
     return (
         <>
+            <StyledAlertStripe>
+                Denne siden viser vedtakshistorikk fra EV VP. (Saker før desember 2008 - PE PP må
+                sjekkes manuelt i Infotrygd)
+            </StyledAlertStripe>
             {skalViseCheckbox && (
                 <Checkbox
                     label={'Vis summerte perioder'}

--- a/src/frontend/Komponenter/Personoversikt/Infotrygdperioderoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Infotrygdperioderoversikt.tsx
@@ -1,0 +1,185 @@
+import React, { useMemo, useState } from 'react';
+import { AxiosRequestConfig } from 'axios';
+import 'nav-frontend-tabell-style';
+import styled from 'styled-components';
+import {
+    formaterNullableIsoDato,
+    formaterNullableMånedÅr,
+    formaterTallMedTusenSkille,
+} from '../../App/utils/formatter';
+import { useDataHenter } from '../../App/hooks/felles/useDataHenter';
+import DataViewer from '../../Felles/DataViewer/DataViewer';
+import { Checkbox } from 'nav-frontend-skjema';
+
+const StyledTabell = styled.table`
+    margin-top: 2rem;
+`;
+
+const Rad = styled.tr``;
+
+interface InfotrygdPerioderResponse {
+    overgangsstønad: Perioder;
+    barnetilsyn: Perioder;
+    skolepenger: Perioder;
+}
+
+interface Perioder {
+    perioder: InfotrygdPeriode[];
+    summert: SummertPeriode[];
+}
+
+interface SummertPeriode {
+    stønadFom: string;
+    stønadTom: string;
+    beløp: number;
+    inntektsreduksjon: number;
+    samordningsfradrag: number;
+}
+
+interface InfotrygdPeriode {
+    stønadId: number;
+    vedtakId: number;
+
+    stønadFom: string;
+    stønadTom: string;
+    opphørsdato?: string;
+
+    beløp: number;
+    inntektsreduksjon: number;
+    samordningsfradrag: number;
+
+    startDato: string;
+    kode: string;
+    brukerId: string;
+}
+
+const SummertePerioder: React.FC<{ perioder: SummertPeriode[] }> = ({ perioder }) => {
+    return (
+        <StyledTabell className="tabell">
+            <thead>
+                <tr>
+                    <th>Periode (fom-tom)</th>
+                    <th>Inntektsgrunnlag</th>
+                    <th>Samordningsfradrag</th>
+                    <th>Stønadsbeløp</th>
+                </tr>
+            </thead>
+            <tbody>
+                {perioder.map((periode) => (
+                    <Rad>
+                        <td>
+                            {formaterNullableMånedÅr(periode.stønadFom)}
+                            {' - '}
+                            {formaterNullableMånedÅr(periode.stønadTom)}
+                        </td>
+                        <td>{formaterTallMedTusenSkille(periode.inntektsreduksjon)}</td>
+                        <td>{formaterTallMedTusenSkille(periode.samordningsfradrag)}</td>
+                        <td>{formaterTallMedTusenSkille(periode.beløp)}</td>
+                    </Rad>
+                ))}
+            </tbody>
+        </StyledTabell>
+    );
+};
+
+const InfotrygdPerioder: React.FC<{ perioder: InfotrygdPeriode[] }> = ({ perioder }) => {
+    return (
+        <StyledTabell className="tabell">
+            <thead>
+                <tr>
+                    <th>StønadId</th>
+                    <th>VedtakId</th>
+                    <th>Periode (fom-tom)</th>
+                    <th>Opphørsdato</th>
+                    <th>Inntektsreduskjon</th>
+                    <th>Samordningsfradrag</th>
+                    <th>Stønadsbeløp</th>
+                    <th>Startdato</th>
+                    <th>Kode</th>
+                    <th>Saksbehandler</th>
+                </tr>
+            </thead>
+            <tbody>
+                {perioder.map((periode) => (
+                    <Rad>
+                        <td>{periode.stønadId}</td>
+                        <td>{periode.vedtakId}</td>
+                        <td>
+                            {formaterNullableMånedÅr(periode.stønadFom)}
+                            {' - '}
+                            {formaterNullableMånedÅr(periode.stønadTom)}
+                        </td>
+                        <td>{formaterNullableMånedÅr(periode.opphørsdato)}</td>
+                        <td>{formaterTallMedTusenSkille(periode.inntektsreduksjon)}</td>
+                        <td>{formaterTallMedTusenSkille(periode.samordningsfradrag)}</td>
+                        <td>{formaterTallMedTusenSkille(periode.beløp)}</td>
+                        <td>{formaterNullableIsoDato(periode.startDato)}</td>
+                        <td>{periode.kode}</td>
+                        <td>{periode.brukerId}</td>
+                    </Rad>
+                ))}
+            </tbody>
+        </StyledTabell>
+    );
+};
+
+const InfotrygdEllerSummertePerioder: React.FC<{ perioder: InfotrygdPerioderResponse }> = ({
+    perioder,
+}) => {
+    const [visSummert, settVisSummert] = useState<boolean>(false);
+
+    const visPerioder = (visSummert: boolean, perioder: Perioder) => {
+        return visSummert ? (
+            <SummertePerioder perioder={perioder.summert} />
+        ) : (
+            <InfotrygdPerioder perioder={perioder.perioder} />
+        );
+    };
+
+    return (
+        <>
+            <Checkbox
+                label={'Vis summerte perioder'}
+                onClick={() => {
+                    settVisSummert((prevState) => !prevState);
+                }}
+                checked={visSummert}
+            />
+            <h1>Overgangsstønad</h1>
+            {visPerioder(visSummert, perioder.overgangsstønad)}
+
+            <h1>Barnetilsyn</h1>
+            {visPerioder(visSummert, perioder.barnetilsyn)}
+
+            <h1>Skolepenger</h1>
+            {visPerioder(visSummert, perioder.skolepenger)}
+        </>
+    );
+};
+
+const Infotrygdperioderoversikt: React.FC<{
+    personIdent: string;
+}> = ({ personIdent }) => {
+    const infotrygdPerioderConfig: AxiosRequestConfig = useMemo(
+        () => ({
+            method: 'POST',
+            url: `/familie-ef-sak/api/infotrygd/perioder`,
+            data: {
+                personIdent,
+            },
+        }),
+        [personIdent]
+    );
+    const infotrygdPerioder = useDataHenter<InfotrygdPerioderResponse, null>(
+        infotrygdPerioderConfig
+    );
+    return (
+        <DataViewer response={{ infotrygdPerioder }}>
+            {({ infotrygdPerioder }) => {
+                return <InfotrygdEllerSummertePerioder perioder={infotrygdPerioder} />;
+            }}
+        </DataViewer>
+    );
+};
+
+export default Infotrygdperioderoversikt;

--- a/src/frontend/Komponenter/Personoversikt/Infotrygdperioderoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Infotrygdperioderoversikt.tsx
@@ -10,6 +10,16 @@ import {
 import { useDataHenter } from '../../App/hooks/felles/useDataHenter';
 import DataViewer from '../../Felles/DataViewer/DataViewer';
 import { Checkbox } from 'nav-frontend-skjema';
+import {
+    aktivitetstypeTilTekst,
+    InfotrygdPeriode,
+    InfotrygdPerioderResponse,
+    kodeTilTekst,
+    overgangsstønadKodeTilTekst,
+    Perioder,
+    sakstypeTilTekst,
+    SummertPeriode,
+} from '../../App/typer/infotrygd';
 
 const StyledTabell = styled.table`
     max-width: 80%;
@@ -17,90 +27,6 @@ const StyledTabell = styled.table`
 `;
 
 const Rad = styled.tr``;
-
-interface InfotrygdPerioderResponse {
-    overgangsstønad: Perioder;
-    barnetilsyn: Perioder;
-    skolepenger: Perioder;
-}
-
-interface Perioder {
-    perioder: InfotrygdPeriode[];
-    summert: SummertPeriode[];
-}
-
-interface SummertPeriode {
-    stønadFom: string;
-    stønadTom: string;
-    beløp: number;
-    inntektsreduksjon: number;
-    samordningsfradrag: number;
-}
-
-interface InfotrygdPeriode {
-    vedtakId: number;
-    vedtakstidspunkt: string;
-
-    stønadFom: string;
-    stønadTom: string;
-    opphørsdato?: string;
-
-    beløp: number;
-    inntektsgrunnlag: number;
-    samordningsfradrag: number;
-
-    kode: Kode;
-    sakstype: Sakstype;
-    brukerId: string;
-}
-
-enum Kode {
-    ANNULERT = 'ANNULERT',
-    ENDRING_BEREGNINGSGRUNNLAG = 'ENDRING_BEREGNINGSGRUNNLAG',
-    FØRSTEGANGSVEDTAK = 'FØRSTEGANGSVEDTAK',
-    G_REGULERING = 'G_REGULERING',
-    NY = 'NY',
-    OPPHØRT = 'OPPHØRT',
-    SATSENDRING = 'SATSENDRING',
-    UAKTUELL = 'UAKTUELL',
-    OVERTFØRT_NY_LØSNING = 'OVERTFØRT_NY_LØSNING',
-}
-
-const kodeTilTekst: Record<Kode, string> = {
-    ANNULERT: 'Annullert (AN)',
-    ENDRING_BEREGNINGSGRUNNLAG: 'Endring i beregningsgrunnlag (E)',
-    FØRSTEGANGSVEDTAK: 'Førstegangsvedtak (F)',
-    G_REGULERING: 'G-regulering (G)',
-    NY: 'Ny (NY)',
-    OPPHØRT: 'Opphørt (O)',
-    SATSENDRING: 'Satsendring (S)',
-    UAKTUELL: 'Uaktuell (UA)',
-    OVERTFØRT_NY_LØSNING: 'Overf ny løsning (OO)',
-};
-
-enum Sakstype {
-    KLAGE = 'KLAGE',
-    MASKINELL_G_OMREGNING = 'MASKINELL_G_OMREGNING',
-    REVURDERING = 'REVURDERING',
-    GRUNNBELØP_OMREGNING = 'GRUNNBELØP_OMREGNING',
-    KONVERTERING = 'KONVERTERING',
-    MASKINELL_SATSOMREGNING = 'MASKINELL_SATSOMREGNING',
-    ANKE = 'ANKE',
-    SØKNAD = 'SØKNAD',
-    SØKNAD_ØKNING_ENDRING = 'SØKNAD_ØKNING_ENDRING',
-}
-
-const sakstypeTilTekst: Record<Sakstype, string> = {
-    KLAGE: 'Klage (K)',
-    MASKINELL_G_OMREGNING: 'Maskinell G-omregning (MG)',
-    REVURDERING: 'Revurdering (R)',
-    GRUNNBELØP_OMREGNING: 'Grunnbeløp omregning (GO)',
-    KONVERTERING: 'Konvertering (KO)',
-    MASKINELL_SATSOMREGNING: 'Maskinell satsomregning (MS)',
-    ANKE: 'Anke (A)',
-    SØKNAD: 'Søknad (S)',
-    SØKNAD_ØKNING_ENDRING: 'Søknad om økning/endring (SØ)',
-};
 
 const SummertePerioder: React.FC<{ perioder: SummertPeriode[] }> = ({ perioder }) => {
     return (
@@ -145,6 +71,8 @@ const InfotrygdPerioder: React.FC<{ perioder: InfotrygdPeriode[] }> = ({ periode
                     <th>Vedtakstidspunkt</th>
                     <th>Kode</th>
                     <th>Sakstype</th>
+                    <th>Aktivitet</th>
+                    <th>Kode </th>
                     <th>Saksbehandler</th>
                 </tr>
             </thead>
@@ -164,6 +92,14 @@ const InfotrygdPerioder: React.FC<{ perioder: InfotrygdPeriode[] }> = ({ periode
                         <td>{formaterNullableIsoDato(periode.vedtakstidspunkt)}</td>
                         <td>{kodeTilTekst[periode.kode]}</td>
                         <td>{sakstypeTilTekst[periode.sakstype]}</td>
+                        <td>
+                            {periode.aktivitetstype &&
+                                aktivitetstypeTilTekst[periode.aktivitetstype]}
+                        </td>
+                        <td>
+                            {periode.kodeOvergangsstønad &&
+                                overgangsstønadKodeTilTekst[periode.kodeOvergangsstønad]}
+                        </td>
                         <td>{periode.brukerId}</td>
                     </Rad>
                 ))}

--- a/src/frontend/Komponenter/Personoversikt/Infotrygdperioderoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Infotrygdperioderoversikt.tsx
@@ -12,6 +12,7 @@ import DataViewer from '../../Felles/DataViewer/DataViewer';
 import { Checkbox } from 'nav-frontend-skjema';
 
 const StyledTabell = styled.table`
+    max-width: 80%;
     margin-top: 2rem;
 `;
 
@@ -37,21 +38,69 @@ interface SummertPeriode {
 }
 
 interface InfotrygdPeriode {
-    stønadId: number;
     vedtakId: number;
+    vedtakstidspunkt: string;
 
     stønadFom: string;
     stønadTom: string;
     opphørsdato?: string;
 
     beløp: number;
-    inntektsreduksjon: number;
+    inntektsgrunnlag: number;
     samordningsfradrag: number;
 
-    startDato: string;
-    kode: string;
+    kode: Kode;
+    sakstype: Sakstype;
     brukerId: string;
 }
+
+enum Kode {
+    ANNULERT = 'ANNULERT',
+    ENDRING_BEREGNINGSGRUNNLAG = 'ENDRING_BEREGNINGSGRUNNLAG',
+    FØRSTEGANGSVEDTAK = 'FØRSTEGANGSVEDTAK',
+    G_REGULERING = 'G_REGULERING',
+    NY = 'NY',
+    OPPHØRT = 'OPPHØRT',
+    SATSENDRING = 'SATSENDRING',
+    UAKTUELL = 'UAKTUELL',
+    OVERTFØRT_NY_LØSNING = 'OVERTFØRT_NY_LØSNING',
+}
+
+const kodeTilTekst: Record<Kode, string> = {
+    ANNULERT: 'Annullert (AN)',
+    ENDRING_BEREGNINGSGRUNNLAG: 'Endring i beregningsgrunnlag (E)',
+    FØRSTEGANGSVEDTAK: 'Førstegangsvedtak (F)',
+    G_REGULERING: 'G-regulering (G)',
+    NY: 'Ny (NY)',
+    OPPHØRT: 'Opphørt (O)',
+    SATSENDRING: 'Satsendring (S)',
+    UAKTUELL: 'Uaktuell (UA)',
+    OVERTFØRT_NY_LØSNING: 'Overf ny løsning (OO)',
+};
+
+enum Sakstype {
+    KLAGE = 'KLAGE',
+    MASKINELL_G_OMREGNING = 'MASKINELL_G_OMREGNING',
+    REVURDERING = 'REVURDERING',
+    GRUNNBELØP_OMREGNING = 'GRUNNBELØP_OMREGNING',
+    KONVERTERING = 'KONVERTERING',
+    MASKINELL_SATSOMREGNING = 'MASKINELL_SATSOMREGNING',
+    ANKE = 'ANKE',
+    SØKNAD = 'SØKNAD',
+    SØKNAD_ØKNING_ENDRING = 'SØKNAD_ØKNING_ENDRING',
+}
+
+const sakstypeTilTekst: Record<Sakstype, string> = {
+    KLAGE: 'Klage (K)',
+    MASKINELL_G_OMREGNING: 'Maskinell G-omregning (MG)',
+    REVURDERING: 'Revurdering (R)',
+    GRUNNBELØP_OMREGNING: 'Grunnbeløp omregning (GO)',
+    KONVERTERING: 'Konvertering (KO)',
+    MASKINELL_SATSOMREGNING: 'Maskinell satsomregning (MS)',
+    ANKE: 'Anke (A)',
+    SØKNAD: 'Søknad (S)',
+    SØKNAD_ØKNING_ENDRING: 'Søknad om økning/endring (SØ)',
+};
 
 const SummertePerioder: React.FC<{ perioder: SummertPeriode[] }> = ({ perioder }) => {
     return (
@@ -87,22 +136,21 @@ const InfotrygdPerioder: React.FC<{ perioder: InfotrygdPeriode[] }> = ({ periode
         <StyledTabell className="tabell">
             <thead>
                 <tr>
-                    <th>StønadId</th>
                     <th>VedtakId</th>
                     <th>Periode (fom-tom)</th>
                     <th>Opphørsdato</th>
-                    <th>Inntektsreduskjon</th>
+                    <th>Inntektsgrunnlag</th>
                     <th>Samordningsfradrag</th>
                     <th>Stønadsbeløp</th>
-                    <th>Startdato</th>
+                    <th>Vedtakstidspunkt</th>
                     <th>Kode</th>
+                    <th>Sakstype</th>
                     <th>Saksbehandler</th>
                 </tr>
             </thead>
             <tbody>
                 {perioder.map((periode) => (
                     <Rad>
-                        <td>{periode.stønadId}</td>
                         <td>{periode.vedtakId}</td>
                         <td>
                             {formaterNullableMånedÅr(periode.stønadFom)}
@@ -110,11 +158,12 @@ const InfotrygdPerioder: React.FC<{ perioder: InfotrygdPeriode[] }> = ({ periode
                             {formaterNullableMånedÅr(periode.stønadTom)}
                         </td>
                         <td>{formaterNullableMånedÅr(periode.opphørsdato)}</td>
-                        <td>{formaterTallMedTusenSkille(periode.inntektsreduksjon)}</td>
+                        <td>{formaterTallMedTusenSkille(periode.inntektsgrunnlag)}</td>
                         <td>{formaterTallMedTusenSkille(periode.samordningsfradrag)}</td>
                         <td>{formaterTallMedTusenSkille(periode.beløp)}</td>
-                        <td>{formaterNullableIsoDato(periode.startDato)}</td>
-                        <td>{periode.kode}</td>
+                        <td>{formaterNullableIsoDato(periode.vedtakstidspunkt)}</td>
+                        <td>{kodeTilTekst[periode.kode]}</td>
+                        <td>{sakstypeTilTekst[periode.sakstype]}</td>
                         <td>{periode.brukerId}</td>
                     </Rad>
                 ))}

--- a/src/frontend/Komponenter/Personoversikt/Infotrygdperioderoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Infotrygdperioderoversikt.tsx
@@ -22,7 +22,6 @@ import {
 } from '../../App/typer/infotrygd';
 
 const StyledTabell = styled.table`
-    max-width: 80%;
     margin-top: 2rem;
 `;
 
@@ -72,7 +71,7 @@ const InfotrygdPerioder: React.FC<{ perioder: InfotrygdPeriode[] }> = ({ periode
                     <th>Kode</th>
                     <th>Sakstype</th>
                     <th>Aktivitet</th>
-                    <th>Kode </th>
+                    <th>Periodetype</th>
                     <th>Saksbehandler</th>
                 </tr>
             </thead>

--- a/src/frontend/Komponenter/Personoversikt/Personoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Personoversikt.tsx
@@ -13,6 +13,7 @@ import Vedtaksperioderoversikt from './Vedtaksperioderoversikt';
 import FrittståendeBrevMedVisning from '../Behandling/Brev/FrittståendeBrevMedVisning';
 import Dokumenter from './Dokumenter';
 import { useSetValgtFagsakId } from '../../App/hooks/useSetValgtFagsakId';
+import Infotrygdperioderoversikt from './Infotrygdperioderoversikt';
 
 const PersonoversiktContent: React.FC<{
     fagsakId: string;
@@ -30,8 +31,9 @@ const PersonoversiktContent: React.FC<{
                         { label: 'Personopplysninger', aktiv: tabvalg === 0 },
                         { label: 'Behandlingsoversikt', aktiv: tabvalg === 1 },
                         { label: 'Vedtaksperioder', aktiv: tabvalg === 2 },
-                        { label: 'Dokumentoversikt', aktiv: tabvalg === 3 },
-                        { label: 'Brev', aktiv: tabvalg === 4 },
+                        { label: 'Infotrygdperioder', aktiv: tabvalg === 3 },
+                        { label: 'Dokumentoversikt', aktiv: tabvalg === 5 },
+                        { label: 'Brev', aktiv: tabvalg === 5 },
                     ]}
                     onChange={(_, tabNumber) => settTabvalg(tabNumber)}
                 />
@@ -43,8 +45,11 @@ const PersonoversiktContent: React.FC<{
                 )}
                 {tabvalg === 1 && <Behandlingsoversikt fagsakId={fagsakId} />}
                 {tabvalg === 2 && <Vedtaksperioderoversikt fagsakId={fagsakId} />}
-                {tabvalg === 3 && <Dokumenter personopplysninger={personopplysninger} />}
-                {tabvalg === 4 && <FrittståendeBrevMedVisning fagsakId={fagsakId} />}
+                {tabvalg === 3 && (
+                    <Infotrygdperioderoversikt personIdent={personopplysninger.personIdent} />
+                )}
+                {tabvalg === 4 && <Dokumenter personopplysninger={personopplysninger} />}
+                {tabvalg === 5 && <FrittståendeBrevMedVisning fagsakId={fagsakId} />}
             </Side>
         </>
     );

--- a/src/frontend/Komponenter/Personoversikt/Personoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Personoversikt.tsx
@@ -12,7 +12,6 @@ import { AxiosRequestConfig } from 'axios';
 import Vedtaksperioderoversikt from './Vedtaksperioderoversikt';
 import FrittståendeBrevMedVisning from '../Behandling/Brev/FrittståendeBrevMedVisning';
 import Dokumenter from './Dokumenter';
-import { useSetValgtFagsakId } from '../../App/hooks/useSetValgtFagsakId';
 import Infotrygdperioderoversikt from './Infotrygdperioderoversikt';
 
 const PersonoversiktContent: React.FC<{
@@ -20,7 +19,6 @@ const PersonoversiktContent: React.FC<{
     personopplysninger: IPersonopplysninger;
 }> = ({ fagsakId, personopplysninger }) => {
     const [tabvalg, settTabvalg] = useState<number>(1);
-    useSetValgtFagsakId(fagsakId);
 
     return (
         <>
@@ -32,7 +30,7 @@ const PersonoversiktContent: React.FC<{
                         { label: 'Behandlingsoversikt', aktiv: tabvalg === 1 },
                         { label: 'Vedtaksperioder', aktiv: tabvalg === 2 },
                         { label: 'Infotrygdperioder', aktiv: tabvalg === 3 },
-                        { label: 'Dokumentoversikt', aktiv: tabvalg === 5 },
+                        { label: 'Dokumentoversikt', aktiv: tabvalg === 4 },
                         { label: 'Brev', aktiv: tabvalg === 5 },
                     ]}
                     onChange={(_, tabNumber) => settTabvalg(tabNumber)}

--- a/src/frontend/Komponenter/Personoversikt/Personoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Personoversikt.tsx
@@ -29,7 +29,7 @@ const PersonoversiktContent: React.FC<{
                         { label: 'Personopplysninger', aktiv: tabvalg === 0 },
                         { label: 'Behandlingsoversikt', aktiv: tabvalg === 1 },
                         { label: 'Vedtaksperioder', aktiv: tabvalg === 2 },
-                        { label: 'Infotrygdperioder', aktiv: tabvalg === 3 },
+                        { label: 'Vedtaksperioder infotrygd', aktiv: tabvalg === 3 },
                         { label: 'Dokumentoversikt', aktiv: tabvalg === 4 },
                         { label: 'Brev', aktiv: tabvalg === 5 },
                     ]}

--- a/src/frontend/Komponenter/Personoversikt/Vedtaksperioderoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Vedtaksperioderoversikt.tsx
@@ -96,7 +96,7 @@ const historikkRad = (andel: AndelHistorikk) => {
             </td>
             <td>{aktivitetTilTekst[andel.aktivitet]}</td>
             <td>{formaterTallMedTusenSkille(andel.andel.inntekt)}</td>
-            <td>{andel.andel.samordningsfradrag}</td>
+            <td>{formaterTallMedTusenSkille(andel.andel.samordningsfradrag)}</td>
             <td>{formaterTallMedTusenSkille(andel.andel.beløp)}</td>
             <td>{formaterIsoDatoTid(andel.vedtakstidspunkt)}</td>
             <td>{andel.saksbehandler}</td>


### PR DESCRIPTION
"Koblet til" migrering https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-7649
Det er ønskelig å vise perioder fra infotrygd. Kanskje kan ses som ett utkast, og av den grunnen burde featuretoggles, men samtidig så skader den ikke å være der (har ikke noe å vise i prod, hvis det ikke er på personen som har blankett)

Viser 2 modus, en som viser alle vedtak med data, og ett modus som kun viser summert data, dvs siste tilstand, uten å vise alle 1000 vedtak som er gjort. Denne kommer sansynligvis endres på senere når vi vet hva vi ønsker her. Kanskje burde featuretoggles då likevel.. ? 

Avhengig av:
* https://github.com/navikt/familie-ef-sak/pull/1095

![image](https://user-images.githubusercontent.com/937168/149402060-e3fca240-6253-4a11-baa1-7955fe38ee98.png)

![image](https://user-images.githubusercontent.com/937168/149402037-3233b29b-4e23-41e1-a90b-28f395b17805.png)
