### PR TITLE
Fritekstbrev flytte avsnitt

### DIFF
--- a/src/frontend/Felles/Knapper/NedKnapp.tsx
+++ b/src/frontend/Felles/Knapper/NedKnapp.tsx
@@ -1,0 +1,20 @@
+import { DownFilled } from '@navikt/ds-icons';
+import React from 'react';
+import styled from 'styled-components';
+import { Flatknapp } from 'nav-frontend-knapper';
+import hiddenIf from '../HiddenIf/hiddenIf';
+
+const KnappMedLuftUnder = styled(Flatknapp)`
+    padding: 0;
+    margin-bottom: 1rem;
+`;
+
+const NedKnapp: React.FC<{ onClick: () => void }> = ({ onClick }) => {
+    return (
+        <KnappMedLuftUnder onClick={onClick} htmlType="button">
+            <DownFilled style={{ marginLeft: '1rem', marginRight: '1rem' }} />
+        </KnappMedLuftUnder>
+    );
+};
+
+export default hiddenIf(NedKnapp);

--- a/src/frontend/Felles/Knapper/OppKnapp.tsx
+++ b/src/frontend/Felles/Knapper/OppKnapp.tsx
@@ -1,0 +1,20 @@
+import { UpFilled } from '@navikt/ds-icons';
+import React from 'react';
+import styled from 'styled-components';
+import { Flatknapp } from 'nav-frontend-knapper';
+import hiddenIf from '../HiddenIf/hiddenIf';
+
+const KnappMedLuftUnder = styled(Flatknapp)`
+    padding: 0;
+    margin-bottom: 1rem;
+`;
+
+const OppKnapp: React.FC<{ onClick: () => void }> = ({ onClick }) => {
+    return (
+        <KnappMedLuftUnder onClick={onClick} htmlType="button">
+            <UpFilled style={{ marginLeft: '1rem', marginRight: '1rem' }} />
+        </KnappMedLuftUnder>
+    );
+};
+
+export default hiddenIf(OppKnapp);

--- a/src/frontend/Komponenter/Behandling/Brev/BrevInnhold.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevInnhold.tsx
@@ -17,13 +17,15 @@ import {
 import { skjulAvsnittIBrevbygger } from './BrevUtils';
 import { useToggles } from '../../../App/context/TogglesContext';
 import { ToggleName } from '../../../App/context/toggles';
+import OppKnapp from '../../../Felles/Knapper/OppKnapp';
+import NedKnapp from '../../../Felles/Knapper/NedKnapp';
 
 const StyledSelect = styled(Select)`
     margin-top: 1rem;
 `;
 
 const Innholdsrad = styled(Panel)`
-    width: 70%;
+    width: 95%;
     margin-top: 1rem;
     display: flex;
     flex-direction: column;
@@ -52,6 +54,9 @@ const BrevKolonner = styled.div`
 const FlyttAvsnittKnappWrapper = styled.div`
     display: flex;
     flex-direction: column;
+    justify-content: space-evenly;
+    margin-left: 0.5rem;
+    margin-top: 1rem;
 `;
 
 type Props = {
@@ -94,6 +99,7 @@ const BrevInnhold: React.FC<Props> = ({
     const brevSkalKunneRedigeres = !ikkeRedigerBareBrev.includes(brevType);
     const { toggles } = useToggles();
     const skalViseValgmulighetForSanksjon = toggles[ToggleName.visValgmulighetForSanksjon];
+    const avsnittSomSkalVises = avsnitt.filter((avsnitt) => !avsnitt.skalSkjulesIBrevbygger);
 
     return (
         <BrevKolonner>
@@ -148,59 +154,52 @@ const BrevInnhold: React.FC<Props> = ({
                             />
                         </LeggTilKnappWrapper>
                     )}
-                    {avsnitt
-                        .filter((avsnitt) => !avsnitt.skalSkjulesIBrevbygger)
-                        .map((rad, index) => {
-                            const deloverskriftId = `deloverskrift-${rad.id}`;
-                            const innholdId = `innhold-${rad.id}`;
-                            const toKolonneId = `toKolonne-${rad.id}`;
-                            const knappWrapperId = `knappWrapper-${rad.id}`;
+                    {avsnittSomSkalVises.map((rad, index) => {
+                        const deloverskriftId = `deloverskrift-${rad.id}`;
+                        const innholdId = `innhold-${rad.id}`;
+                        const toKolonneId = `toKolonne-${rad.id}`;
+                        const knappWrapperId = `knappWrapper-${rad.id}`;
 
-                            return (
-                                <ToKolonneLayout id={toKolonneId}>
-                                    <Innholdsrad key={rad.id} border>
-                                        <Input
-                                            onChange={endreDeloverskriftAvsnitt(rad.id)}
-                                            label="Deloverskrift (valgfri)"
-                                            id={deloverskriftId}
-                                            value={rad.deloverskrift}
+                        return (
+                            <ToKolonneLayout id={toKolonneId}>
+                                <Innholdsrad key={rad.id} border>
+                                    <Input
+                                        onChange={endreDeloverskriftAvsnitt(rad.id)}
+                                        label="Deloverskrift (valgfri)"
+                                        id={deloverskriftId}
+                                        value={rad.deloverskrift}
+                                    />
+                                    <Textarea
+                                        onChange={endreInnholdAvsnitt(rad.id)}
+                                        label="Innhold"
+                                        id={innholdId}
+                                        value={rad.innhold}
+                                        maxLength={0}
+                                    />
+                                    <LenkeKnapp onClick={() => fjernRad(rad.id)}>
+                                        <SlettSøppelkasse withDefaultStroke={false} />
+                                        Slett avsnitt
+                                    </LenkeKnapp>
+                                </Innholdsrad>
+                                <FlyttAvsnittKnappWrapper id={knappWrapperId}>
+                                    {index > 0 && (
+                                        <OppKnapp
+                                            onClick={() => {
+                                                flyttAvsnittOpp(rad.id);
+                                            }}
                                         />
-                                        <Textarea
-                                            onChange={endreInnholdAvsnitt(rad.id)}
-                                            label="Innhold"
-                                            id={innholdId}
-                                            value={rad.innhold}
-                                            maxLength={0}
+                                    )}
+                                    {index + 1 < avsnittSomSkalVises.length && (
+                                        <NedKnapp
+                                            onClick={() => {
+                                                flyttAvsnittNed(rad.id);
+                                            }}
                                         />
-                                        <LenkeKnapp onClick={() => fjernRad(rad.id)}>
-                                            <SlettSøppelkasse withDefaultStroke={false} />
-                                            Slett avsnitt
-                                        </LenkeKnapp>
-                                    </Innholdsrad>
-                                    <FlyttAvsnittKnappWrapper id={knappWrapperId}>
-                                        {index !== 0 && (
-                                            <LeggTilKnapp
-                                                onClick={() => {
-                                                    flyttAvsnittOpp(rad.id);
-                                                }}
-                                                knappetekst="Flytt avsnitt opp"
-                                            />
-                                        )}
-                                        {index + 1 !==
-                                            avsnitt.filter(
-                                                (avsnitt) => !avsnitt.skalSkjulesIBrevbygger
-                                            ).length && (
-                                            <LeggTilKnapp
-                                                onClick={() => {
-                                                    flyttAvsnittNed(rad.id);
-                                                }}
-                                                knappetekst="Flytt avsnitt ned"
-                                            />
-                                        )}
-                                    </FlyttAvsnittKnappWrapper>
-                                </ToKolonneLayout>
-                            );
-                        })}
+                                    )}
+                                </FlyttAvsnittKnappWrapper>
+                            </ToKolonneLayout>
+                        );
+                    })}
                     {brevSkalKunneRedigeres && (
                         <LeggTilKnappWrapper>
                             <LeggTilKnapp

--- a/src/frontend/Komponenter/Behandling/Brev/BrevInnhold.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevInnhold.tsx
@@ -23,10 +23,15 @@ const StyledSelect = styled(Select)`
 `;
 
 const Innholdsrad = styled(Panel)`
+    width: 70%;
     margin-top: 1rem;
     display: flex;
     flex-direction: column;
     gap: 10px;
+`;
+
+const ToKolonneLayout = styled.div`
+    display: flex;
 `;
 
 const Overskrift = styled(Input)`
@@ -44,6 +49,11 @@ const BrevKolonner = styled.div`
     flex-direction: column;
 `;
 
+const FlyttAvsnittKnappWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+`;
+
 type Props = {
     brevType: FrittståendeBrevtype | FritekstBrevtype | undefined;
     endreBrevType: (nyBrevType: FrittståendeBrevtype | FritekstBrevtype) => void;
@@ -54,8 +64,10 @@ type Props = {
     endreDeloverskriftAvsnitt: (radId: string) => ChangeEventHandler<HTMLInputElement>;
     endreInnholdAvsnitt: (radId: string) => ChangeEventHandler<HTMLTextAreaElement>;
     fjernRad: (radId: string) => void;
-    leggTilAvsnittForan: () => void;
+    leggTilAvsnittFørst: () => void;
     leggAvsnittBakSisteSynligeAvsnitt: () => void;
+    flyttAvsnittOpp: (avsnittId: string) => void;
+    flyttAvsnittNed: (avsnittId: string) => void;
     context: FritekstBrevContext;
 };
 
@@ -69,8 +81,10 @@ const BrevInnhold: React.FC<Props> = ({
     endreDeloverskriftAvsnitt,
     endreInnholdAvsnitt,
     fjernRad,
-    leggTilAvsnittForan,
+    leggTilAvsnittFørst,
     leggAvsnittBakSisteSynligeAvsnitt,
+    flyttAvsnittOpp,
+    flyttAvsnittNed,
     context,
 }) => {
     const ikkeRedigerBareBrev: (FrittståendeBrevtype | FritekstBrevtype | undefined)[] = [
@@ -129,37 +143,62 @@ const BrevInnhold: React.FC<Props> = ({
                     {finnesSynligeAvsnitt && brevSkalKunneRedigeres && (
                         <LeggTilKnappWrapper>
                             <LeggTilKnapp
-                                onClick={leggTilAvsnittForan}
+                                onClick={leggTilAvsnittFørst}
                                 knappetekst="Legg til avsnitt"
                             />
                         </LeggTilKnappWrapper>
                     )}
                     {avsnitt
                         .filter((avsnitt) => !avsnitt.skalSkjulesIBrevbygger)
-                        .map((rad) => {
+                        .map((rad, index) => {
                             const deloverskriftId = `deloverskrift-${rad.id}`;
                             const innholdId = `innhold-${rad.id}`;
+                            const toKolonneId = `toKolonne-${rad.id}`;
+                            const knappWrapperId = `knappWrapper-${rad.id}`;
 
                             return (
-                                <Innholdsrad key={rad.id} border>
-                                    <Input
-                                        onChange={endreDeloverskriftAvsnitt(rad.id)}
-                                        label="Deloverskrift (valgfri)"
-                                        id={deloverskriftId}
-                                        value={rad.deloverskrift}
-                                    />
-                                    <Textarea
-                                        onChange={endreInnholdAvsnitt(rad.id)}
-                                        label="Innhold"
-                                        id={innholdId}
-                                        value={rad.innhold}
-                                        maxLength={0}
-                                    />
-                                    <LenkeKnapp onClick={() => fjernRad(rad.id)}>
-                                        <SlettSøppelkasse withDefaultStroke={false} />
-                                        Slett avsnitt
-                                    </LenkeKnapp>
-                                </Innholdsrad>
+                                <ToKolonneLayout id={toKolonneId}>
+                                    <Innholdsrad key={rad.id} border>
+                                        <Input
+                                            onChange={endreDeloverskriftAvsnitt(rad.id)}
+                                            label="Deloverskrift (valgfri)"
+                                            id={deloverskriftId}
+                                            value={rad.deloverskrift}
+                                        />
+                                        <Textarea
+                                            onChange={endreInnholdAvsnitt(rad.id)}
+                                            label="Innhold"
+                                            id={innholdId}
+                                            value={rad.innhold}
+                                            maxLength={0}
+                                        />
+                                        <LenkeKnapp onClick={() => fjernRad(rad.id)}>
+                                            <SlettSøppelkasse withDefaultStroke={false} />
+                                            Slett avsnitt
+                                        </LenkeKnapp>
+                                    </Innholdsrad>
+                                    <FlyttAvsnittKnappWrapper id={knappWrapperId}>
+                                        {index !== 0 && (
+                                            <LeggTilKnapp
+                                                onClick={() => {
+                                                    flyttAvsnittOpp(rad.id);
+                                                }}
+                                                knappetekst="Flytt avsnitt opp"
+                                            />
+                                        )}
+                                        {index + 1 !==
+                                            avsnitt.filter(
+                                                (avsnitt) => !avsnitt.skalSkjulesIBrevbygger
+                                            ).length && (
+                                            <LeggTilKnapp
+                                                onClick={() => {
+                                                    flyttAvsnittNed(rad.id);
+                                                }}
+                                                knappetekst="Flytt avsnitt ned"
+                                            />
+                                        )}
+                                    </FlyttAvsnittKnappWrapper>
+                                </ToKolonneLayout>
                             );
                         })}
                     {brevSkalKunneRedigeres && (

--- a/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
@@ -126,6 +126,41 @@ export const leggAvsnittBakSisteSynligeAvsnitt = (
     ];
 };
 
-export const leggTilAvsnittForran = (eksisterendeAvsnitt: AvsnittMedId[]): AvsnittMedId[] => {
+export const leggTilAvsnittFørst = (eksisterendeAvsnitt: AvsnittMedId[]): AvsnittMedId[] => {
     return [lagTomtAvsnitt(), ...eksisterendeAvsnitt];
+};
+
+export const flyttAvsnittOppover = (
+    avsnittId: string,
+    eksisterendeAvsnitt: AvsnittMedId[]
+): AvsnittMedId[] => {
+    const avsnittSomSkalFlyttesIndeks = eksisterendeAvsnitt.findIndex(
+        (avsnitt) => avsnitt.id === avsnittId
+    );
+    const avsnittFørIndeks = avsnittSomSkalFlyttesIndeks - 1;
+    const avsnittEtterIndeks = avsnittSomSkalFlyttesIndeks + 1;
+
+    return [
+        ...eksisterendeAvsnitt.slice(0, avsnittFørIndeks),
+        eksisterendeAvsnitt[avsnittSomSkalFlyttesIndeks],
+        eksisterendeAvsnitt[avsnittFørIndeks],
+        ...eksisterendeAvsnitt.slice(avsnittEtterIndeks),
+    ];
+};
+
+export const flyttAvsnittNedover = (
+    avsnittId: string,
+    eksisterendeAvsnitt: AvsnittMedId[]
+): AvsnittMedId[] => {
+    const avsnittSomSkalFlyttesIndeks = eksisterendeAvsnitt.findIndex(
+        (avsnitt) => avsnitt.id === avsnittId
+    );
+    const avsnittEtterIndeks = avsnittSomSkalFlyttesIndeks + 1;
+
+    return [
+        ...eksisterendeAvsnitt.slice(0, avsnittSomSkalFlyttesIndeks),
+        eksisterendeAvsnitt[avsnittEtterIndeks],
+        eksisterendeAvsnitt[avsnittSomSkalFlyttesIndeks],
+        ...eksisterendeAvsnitt.slice(avsnittEtterIndeks + 1),
+    ];
 };

--- a/src/frontend/Komponenter/Behandling/Brev/FritekstBrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/FritekstBrev.tsx
@@ -15,9 +15,11 @@ import {
     IMellomlagretBrevFritekst,
 } from './BrevTyper';
 import {
+    flyttAvsnittNedover,
+    flyttAvsnittOppover,
     initielleAvsnittMellomlager,
     leggAvsnittBakSisteSynligeAvsnitt,
-    leggTilAvsnittForran,
+    leggTilAvsnittFørst,
 } from './BrevUtils';
 import BrevInnhold from './BrevInnhold';
 
@@ -69,8 +71,16 @@ const FritekstBrev: React.FC<Props> = ({
         settAvsnitt(nyttAvsnitt);
     };
 
-    const oppdaterLeggTilAvsnittForan = () => {
-        settAvsnitt(leggTilAvsnittForran(avsnitt));
+    const oppdaterFlyttAvsnittOppover = (avsnittId: string) => {
+        settAvsnitt(flyttAvsnittOppover(avsnittId, avsnitt));
+    };
+
+    const oppdaterFlyttAvsnittNedover = (avsnittId: string) => {
+        settAvsnitt(flyttAvsnittNedover(avsnittId, avsnitt));
+    };
+
+    const oppdaterLeggTilAvsnittFørst = () => {
+        settAvsnitt(leggTilAvsnittFørst(avsnitt));
     };
 
     const oppdaterLeggAvsnittBakSisteSynligeAvsnitt = () => {
@@ -147,8 +157,10 @@ const FritekstBrev: React.FC<Props> = ({
                 endreDeloverskriftAvsnitt={endreDeloverskriftAvsnitt}
                 endreInnholdAvsnitt={endreInnholdAvsnitt}
                 fjernRad={fjernRad}
-                leggTilAvsnittForan={oppdaterLeggTilAvsnittForan}
+                leggTilAvsnittFørst={oppdaterLeggTilAvsnittFørst}
                 leggAvsnittBakSisteSynligeAvsnitt={oppdaterLeggAvsnittBakSisteSynligeAvsnitt}
+                flyttAvsnittOpp={oppdaterFlyttAvsnittOppover}
+                flyttAvsnittNed={oppdaterFlyttAvsnittNedover}
                 context={FritekstBrevContext.BEHANDLING}
             />
         </StyledBrev>

--- a/src/frontend/Komponenter/Behandling/Brev/FrittståendeBrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/FrittståendeBrev.tsx
@@ -19,7 +19,7 @@ import {
 import {
     initielleAvsnittMellomlager,
     leggAvsnittBakSisteSynligeAvsnitt,
-    leggTilAvsnittForran,
+    leggTilAvsnittFørst,
 } from './BrevUtils';
 import BrevInnhold from './BrevInnhold';
 
@@ -78,7 +78,7 @@ const FrittståendeBrev: React.FC<Props> = ({
     };
 
     const oppdaterLeggTilAvsnittForan = () => {
-        settAvsnitt(leggTilAvsnittForran(avsnitt));
+        settAvsnitt(leggTilAvsnittFørst(avsnitt));
     };
 
     const oppdaterLeggAvsnittBakSisteSynligeAvsnitt = () => {


### PR DESCRIPTION
Denne PRen løser [følgende oppgave](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8007).

Man kan nå flytte avsnitt opp og ned i fritekstbrevet.
Slik ser det ut:
![Skjermbilde 2022-02-16 kl  16 29 28](https://user-images.githubusercontent.com/32769446/154298062-cc92fe04-c770-43aa-b703-4742ffc4eb18.png)

Tenker Lars får kommentere på designet også kan det utbedres senere dersom det skulle være ønskelig
