### PR TITLE
Vedtak og beregningsiden samt brev skal kun vise beløpsperioder som e…

### DIFF
--- a/src/frontend/App/typer/vedtak.ts
+++ b/src/frontend/App/typer/vedtak.ts
@@ -17,6 +17,7 @@ export interface IBeløpsperiode {
 export interface IBeregningsgrunnlag {
     inntekt: number;
     samordningsfradrag: number;
+    samordningsfradragType: ESamordningsfradragtype | null;
     avkortningPerMåned: number;
     fullOvergangsStønadPerMåned: number | null;
     grunnbeløp: number | null;

--- a/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
@@ -25,6 +25,7 @@ import {
 import FritekstBrev from './FritekstBrev';
 import { useToggles } from '../../../App/context/TogglesContext';
 import { ToggleName } from '../../../App/context/toggles';
+import { IBeløpsperiode } from '../../../App/typer/vedtak';
 
 export interface BrevmenyProps {
     oppdaterBrevRessurs: (brevRessurs: Ressurs<string>) => void;
@@ -51,6 +52,9 @@ const Brevmeny: React.FC<BrevmenyProps> = (props) => {
         byggTomRessurs()
     );
     const [tilkjentYtelse, settTilkjentYtelse] = useState<Ressurs<TilkjentYtelse | undefined>>(
+        byggTomRessurs()
+    );
+    const [beløpsperiode, settBeløpsperiode] = useState<Ressurs<IBeløpsperiode[] | undefined>>(
         byggTomRessurs()
     );
 
@@ -90,8 +94,15 @@ const Brevmeny: React.FC<BrevmenyProps> = (props) => {
             }).then((respons: Ressurs<TilkjentYtelse>) => {
                 settTilkjentYtelse(respons);
             });
+            axiosRequest<IBeløpsperiode[], null>({
+                method: 'GET',
+                url: `/familie-ef-sak/api/beregning/${props.behandlingId}`,
+            }).then((respons: Ressurs<IBeløpsperiode[]>) => {
+                settBeløpsperiode(respons);
+            });
         } else {
             settTilkjentYtelse(byggSuksessRessurs<TilkjentYtelse | undefined>(undefined));
+            settBeløpsperiode(byggSuksessRessurs<IBeløpsperiode[] | undefined>(undefined));
         }
         // eslint-disable-next-line
     }, [harVedtaksresultatMedTilkjentYtelse, vedtaksresultat]);
@@ -145,13 +156,19 @@ const Brevmeny: React.FC<BrevmenyProps> = (props) => {
                     )}
                 </DataViewer>
             ) : (
-                <DataViewer response={{ brevStruktur, tilkjentYtelse, mellomlagretBrev }}>
-                    {({ brevStruktur, tilkjentYtelse, mellomlagretBrev }) =>
+                <DataViewer
+                    response={{
+                        brevStruktur,
+                        mellomlagretBrev,
+                        beløpsperiode,
+                    }}
+                >
+                    {({ brevStruktur, mellomlagretBrev, beløpsperiode }) =>
                         brevMal && (
                             <BrevmenyVisning
                                 {...props}
                                 brevStruktur={brevStruktur}
-                                tilkjentYtelse={tilkjentYtelse}
+                                beløpsperiode={beløpsperiode}
                                 brevMal={brevMal}
                                 mellomlagretBrevVerdier={
                                     (mellomlagretBrev as IMellomlagretBrevResponse)?.brevverdier

--- a/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
@@ -168,7 +168,7 @@ const Brevmeny: React.FC<BrevmenyProps> = (props) => {
                             <BrevmenyVisning
                                 {...props}
                                 brevStruktur={brevStruktur}
-                                beløpsperiode={beløpsperioder}
+                                beløpsperioder={beløpsperioder}
                                 brevMal={brevMal}
                                 mellomlagretBrevVerdier={
                                     (mellomlagretBrev as IMellomlagretBrevResponse)?.brevverdier

--- a/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
@@ -54,7 +54,7 @@ const Brevmeny: React.FC<BrevmenyProps> = (props) => {
     const [tilkjentYtelse, settTilkjentYtelse] = useState<Ressurs<TilkjentYtelse | undefined>>(
         byggTomRessurs()
     );
-    const [beløpsperiode, settBeløpsperiode] = useState<Ressurs<IBeløpsperiode[] | undefined>>(
+    const [beløpsperioder, settBeløpsperioder] = useState<Ressurs<IBeløpsperiode[] | undefined>>(
         byggTomRessurs()
     );
 
@@ -98,11 +98,11 @@ const Brevmeny: React.FC<BrevmenyProps> = (props) => {
                 method: 'GET',
                 url: `/familie-ef-sak/api/beregning/${props.behandlingId}`,
             }).then((respons: Ressurs<IBeløpsperiode[]>) => {
-                settBeløpsperiode(respons);
+                settBeløpsperioder(respons);
             });
         } else {
             settTilkjentYtelse(byggSuksessRessurs<TilkjentYtelse | undefined>(undefined));
-            settBeløpsperiode(byggSuksessRessurs<IBeløpsperiode[] | undefined>(undefined));
+            settBeløpsperioder(byggSuksessRessurs<IBeløpsperiode[] | undefined>(undefined));
         }
         // eslint-disable-next-line
     }, [harVedtaksresultatMedTilkjentYtelse, vedtaksresultat]);
@@ -160,15 +160,15 @@ const Brevmeny: React.FC<BrevmenyProps> = (props) => {
                     response={{
                         brevStruktur,
                         mellomlagretBrev,
-                        beløpsperiode,
+                        beløpsperioder,
                     }}
                 >
-                    {({ brevStruktur, mellomlagretBrev, beløpsperiode }) =>
+                    {({ brevStruktur, mellomlagretBrev, beløpsperioder }) =>
                         brevMal && (
                             <BrevmenyVisning
                                 {...props}
                                 brevStruktur={brevStruktur}
-                                beløpsperiode={beløpsperiode}
+                                beløpsperiode={beløpsperioder}
                                 brevMal={brevMal}
                                 mellomlagretBrevVerdier={
                                     (mellomlagretBrev as IMellomlagretBrevResponse)?.brevverdier

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
@@ -24,9 +24,9 @@ import Panel from 'nav-frontend-paneler';
 import { BrevmenyProps } from './Brevmeny';
 import { apiLoggFeil } from '../../../App/api/axios';
 import { delmalTilHtml } from './Htmlfelter';
-import { TilkjentYtelse } from '../../../App/typer/tilkjentytelse';
 import { IBrevverdier, useMellomlagringBrev } from '../../../App/hooks/useMellomlagringBrev';
 import { useDebouncedCallback } from 'use-debounce';
+import { IBeløpsperiode } from '../../../App/typer/vedtak';
 
 const BrevFelter = styled.div`
     display: flex;
@@ -46,7 +46,7 @@ const BrevMenyDelmalWrapper = styled.div<{ førsteElement?: boolean }>`
 
 export interface BrevmenyVisningProps extends BrevmenyProps {
     brevStruktur: BrevStruktur;
-    tilkjentYtelse?: TilkjentYtelse;
+    beløpsperiode?: IBeløpsperiode[];
     mellomlagretBrevVerdier?: string;
     brevMal: string;
     flettefeltStore: { [navn: string]: string };
@@ -58,7 +58,7 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
     personopplysninger,
     settKanSendesTilBeslutter,
     brevStruktur,
-    tilkjentYtelse,
+    beløpsperiode,
     mellomlagretBrevVerdier,
     brevMal,
     flettefeltStore,
@@ -142,7 +142,7 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
                           {
                               flettefelter: lagFlettefelterForDelmal(delmal.delmalFlettefelter),
                               valgfelter: lagValgfelterForDelmal(delmal.delmalValgfelt),
-                              htmlfelter: delmalTilHtml(tilkjentYtelse),
+                              htmlfelter: delmalTilHtml(beløpsperiode),
                           },
                       ],
                   }

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
@@ -46,7 +46,7 @@ const BrevMenyDelmalWrapper = styled.div<{ førsteElement?: boolean }>`
 
 export interface BrevmenyVisningProps extends BrevmenyProps {
     brevStruktur: BrevStruktur;
-    beløpsperiode?: IBeløpsperiode[];
+    beløpsperioder?: IBeløpsperiode[];
     mellomlagretBrevVerdier?: string;
     brevMal: string;
     flettefeltStore: { [navn: string]: string };
@@ -58,7 +58,7 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
     personopplysninger,
     settKanSendesTilBeslutter,
     brevStruktur,
-    beløpsperiode,
+    beløpsperioder,
     mellomlagretBrevVerdier,
     brevMal,
     flettefeltStore,
@@ -142,7 +142,7 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
                           {
                               flettefelter: lagFlettefelterForDelmal(delmal.delmalFlettefelter),
                               valgfelter: lagValgfelterForDelmal(delmal.delmalValgfelt),
-                              htmlfelter: delmalTilHtml(beløpsperiode),
+                              htmlfelter: delmalTilHtml(beløpsperioder),
                           },
                       ],
                   }


### PR DESCRIPTION
…r relevante for nåværende vedtak.

Denne PRen løser frontend-delen av [denne oppgaven.](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8033)

Brevet og vedtak og beregningsiden skal nå kun vise beløpsperiode/tilkjente ytelser for vedtaket som blir lagret i den aktuelle behandlingen.

[Backend-PR](https://github.com/navikt/familie-ef-sak/pull/1208)