### PR TITLE
Trigger hentBehandling etter att man sendt til beslutter for å trigge…

### DIFF
--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutterFooter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutterFooter.tsx
@@ -33,7 +33,7 @@ const SendTilBeslutterFooter: React.FC<{
 }> = ({ behandlingId, kanSendesTilBeslutter }) => {
     const { axiosRequest } = useApp();
     const { modalDispatch } = useModal();
-    const { hentTotrinnskontroll } = useBehandling();
+    const { hentTotrinnskontroll, hentBehandling } = useBehandling();
     const [laster, settLaster] = useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState<string>();
 
@@ -46,6 +46,7 @@ const SendTilBeslutterFooter: React.FC<{
         })
             .then((res: RessursSuksess<string> | RessursFeilet) => {
                 if (res.status === RessursStatus.SUKSESS) {
+                    hentBehandling.rerun();
                     hentTotrinnskontroll.rerun();
                     modalDispatch({
                         type: ModalAction.VIS_MODAL,


### PR DESCRIPTION
… erBehandlingRedigerbar som då låser hele behandlingen for videre behandling og fjerner knappen for sendTilBeslutter

Hvis man ikke har denne, så kan man lukke modalen som popper opp når man sendt til beslutter, og då klikke på "send til beslutter" på nytt, eller gå til en annen fane i behandlingen og eks prøve å endre en vurdering - som då også vil feile. 

Denne triggen ser til att selve behandlingen "låses" i frontend, og knappen for å sende til beslutter blir fjernet :) 

![image](https://user-images.githubusercontent.com/937168/155381761-f12a1456-9c6f-4b50-bb32-d38d6c602368.png)
