### PR TITLE
Ny behandling for ferdigstilt journalpost

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -20,6 +20,7 @@ import { AppEnv, hentEnv } from './App/api/env';
 import { Toast } from './Felles/Toast/Toast';
 import FagsakTilFagsakPersonRedirect from './Komponenter/Redirect/FagsakTilFagsakPersonRedirect';
 import OppgaveMigreringApp from './Komponenter/Migrering/OppgaveMigrering';
+import { AdminApp } from './Komponenter/Admin/AdminApp';
 
 Modal.setAppElement(document.getElementById('modal-a11y-wrapper'));
 
@@ -96,6 +97,7 @@ const AppInnhold: React.FC<{ innloggetSaksbehandler: ISaksbehandler }> = ({
                 <Route path="/behandling/:behandlingId/*" element={<BehandlingContainer />} />
                 <Route path="/oppgavebenk" element={<OppgavebenkApp />} />
                 <Route path="/journalfor" element={<JournalforingApp />} />
+                <Route path="/admin/*" element={<AdminApp />} />
                 <Route path="/oppgavemigrering" element={<OppgaveMigreringApp />} />
                 <Route path="/fagsak/:fagsakId" element={<FagsakTilFagsakPersonRedirect />} />
                 <Route path="/person/:fagsakPersonId/*" element={<Personoversikt />} />

--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -11,4 +11,5 @@ export enum ToggleName {
     visValgmulighetForSanksjon = 'familie.ef.sak.frontend-vis-sanksjon-en-maned',
     kanLeggeTilNyeBarnPaaRevurdering = 'familie.ef.sak.kan-legge-til-nye-barn-paa-revurdering',
     oppgavebenkMigrerFagsak = 'familie.ef.sak.frontend-oppgavebenk-migrer-fagsak',
+    opprettBehandlingForFerdigstiltJournalpost = 'familie.ef.sak.opprett-behandling-for-ferdigstilt-journalpost',
 }

--- a/src/frontend/Felles/HeaderMedSøk/HeaderMedSøk.tsx
+++ b/src/frontend/Felles/HeaderMedSøk/HeaderMedSøk.tsx
@@ -10,6 +10,8 @@ import { lagAInntektLink } from '../Linker/AInntekt/AInntektLink';
 import { AxiosRequestCallback } from '../../App/typer/axiosRequest';
 import Endringslogg from '@navikt/familie-endringslogg';
 import { harTilgangTilRolle } from '../../App/utils/roller';
+import { useToggles } from '../../App/context/TogglesContext';
+import { ToggleName, Toggles } from '../../App/context/toggles';
 
 export interface IHeaderMedSøkProps {
     innloggetSaksbehandler: ISaksbehandler;
@@ -38,6 +40,7 @@ const lagEksterneLenker = (
     axiosRequest: AxiosRequestCallback,
     appEnv: AppEnv,
     innloggetSaksbehandler: ISaksbehandler,
+    toggles: Toggles,
     fagsakId?: string
 ): PopoverItem[] => {
     const eksterneLenker = [lagAInntekt(axiosRequest, appEnv, fagsakId)];
@@ -47,6 +50,12 @@ const lagEksterneLenker = (
             href: '/uttrekk/arbeidssoker',
         });
     }
+    if (toggles[ToggleName.opprettBehandlingForFerdigstiltJournalpost]) {
+        eksterneLenker.push({
+            name: '[Admin] Lag behandling fra journalpost',
+            href: '/admin/ny-behandling-for-ferdigstilt-journalpost/',
+        });
+    }
     return eksterneLenker;
 };
 
@@ -54,10 +63,11 @@ export const HeaderMedSøk: React.FunctionComponent<IHeaderMedSøkProps> = ({
     innloggetSaksbehandler,
 }) => {
     const { axiosRequest, gåTilUrl, appEnv, valgtFagsakId } = useApp();
-
+    const { toggles } = useToggles();
     const eksterneLenker = useMemo(
-        () => lagEksterneLenker(axiosRequest, appEnv, innloggetSaksbehandler, valgtFagsakId),
-        [axiosRequest, appEnv, innloggetSaksbehandler, valgtFagsakId]
+        () =>
+            lagEksterneLenker(axiosRequest, appEnv, innloggetSaksbehandler, toggles, valgtFagsakId),
+        [axiosRequest, appEnv, innloggetSaksbehandler, valgtFagsakId, toggles]
     );
 
     return (

--- a/src/frontend/Komponenter/Admin/AdminApp.tsx
+++ b/src/frontend/Komponenter/Admin/AdminApp.tsx
@@ -1,0 +1,15 @@
+import { Navigate, Route, Routes } from 'react-router-dom';
+import React from 'react';
+import { JournalforingAdmin } from '../Journalforing/JournalforingAdmin';
+
+export const AdminApp: React.FC = () => {
+    return (
+        <Routes>
+            <Route
+                path={`/ny-behandling-for-ferdigstilt-journalpost/:journalpostid`}
+                element={<JournalforingAdmin />}
+            />
+            <Route path="*" element={<Navigate to="/" replace={true} />} />
+        </Routes>
+    );
+};

--- a/src/frontend/Komponenter/Admin/AdminApp.tsx
+++ b/src/frontend/Komponenter/Admin/AdminApp.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Route, Routes } from 'react-router-dom';
 import React from 'react';
 import { JournalforingAdmin } from '../Journalforing/JournalforingAdmin';
+import { JournalforingAdminVelger } from '../Journalforing/JournalforingAdminVelger';
 
 export const AdminApp: React.FC = () => {
     return (
@@ -8,6 +9,10 @@ export const AdminApp: React.FC = () => {
             <Route
                 path={`/ny-behandling-for-ferdigstilt-journalpost/:journalpostid`}
                 element={<JournalforingAdmin />}
+            />
+            <Route
+                path={`/ny-behandling-for-ferdigstilt-journalpost`}
+                element={<JournalforingAdminVelger />}
             />
             <Route path="*" element={<Navigate to="/" replace={true} />} />
         </Routes>

--- a/src/frontend/Komponenter/Journalforing/Behandling.tsx
+++ b/src/frontend/Komponenter/Journalforing/Behandling.tsx
@@ -6,12 +6,13 @@ import { Flatknapp } from 'nav-frontend-knapper';
 import LeggtilMedSirkel from '../../Felles/Ikoner/LeggtilMedSirkel';
 import styled from 'styled-components';
 import { Behandlingstype } from '../../App/typer/behandlingstype';
-import { Behandling, BehandlingResultat, Fagsak } from '../../App/typer/fagsak';
+import { Behandling, Fagsak } from '../../App/typer/fagsak';
 import DataViewer from '../../Felles/DataViewer/DataViewer';
 import { BehandlingRequest } from '../../App/hooks/useJournalføringState';
 import { formaterIsoDatoTid } from '../../App/utils/formatter';
 import { Ressurs } from '../../App/typer/ressurs';
 import { Behandlingsårsak } from '../../App/typer/Behandlingsårsak';
+import { utledRiktigBehandlingstype } from './journalførBehandlingUtil';
 
 interface Props {
     settBehandling: (behandling?: BehandlingRequest) => void;
@@ -30,17 +31,6 @@ const StyledNyBehandlingRad = styled.tr`
 const BehandlingInnold: React.FC<Props> = ({ behandling, settBehandling, fagsak }) => {
     const [nyBehandling, settNyBehandling] = useState<INyBehandling>();
     const [harValgtNyBehandling, settHarValgtNyBehandling] = useState<boolean>(false);
-
-    const utledRiktigBehandlingstype = (tidligereBehandlinger: Behandling[]): Behandlingstype => {
-        const harIverksattTidligereBehandlinger =
-            tidligereBehandlinger.filter(
-                (tidligereBehandling) => tidligereBehandling.resultat !== BehandlingResultat.HENLAGT
-            ).length > 0;
-
-        return harIverksattTidligereBehandlinger
-            ? Behandlingstype.REVURDERING
-            : Behandlingstype.FØRSTEGANGSBEHANDLING;
-    };
 
     const håndterCheck = (behandlingsId: string) => {
         return (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/frontend/Komponenter/Journalforing/JournalforingAdmin.tsx
+++ b/src/frontend/Komponenter/Journalforing/JournalforingAdmin.tsx
@@ -115,6 +115,12 @@ export const JournalforingAdmin: React.FC = () => {
                 <SideLayout className={'container'}>
                     <Sidetittel>Opprett ny behandling for journalpost</Sidetittel>
                     <Blokk>
+                        <Normaltekst>
+                            Her kan du opprette en ny behandling med søknadsdata for en journalpost
+                            som er ferdigstilt
+                        </Normaltekst>
+                    </Blokk>
+                    <Blokk>
                         <Brukerinfo personIdent={journalResponse.personIdent} />
                     </Blokk>
                     <Blokk>
@@ -134,9 +140,9 @@ export const JournalforingAdmin: React.FC = () => {
                     </Blokk>
                     <Blokk>
                         <Systemtittel>Behandlingstype</Systemtittel>
-                        <Normaltekst>
-                            {nyBehandlingstype && behandlingstypeTilTekst[nyBehandlingstype]}
-                        </Normaltekst>
+                        {nyBehandlingstype && (
+                            <Normaltekst>${behandlingstypeTilTekst[nyBehandlingstype]}</Normaltekst>
+                        )}
                     </Blokk>
 
                     <Hovedknapp

--- a/src/frontend/Komponenter/Journalforing/JournalforingAdmin.tsx
+++ b/src/frontend/Komponenter/Journalforing/JournalforingAdmin.tsx
@@ -1,0 +1,153 @@
+import React, { useEffect, useState } from 'react';
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
+import { RessursFeilet, RessursStatus, RessursSuksess } from '../../App/typer/ressurs';
+import styled from 'styled-components';
+import Brukerinfo from './Brukerinfo';
+import { Normaltekst, Sidetittel, Systemtittel } from 'nav-frontend-typografi';
+import {
+    behandlingstemaTilStønadstype,
+    stønadstypeTilTekst,
+} from '../../App/typer/behandlingstema';
+import { Hovedknapp } from 'nav-frontend-knapper';
+import DataViewer from '../../Felles/DataViewer/DataViewer';
+import { AlertStripeFeil } from 'nav-frontend-alertstriper';
+import { useHentJournalpost } from '../../App/hooks/useHentJournalpost';
+import { useHentFagsak } from '../../App/hooks/useHentFagsak';
+import { useApp } from '../../App/context/AppContext';
+import { Behandlingstype, behandlingstypeTilTekst } from '../../App/typer/behandlingstype';
+import { utledRiktigBehandlingstype } from './journalførBehandlingUtil';
+import {
+    hentFraLocalStorage,
+    lagreTilLocalStorage,
+    oppgaveRequestKey,
+} from '../Oppgavebenk/oppgavefilterStorage';
+import { IJojurnalpostResponse, journalstatusTilTekst } from '../../App/typer/journalforing';
+import { formaterIsoDatoTid } from '../../App/utils/formatter';
+
+const Blokk = styled.div`
+    margin-bottom: 1rem;
+    margin-top: 1rem;
+`;
+const SideLayout = styled.div`
+    max-width: 50rem;
+    padding: 2rem;
+`;
+
+type IJournalpostParams = {
+    journalpostid: string;
+};
+
+export const JournalforingAdmin: React.FC = () => {
+    const { journalpostid } = useParams<IJournalpostParams>();
+    const { axiosRequest, innloggetSaksbehandler } = useApp();
+    const navigate = useNavigate();
+    const { hentJournalPost, journalResponse } = useHentJournalpost(journalpostid);
+    const { hentFagsak, fagsak } = useHentFagsak();
+    const [nyBehandlingstype, settNyBehandlingstype] = useState<Behandlingstype | undefined>();
+    const [senderInn, settSenderInn] = useState<boolean>(false);
+    const [feilmelding, settFeilmelding] = useState<string>('');
+
+    useEffect(() => {
+        if (fagsak.status === RessursStatus.SUKSESS) {
+            settNyBehandlingstype(utledRiktigBehandlingstype(fagsak.data.behandlinger));
+        }
+    }, [fagsak]);
+
+    useEffect(() => {
+        if (journalResponse.status === RessursStatus.SUKSESS) {
+            const stønadstype = behandlingstemaTilStønadstype(
+                journalResponse.data.journalpost.behandlingstema
+            );
+            stønadstype && hentFagsak(journalResponse.data.personIdent, stønadstype);
+        }
+        // eslint-disable-next-line
+    }, [journalResponse]);
+
+    useEffect(() => {
+        document.title = 'Journalpost';
+        hentJournalPost();
+    }, [hentJournalPost]);
+
+    if (!journalpostid) {
+        return <Navigate to="/oppgavebenk" />;
+    }
+
+    const gåTilOppgavebenkMedPersonSøk = (personIdent: string) => {
+        const lagredeOppgaveFiltreringer = hentFraLocalStorage(
+            oppgaveRequestKey(innloggetSaksbehandler.navIdent),
+            {}
+        );
+
+        lagreTilLocalStorage(oppgaveRequestKey(innloggetSaksbehandler.navIdent), {
+            ...lagredeOppgaveFiltreringer,
+            ident: personIdent,
+        });
+        navigate('/oppgavebenk');
+    };
+
+    const sendInn = (journalpostResponse: IJojurnalpostResponse, fagsakId: string) => {
+        settFeilmelding('');
+        if (!nyBehandlingstype) {
+            settFeilmelding('Har ikke fått satt riktig behandlingstype');
+        } else if (!senderInn) {
+            settSenderInn(true);
+            axiosRequest<string, { fagsakId: string; behandlingstype: Behandlingstype }>({
+                method: 'POST',
+                url: `/familie-ef-sak/api/journalpost/${journalpostResponse.journalpost.journalpostId}/opprett-behandling-med-soknadsdata-fra-en-ferdigstilt-journalpost`,
+                data: { fagsakId: fagsakId, behandlingstype: nyBehandlingstype },
+            })
+                .then((res: RessursSuksess<string> | RessursFeilet) => {
+                    if (res.status === RessursStatus.SUKSESS) {
+                        gåTilOppgavebenkMedPersonSøk(journalpostResponse.personIdent);
+                    } else {
+                        settFeilmelding(res.frontendFeilmelding);
+                    }
+                })
+                .finally(() => {
+                    settSenderInn(false);
+                });
+        }
+    };
+
+    return (
+        <DataViewer response={{ journalResponse, fagsak }}>
+            {({ journalResponse, fagsak }) => (
+                <SideLayout className={'container'}>
+                    <Sidetittel>Opprett ny behandling for journalpost</Sidetittel>
+                    <Blokk>
+                        <Brukerinfo personIdent={journalResponse.personIdent} />
+                    </Blokk>
+                    <Blokk>
+                        <Systemtittel>Journalpost</Systemtittel>
+                        <Normaltekst>{stønadstypeTilTekst[fagsak.stønadstype]}</Normaltekst>
+                        <Normaltekst>
+                            JournalpostID: {journalResponse.journalpost.journalpostId}
+                        </Normaltekst>
+                        <Normaltekst>
+                            Status:{' '}
+                            {journalstatusTilTekst[journalResponse.journalpost.journalstatus]}
+                        </Normaltekst>
+                        <Normaltekst>
+                            Dato mottatt:{' '}
+                            {formaterIsoDatoTid(journalResponse.journalpost.datoMottatt)}
+                        </Normaltekst>
+                    </Blokk>
+                    <Blokk>
+                        <Systemtittel>Behandlingstype</Systemtittel>
+                        <Normaltekst>
+                            {nyBehandlingstype && behandlingstypeTilTekst[nyBehandlingstype]}
+                        </Normaltekst>
+                    </Blokk>
+
+                    <Hovedknapp
+                        onClick={() => sendInn(journalResponse, fagsak.id)}
+                        spinner={senderInn}
+                    >
+                        Opprett behandling
+                    </Hovedknapp>
+                    {feilmelding && <AlertStripeFeil>{feilmelding}</AlertStripeFeil>}
+                </SideLayout>
+            )}
+        </DataViewer>
+    );
+};

--- a/src/frontend/Komponenter/Journalforing/JournalforingAdmin.tsx
+++ b/src/frontend/Komponenter/Journalforing/JournalforingAdmin.tsx
@@ -141,7 +141,7 @@ export const JournalforingAdmin: React.FC = () => {
                     <Blokk>
                         <Systemtittel>Behandlingstype</Systemtittel>
                         {nyBehandlingstype && (
-                            <Normaltekst>${behandlingstypeTilTekst[nyBehandlingstype]}</Normaltekst>
+                            <Normaltekst>{behandlingstypeTilTekst[nyBehandlingstype]}</Normaltekst>
                         )}
                     </Blokk>
 

--- a/src/frontend/Komponenter/Journalforing/JournalforingAdminVelger.tsx
+++ b/src/frontend/Komponenter/Journalforing/JournalforingAdminVelger.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { Sidetittel } from 'nav-frontend-typografi';
+import { Hovedknapp } from 'nav-frontend-knapper';
+import { FamilieInput } from '@navikt/familie-form-elements';
+import { useNavigate } from 'react-router-dom';
+
+const SideLayout = styled.div`
+    max-width: 50rem;
+    padding: 2rem;
+`;
+
+const Blokk = styled.div`
+    margin-bottom: 1rem;
+    margin-top: 1rem;
+    max-width: 10rem;
+`;
+
+export const JournalforingAdminVelger: React.FC = () => {
+    const [journalpostId, settJournalpostId] = useState<string>('');
+    const navigate = useNavigate();
+    const gåVidere = () => {
+        if (journalpostId) {
+            navigate(`/admin/ny-behandling-for-ferdigstilt-journalpost/${journalpostId}`);
+        }
+    };
+
+    return (
+        <SideLayout className={'container'}>
+            <Sidetittel>Opprett ny behandling for journalpost</Sidetittel>
+            <Blokk>
+                <FamilieInput
+                    label={'Skriv inn journalpostID'}
+                    value={journalpostId}
+                    onChange={(e) => {
+                        settJournalpostId(e.target.value);
+                    }}
+                />
+            </Blokk>
+            <Hovedknapp onClick={() => gåVidere()}>Velg journalpost</Hovedknapp>
+        </SideLayout>
+    );
+};

--- a/src/frontend/Komponenter/Journalforing/journalførBehandlingUtil.ts
+++ b/src/frontend/Komponenter/Journalforing/journalførBehandlingUtil.ts
@@ -1,0 +1,16 @@
+import { Behandling, BehandlingResultat } from '../../App/typer/fagsak';
+import { Behandlingstype } from '../../App/typer/behandlingstype';
+
+export const utledRiktigBehandlingstype = (
+    tidligereBehandlinger: Behandling[]
+): Behandlingstype => {
+    const harIverksattTidligereBehandlinger = tidligereBehandlinger.some(
+        (tidligereBehandling) =>
+            tidligereBehandling.resultat !== BehandlingResultat.HENLAGT &&
+            tidligereBehandling.type !== Behandlingstype.BLANKETT
+    );
+
+    return harIverksattTidligereBehandlinger
+        ? Behandlingstype.REVURDERING
+        : Behandlingstype.FØRSTEGANGSBEHANDLING;
+};


### PR DESCRIPTION
Legger inn en adminfunksjon for å kunne opprette en behandling med søknadsdata basert på en journalpost som allerede er ferdigstilt og ikke kan journalføres på "normal" måte.
<img width="721" alt="Skjermbilde 2022-02-10 kl  16 47 29" src="https://user-images.githubusercontent.com/402915/153443796-0f4a030c-ca3f-4575-b37d-b136e8d71270.png">
<img width="708" alt="Skjermbilde 2022-02-10 kl  16 47 33" src="https://user-images.githubusercontent.com/402915/153443792-a708cde1-d8f9-42a6-b2ae-926664e11bfe.png">
