### PR TITLE
sanksjonsperioden som vises i tekst mskal genereres ut fra dagens dat…

### DIFF
--- a/src/frontend/Komponenter/Behandling/Sanksjon/Sanksjonsfastsettelse.tsx
+++ b/src/frontend/Komponenter/Behandling/Sanksjon/Sanksjonsfastsettelse.tsx
@@ -86,7 +86,13 @@ const Sanksjonsfastsettelse: FC<Props> = ({ behandlingId }) => {
     return (
         <DataViewer response={{ vedtak }}>
             {({ vedtak }) => {
-                return <SanksjonsvedtakVisning behandlingId={behandlingId} lagretVedtak={vedtak} />;
+                return (
+                    <SanksjonsvedtakVisning
+                        behandlingId={behandlingId}
+                        lagretVedtak={vedtak}
+                        key={'sanksjonsvedtakVisning'}
+                    />
+                );
             }}
         </DataViewer>
     );
@@ -185,9 +191,14 @@ const SanksjonsvedtakVisning: FC<{ behandlingId: string; lagretVedtak?: IVedtak 
                             sanksjonsårsakTilTekst[sanksjonårsak.value as Sanksjonsårsak]
                         }
                     >
-                        <option value="">Velg</option>
-                        {sanksjonsårsaker.map((sanksjonsårsak: Sanksjonsårsak, index: number) => (
-                            <option key={index} value={sanksjonsårsak}>
+                        <option value="" key={'velg'}>
+                            Velg
+                        </option>
+                        {sanksjonsårsaker.map((sanksjonsårsak: Sanksjonsårsak) => (
+                            <option
+                                key={sanksjonsårsakTilTekst[sanksjonsårsak]}
+                                value={sanksjonsårsak}
+                            >
                                 {sanksjonsårsakTilTekst[sanksjonsårsak]}
                             </option>
                         ))}
@@ -201,9 +212,16 @@ const SanksjonsvedtakVisning: FC<{ behandlingId: string; lagretVedtak?: IVedtak 
                         <Seksjon>
                             <Undertittel>Sanksjonsperiode</Undertittel>
                             <NormaltekstMedMargin>
-                                Måneden for sanksjon er <b>{nåværendeÅrOgMånedFormatert()}</b> som
-                                er måneden etter dette vedtaket. Bruker vil ikke få utbetalt stønad
-                                i denne perioden.
+                                Måneden for sanksjon er{' '}
+                                <b>
+                                    {nåværendeÅrOgMånedFormatert(
+                                        !behandlingErRedigerbar
+                                            ? lagretSanksjonertVedtak?.periode.årMånedFra
+                                            : ''
+                                    )}
+                                </b>{' '}
+                                som er måneden etter dette vedtaket. Bruker vil ikke få utbetalt
+                                stønad i denne perioden.
                             </NormaltekstMedMargin>
                         </Seksjon>
                         <Seksjon>
@@ -211,7 +229,7 @@ const SanksjonsvedtakVisning: FC<{ behandlingId: string; lagretVedtak?: IVedtak 
                                 {sanksjonInfoDel1}
                                 <ul>
                                     {stønaderForSanksjonInfo.map((stønad) => (
-                                        <li>{stønad}</li>
+                                        <li key={stønad}>{stønad}</li>
                                     ))}
                                 </ul>
                                 {sanksjonInfoDel2}

--- a/src/frontend/Komponenter/Behandling/Sanksjon/utils.ts
+++ b/src/frontend/Komponenter/Behandling/Sanksjon/utils.ts
@@ -23,11 +23,20 @@ export const nesteMånedOgNesteMånedsÅrFormatert = (): string => {
         : `${nesteMånedsÅr.toString()}-${nesteMåned.toString()}`;
 };
 
-export const nåværendeÅrOgMånedFormatert = (): string => {
+export const nåværendeÅrOgMånedFormatert = (årMåned?: string): string => {
+    return årMåned ? genererNåværendeÅrOgMånedFraStreng(årMåned) : genererNåværendeÅrOgMåned();
+};
+
+const genererNåværendeÅrOgMåned = (): string => {
     const [nesteMånedIndex, nesteMånedsÅr] = nesteMånedOgNesteMånedsÅr();
     const nesteMåned = måneder[nesteMånedIndex - 1];
-
     return `${nesteMåned} ${nesteMånedsÅr}`;
+};
+
+const genererNåværendeÅrOgMånedFraStreng = (årMåned: string) => {
+    const [år, månedIndex] = årMåned.split('-');
+    const måned = måneder[parseInt(månedIndex) - 1];
+    return `${måned.toString()} ${år}`;
 };
 
 const nesteMånedOgNesteMånedsÅr = () => {

--- a/src/frontend/Komponenter/Behandling/Sanksjon/utils.ts
+++ b/src/frontend/Komponenter/Behandling/Sanksjon/utils.ts
@@ -24,7 +24,7 @@ export const nesteMånedOgNesteMånedsÅrFormatert = (): string => {
 };
 
 export const nåværendeÅrOgMånedFormatert = (årMåned?: string): string => {
-    return årMåned ? genererNåværendeÅrOgMånedFraStreng(årMåned) : genererNåværendeÅrOgMåned();
+    return årMåned ? genererÅrOgMånedFraStreng(årMåned) : genererNåværendeÅrOgMåned();
 };
 
 const genererNåværendeÅrOgMåned = (): string => {
@@ -33,7 +33,7 @@ const genererNåværendeÅrOgMåned = (): string => {
     return `${nesteMåned} ${nesteMånedsÅr}`;
 };
 
-const genererNåværendeÅrOgMånedFraStreng = (årMåned: string) => {
+const genererÅrOgMånedFraStreng = (årMåned: string) => {
     const [år, månedIndex] = årMåned.split('-');
     const måned = måneder[parseInt(månedIndex) - 1];
     return `${måned.toString()} ${år}`;

--- a/src/frontend/Komponenter/Behandling/Simulering/Simulering.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/Simulering.tsx
@@ -11,7 +11,7 @@ import { useApp } from '../../../App/context/AppContext';
 
 export const Simulering: FC<{ behandlingId: string }> = ({ behandlingId }) => {
     const { axiosRequest } = useApp();
-    const { hentVedtak, vedtaksresultat } = useHentVedtak(behandlingId);
+    const { vedtak, hentVedtak, vedtaksresultat } = useHentVedtak(behandlingId);
     const [simuleringsresultat, settSimuleringsresultat] = useState<Ressurs<ISimulering>>(
         byggTomRessurs()
     );
@@ -32,11 +32,12 @@ export const Simulering: FC<{ behandlingId: string }> = ({ behandlingId }) => {
     }, [hentVedtak]);
 
     return (
-        <DataViewer response={{ simuleringsresultat }}>
-            {({ simuleringsresultat }) => (
+        <DataViewer response={{ simuleringsresultat, vedtak }}>
+            {({ simuleringsresultat, vedtak }) => (
                 <SimuleringTabellWrapper
                     simuleringsresultat={simuleringsresultat}
                     behandlingId={behandlingId}
+                    lagretVedtak={vedtak}
                 />
             )}
         </DataViewer>

--- a/src/frontend/Komponenter/Behandling/Simulering/SimuleringTabellWrapper.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/SimuleringTabellWrapper.tsx
@@ -6,9 +6,20 @@ import { gjelderÅr } from '../../../App/utils/dato';
 import styled from 'styled-components';
 import SimuleringOversikt from './SimuleringOversikt';
 import { Tilbakekreving } from './Tilbakekreving';
+import { EBehandlingResultat, ISanksjonereVedtak, IVedtak } from '../../../App/typer/vedtak';
+import { Normaltekst, Undertittel } from 'nav-frontend-typografi';
+import { nåværendeÅrOgMånedFormatert } from '../Sanksjon/utils';
 
 const SimuleringsContainer = styled.div`
     margin: 2rem;
+`;
+
+const Seksjon = styled.div`
+    margin-top: 2rem;
+`;
+
+const NormaltekstMedMargin = styled(Normaltekst)`
+    margin-top: 1rem;
 `;
 
 const mapSimuleringstabellRader = (
@@ -33,7 +44,8 @@ const mapSimuleringstabellRader = (
 const SimuleringTabellWrapper: React.FC<{
     simuleringsresultat: ISimulering;
     behandlingId: string;
-}> = ({ simuleringsresultat, behandlingId }) => {
+    lagretVedtak?: IVedtak;
+}> = ({ simuleringsresultat, behandlingId, lagretVedtak }) => {
     const muligeÅr = [...new Set(simuleringsresultat.perioder.map((p) => formaterIsoÅr(p.fom)))];
 
     const [år, settÅr] = useState(
@@ -41,6 +53,11 @@ const SimuleringTabellWrapper: React.FC<{
     );
 
     const simuleringTabellRader = mapSimuleringstabellRader(simuleringsresultat, år);
+
+    const lagretSanksjonertVedtak =
+        lagretVedtak?.resultatType === EBehandlingResultat.SANKSJONERE
+            ? (lagretVedtak as ISanksjonereVedtak)
+            : undefined;
 
     function harFeilutbetaling() {
         return simuleringsresultat.feilutbetaling > 0;
@@ -53,7 +70,24 @@ const SimuleringTabellWrapper: React.FC<{
                 perioder={simuleringTabellRader}
                 årsvelger={{ valgtÅr: år, settÅr: settÅr, muligeÅr: muligeÅr }}
             />
-            {harFeilutbetaling() && <Tilbakekreving behandlingId={behandlingId} />}
+            {harFeilutbetaling() && !lagretSanksjonertVedtak && (
+                <Tilbakekreving behandlingId={behandlingId} />
+            )}
+            {lagretSanksjonertVedtak && (
+                <Seksjon>
+                    <Undertittel>Sanksjonsperiode</Undertittel>
+                    <NormaltekstMedMargin>
+                        Måneden for sanksjon er{' '}
+                        <b>
+                            {nåværendeÅrOgMånedFormatert(
+                                lagretSanksjonertVedtak?.periode.årMånedFra
+                            )}
+                        </b>{' '}
+                        som er måneden etter dette vedtaket. Bruker vil ikke få utbetalt stønad i
+                        denne perioden.
+                    </NormaltekstMedMargin>
+                </Seksjon>
+            )}
         </SimuleringsContainer>
     );
 };


### PR DESCRIPTION
…o. Dersom behandling ikke lenger er redigerbar må teksten genereres basert på det lagrede vedtaket.

Informasjon om sanksjonsperioden vises og så på simuleringsfanen:
![Skjermbilde 2022-02-10 kl  16 21 47](https://user-images.githubusercontent.com/32769446/153438681-f0809a8a-0828-4c76-834d-a6547b346be8.png)

