### PR TITLE
Skal kun vise migreringsknappen for de som er opprettet av oss. Hvis …

### DIFF
--- a/src/frontend/Komponenter/Oppgavebenk/OppgaveRad.tsx
+++ b/src/frontend/Komponenter/Oppgavebenk/OppgaveRad.tsx
@@ -69,7 +69,9 @@ const kanMigreres = (oppgave: IOppgave) => {
     return (
         oppgave.behandlesAvApplikasjon === '' &&
         oppgave.oppgavetype === 'JFR' &&
-        oppgave.behandlingstema === 'ab0071'
+        oppgave.behandlingstema === 'ab0071' &&
+        oppgave.opprettetAv &&
+        oppgave.opprettetAv.indexOf('familie-integrasjoner') > -1
     );
 };
 


### PR DESCRIPTION
…de er opprettet av andre er det ikke sikkert de har noe hos i infotrygd

Glømte denne i forrige PR
* https://github.com/navikt/familie-ef-sak-frontend/pull/880