### PR TITLE
Utbedringer - Responsivt design

### DIFF
--- a/src/frontend/App/hooks/felles/useEventListener.ts
+++ b/src/frontend/App/hooks/felles/useEventListener.ts
@@ -1,0 +1,48 @@
+import { RefObject, useEffect, useRef } from 'react';
+
+function useEventListener<K extends keyof WindowEventMap>(
+    eventName: K,
+    handler: (event: WindowEventMap[K]) => void
+): void;
+
+function useEventListener<
+    K extends keyof HTMLElementEventMap,
+    T extends HTMLElement = HTMLDivElement
+>(eventName: K, handler: (event: HTMLElementEventMap[K]) => void, element: RefObject<T>): void;
+
+function useEventListener<
+    KW extends keyof WindowEventMap,
+    KH extends keyof HTMLElementEventMap,
+    T extends HTMLElement | void = void
+>(
+    eventName: KW | KH,
+    handler: (event: WindowEventMap[KW] | HTMLElementEventMap[KH] | Event) => void,
+    element?: RefObject<T>
+) {
+    const savedHandler = useRef<typeof handler>();
+
+    useEffect(() => {
+        const targetElement: T | Window = element?.current || window;
+        if (!(targetElement && targetElement.addEventListener)) {
+            return;
+        }
+
+        if (savedHandler.current !== handler) {
+            savedHandler.current = handler;
+        }
+
+        const eventListener: typeof handler = (event) => {
+            if (savedHandler?.current) {
+                savedHandler.current(event);
+            }
+        };
+
+        targetElement.addEventListener(eventName, eventListener);
+
+        return () => {
+            targetElement.removeEventListener(eventName, eventListener);
+        };
+    }, [eventName, element, handler]);
+}
+
+export default useEventListener;

--- a/src/frontend/App/hooks/felles/useWindowSize.ts
+++ b/src/frontend/App/hooks/felles/useWindowSize.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect, useLayoutEffect } from 'react';
+
+import useEventListener from './useEventListener';
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+interface WindowSize {
+    width: number;
+    height: number;
+}
+
+export const useWindowSize = (): WindowSize => {
+    const [windowSize, setWindowSize] = useState<WindowSize>({
+        width: 0,
+        height: 0,
+    });
+
+    const handleSize = () => {
+        setWindowSize({
+            width: window.innerWidth,
+            height: window.innerHeight,
+        });
+    };
+
+    useEventListener('resize', handleSize);
+
+    useIsomorphicLayoutEffect(() => {
+        handleSize();
+        // eslint-disable-next-line
+    }, []);
+
+    return windowSize;
+};

--- a/src/frontend/Felles/Visittkort/Status/StatusElementer.tsx
+++ b/src/frontend/Felles/Visittkort/Status/StatusElementer.tsx
@@ -15,7 +15,7 @@ interface StatusMenyInnholdProps {
 }
 
 interface StatusProps {
-    singel?: boolean;
+    kunEttElement?: boolean;
 }
 
 export const GråTekst = styled(Normaltekst)`
@@ -83,7 +83,7 @@ export const StatuserLitenSkjerm = styled.div`
 export const Status = styled.div<StatusProps>`
     display: flex;
     width: 100%;
-    margin-right: ${(props) => (props.singel ? '0' : '1.3rem')};
+    margin-right: ${(props) => (props.kunEttElement ? '0' : '1.3rem')};
 
     flex-gap: 0.5rem;
     > p {

--- a/src/frontend/Felles/Visittkort/Status/StatusElementer.tsx
+++ b/src/frontend/Felles/Visittkort/Status/StatusElementer.tsx
@@ -14,6 +14,10 @@ interface StatusMenyInnholdProps {
     åpen: boolean;
 }
 
+interface StatusProps {
+    singel?: boolean;
+}
+
 export const GråTekst = styled(Normaltekst)`
     color: ${navFarger.navGra60};
 `;
@@ -49,9 +53,7 @@ const StatusMenyInnhold = styled.div`
 `;
 
 const VisStatuserKnapp = styled(Button)`
-    padding: 0.5rem;
-    padding-top: 1rem;
-    padding-right: 2rem;
+    color: ${navFarger.navGra60};
 `;
 
 export const Statuser = styled.div`
@@ -78,10 +80,10 @@ export const StatuserLitenSkjerm = styled.div`
     }
 `;
 
-export const Status = styled.div`
+export const Status = styled.div<StatusProps>`
     display: flex;
     width: 100%;
-    margin-right: 1.3rem;
+    margin-right: ${(props) => (props.singel ? '0' : '1.3rem')};
 
     flex-gap: 0.5rem;
     > p {
@@ -96,6 +98,7 @@ export const StatusMeny: FC<{ behandling: Behandling }> = ({ behandling }) => {
     return (
         <div>
             <VisStatuserKnapp
+                variant="tertiary"
                 onClick={() => {
                     settÅpenStatusMeny(!åpenStatusMeny);
                 }}

--- a/src/frontend/Felles/Visittkort/Visittkort.tsx
+++ b/src/frontend/Felles/Visittkort/Visittkort.tsx
@@ -33,7 +33,7 @@ const Visningsnavn = styled(Element)`
     white-space: nowrap;
 `;
 
-const StyledLenke = styled(Lenke)`
+const ResponsivLenke = styled(Lenke)`
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
@@ -115,7 +115,7 @@ const VisittkortComponent: FC<{ data: IPersonopplysninger; behandling?: Behandli
                 ident={personIdent}
                 kjønn={kjønn}
                 navn={
-                    <StyledLenke
+                    <ResponsivLenke
                         role={'link'}
                         href={`/fagsak/${fagsakId}`}
                         onClick={(e) => {
@@ -124,7 +124,7 @@ const VisittkortComponent: FC<{ data: IPersonopplysninger; behandling?: Behandli
                         }}
                     >
                         <Visningsnavn>{navn.visningsnavn}</Visningsnavn>
-                    </StyledLenke>
+                    </ResponsivLenke>
                 }
             >
                 {folkeregisterpersonstatus && (
@@ -168,7 +168,7 @@ const VisittkortComponent: FC<{ data: IPersonopplysninger; behandling?: Behandli
                 <>
                     <AlleStatuser behandling={behandling} />
                     <StatuserLitenSkjerm>
-                        <Status singel={true}>
+                        <Status kunEttElement={true}>
                             <GråTekst>Behandlingstype</GråTekst>
                             <Normaltekst>{behandlingstypeTilTekst[behandling.type]}</Normaltekst>
                         </Status>

--- a/src/frontend/Felles/Visittkort/Visittkort.tsx
+++ b/src/frontend/Felles/Visittkort/Visittkort.tsx
@@ -168,7 +168,7 @@ const VisittkortComponent: FC<{ data: IPersonopplysninger; behandling?: Behandli
                 <>
                     <AlleStatuser behandling={behandling} />
                     <StatuserLitenSkjerm>
-                        <Status>
+                        <Status singel={true}>
                             <GråTekst>Behandlingstype</GråTekst>
                             <Normaltekst>{behandlingstypeTilTekst[behandling.type]}</Normaltekst>
                         </Status>

--- a/src/frontend/Felles/Visittkort/Visittkort.tsx
+++ b/src/frontend/Felles/Visittkort/Visittkort.tsx
@@ -27,6 +27,18 @@ import {
     GråTekst,
 } from './Status/StatusElementer';
 
+const Visningsnavn = styled(Element)`
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+`;
+
+const StyledLenke = styled(Lenke)`
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+`;
+
 export const VisittkortWrapper = styled(Sticky)`
     display: flex;
 
@@ -103,7 +115,7 @@ const VisittkortComponent: FC<{ data: IPersonopplysninger; behandling?: Behandli
                 ident={personIdent}
                 kjønn={kjønn}
                 navn={
-                    <Lenke
+                    <StyledLenke
                         role={'link'}
                         href={`/fagsak/${fagsakId}`}
                         onClick={(e) => {
@@ -111,8 +123,8 @@ const VisittkortComponent: FC<{ data: IPersonopplysninger; behandling?: Behandli
                             gåTilUrl(`/fagsak/${fagsakId}`);
                         }}
                     >
-                        <Element>{navn.visningsnavn}</Element>
-                    </Lenke>
+                        <Visningsnavn>{navn.visningsnavn}</Visningsnavn>
+                    </StyledLenke>
                 }
             >
                 {folkeregisterpersonstatus && (

--- a/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, useEffect } from 'react';
+import { FC, useEffect, useState } from 'react';
 import Høyremeny from './Høyremeny/Høyremeny';
 import styled from 'styled-components';
 import Fanemeny from './Fanemeny/Fanemeny';
@@ -21,24 +21,27 @@ const Container = styled.div`
     display: flex;
 `;
 
-const HøyreMenyWrapper = styled.div`
+interface InnholdWrapperProps {
+    åpenHøyremeny: boolean;
+}
+
+interface HøyreMenyWrapperProps {
+    åpenHøyremeny: boolean;
+}
+
+const HøyreMenyWrapper = styled.div<HøyreMenyWrapperProps>`
     border-left: 2px solid ${navFarger.navGra40};
     overflow-x: hidden;
 
-    width: 20rem;
+    width: ${(p) => (p.åpenHøyremeny ? '20rem' : '0rem')};
 
-    @media (max-width: 800px) {
-        width: 0rem;
-    }
     overflow-y: auto;
 `;
 
-const InnholdWrapper = styled.div`
+const InnholdWrapper = styled.div<InnholdWrapperProps>`
     flex: 1;
-    max-width: calc(100% - 20rem);
-    @media (max-width: 800px) {
-        max-width: 100%;
-    }
+
+    max-width: ${(p) => (p.åpenHøyremeny ? 'calc(100% - 20rem)' : '100%')};
 `;
 
 const BehandlingContainer: FC = () => {
@@ -58,11 +61,20 @@ const BehandlingContent: FC<{
 }> = ({ behandling, personopplysninger }) => {
     useSetValgtFagsakId(behandling.fagsakId);
 
+    const [åpenHøyremeny, settÅpenHøyremeny] = useState(true);
+
     return (
         <>
             <VisittkortComponent data={personopplysninger} behandling={behandling} />
+            <button
+                onClick={() => {
+                    settÅpenHøyremeny(!åpenHøyremeny);
+                }}
+            >
+                toggle høyremeny
+            </button>
             <Container>
-                <InnholdWrapper>
+                <InnholdWrapper åpenHøyremeny={åpenHøyremeny}>
                     <Fanemeny behandlingId={behandling.id} />
                     <BehandlingRoutes />
                     <GodkjennEndringer behandling={behandling} />
@@ -72,7 +84,7 @@ const BehandlingContent: FC<{
                     />
                     <HenleggModal behandling={behandling} />
                 </InnholdWrapper>
-                <HøyreMenyWrapper>
+                <HøyreMenyWrapper åpenHøyremeny={åpenHøyremeny}>
                     <Høyremeny behandlingId={behandling.id} />
                 </HøyreMenyWrapper>
             </Container>

--- a/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
@@ -16,7 +16,6 @@ import { Behandling } from '../../App/typer/fagsak';
 import { IPersonopplysninger } from '../../App/typer/personopplysninger';
 import { useSetValgtFagsakId } from '../../App/hooks/useSetValgtFagsakId';
 import { HenleggModal } from './Henleggelse/HenleggModal';
-import { useWindowSize } from '../../App/hooks/felles/useWindowSize';
 
 const Container = styled.div`
     display: flex;
@@ -69,12 +68,6 @@ const BehandlingContent: FC<{
     personopplysninger: IPersonopplysninger;
 }> = ({ behandling, personopplysninger }) => {
     useSetValgtFagsakId(behandling.fagsakId);
-
-    const { width } = useWindowSize();
-
-    useEffect(() => {
-        console.log('width', width);
-    }, [width]);
 
     const [åpenHøyremeny, settÅpenHøyremeny] = useState(true);
 

--- a/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
@@ -20,6 +20,8 @@ import { useWindowSize } from '../../App/hooks/felles/useWindowSize';
 
 const Container = styled.div`
     display: flex;
+
+    flex-shrink: 2;
 `;
 
 interface InnholdWrapperProps {
@@ -32,15 +34,19 @@ interface HøyreMenyWrapperProps {
 
 const HøyreMenyWrapper = styled.div<HøyreMenyWrapperProps>`
     border-left: 2px solid ${navFarger.navGra40};
-    overflow-x: hidden;
+
+    flex-shrink: 1;
+    flex-grow: 0;
 
     width: ${(p) => (p.åpenHøyremeny ? '20rem' : '1.5rem')};
-
-    overflow-y: auto;
+    min-width: ${(p) => (p.åpenHøyremeny ? '20rem' : '1.5rem')};
 `;
 
 const InnholdWrapper = styled.div<InnholdWrapperProps>`
-    flex: 1;
+    flex-shrink: 0;
+    flex-grow: 1;
+    flex-basis: 0px;
+    min-width: 0px;
 
     max-width: ${(p) => (p.åpenHøyremeny ? 'calc(100% - 1.5rem)' : '100%')};
 `;
@@ -73,13 +79,6 @@ const BehandlingContent: FC<{
     return (
         <>
             <VisittkortComponent data={personopplysninger} behandling={behandling} />
-            <button
-                onClick={() => {
-                    settÅpenHøyremeny(!åpenHøyremeny);
-                }}
-            >
-                toggle høyremeny
-            </button>
             <Container>
                 <InnholdWrapper åpenHøyremeny={åpenHøyremeny}>
                     <Fanemeny behandlingId={behandling.id} />

--- a/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
@@ -16,6 +16,7 @@ import { Behandling } from '../../App/typer/fagsak';
 import { IPersonopplysninger } from '../../App/typer/personopplysninger';
 import { useSetValgtFagsakId } from '../../App/hooks/useSetValgtFagsakId';
 import { HenleggModal } from './Henleggelse/HenleggModal';
+import { useWindowSize } from '../../App/hooks/felles/useWindowSize';
 
 const Container = styled.div`
     display: flex;
@@ -33,7 +34,7 @@ const HøyreMenyWrapper = styled.div<HøyreMenyWrapperProps>`
     border-left: 2px solid ${navFarger.navGra40};
     overflow-x: hidden;
 
-    width: ${(p) => (p.åpenHøyremeny ? '20rem' : '0rem')};
+    width: ${(p) => (p.åpenHøyremeny ? '20rem' : '1.5rem')};
 
     overflow-y: auto;
 `;
@@ -41,7 +42,7 @@ const HøyreMenyWrapper = styled.div<HøyreMenyWrapperProps>`
 const InnholdWrapper = styled.div<InnholdWrapperProps>`
     flex: 1;
 
-    max-width: ${(p) => (p.åpenHøyremeny ? 'calc(100% - 20rem)' : '100%')};
+    max-width: ${(p) => (p.åpenHøyremeny ? 'calc(100% - 1.5rem)' : '100%')};
 `;
 
 const BehandlingContainer: FC = () => {
@@ -60,6 +61,12 @@ const BehandlingContent: FC<{
     personopplysninger: IPersonopplysninger;
 }> = ({ behandling, personopplysninger }) => {
     useSetValgtFagsakId(behandling.fagsakId);
+
+    const { width } = useWindowSize();
+
+    useEffect(() => {
+        console.log('width', width);
+    }, [width]);
 
     const [åpenHøyremeny, settÅpenHøyremeny] = useState(true);
 
@@ -85,7 +92,11 @@ const BehandlingContent: FC<{
                     <HenleggModal behandling={behandling} />
                 </InnholdWrapper>
                 <HøyreMenyWrapper åpenHøyremeny={åpenHøyremeny}>
-                    <Høyremeny behandlingId={behandling.id} />
+                    <Høyremeny
+                        åpenHøyremeny={åpenHøyremeny}
+                        behandlingId={behandling.id}
+                        settÅpenHøyremeny={settÅpenHøyremeny}
+                    />
                 </HøyreMenyWrapper>
             </Container>
         </>

--- a/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
@@ -49,7 +49,7 @@ const InnholdWrapper = styled.div<InnholdWrapperProps>`
 
     overflow-x: scroll;
 
-    max-width: ${(p) => (p.åpenHøyremeny ? 'calc(100% - 1.5rem)' : '100%')};
+    max-width: ${(p) => (p.åpenHøyremeny ? 'calc(100% - 20rem)' : '100%')};
 `;
 
 const BehandlingContainer: FC = () => {

--- a/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
@@ -48,6 +48,8 @@ const InnholdWrapper = styled.div<InnholdWrapperProps>`
     flex-basis: 0px;
     min-width: 0px;
 
+    overflow-x: scroll;
+
     max-width: ${(p) => (p.åpenHøyremeny ? 'calc(100% - 1.5rem)' : '100%')};
 `;
 

--- a/src/frontend/Komponenter/Behandling/Fanemeny/Fane.tsx
+++ b/src/frontend/Komponenter/Behandling/Fanemeny/Fane.tsx
@@ -15,6 +15,13 @@ const StyledNavLink = styled(NavLink)`
     padding-top: 1rem;
     padding-bottom: 1rem;
 
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+
+    padding-left: 5px;
+    padding-right: 5px;
+
     :hover {
         border-bottom: 5px solid ${navFarger.navBlaLighten20};
 
@@ -33,6 +40,12 @@ const StyledNavLink = styled(NavLink)`
     }
 `;
 
+const StyledLenketekst = styled(Normaltekst)`
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+`;
+
 const StyledTekst = styled(Normaltekst)`
     border-bottom: 5px solid white;
     color: ${navFarger.navGra20};
@@ -41,6 +54,12 @@ const StyledTekst = styled(Normaltekst)`
     width: 100%;
     padding-top: 1rem;
     padding-bottom: 1rem;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    white-space: nowrap;
+
+    padding-left: 5px;
+    padding-right: 5px;
 `;
 
 interface Props {
@@ -69,9 +88,9 @@ const Fane: React.FC<Props> = ({ side, behandlingId, index, deaktivert }) => {
                         gåTilUrl(`/behandling/${behandlingId}/${side.href}`);
                     }}
                 >
-                    <Normaltekst>
+                    <StyledLenketekst>
                         {index + 1}. {side.navn}
-                    </Normaltekst>
+                    </StyledLenketekst>
                 </StyledNavLink>
             )}
         </>

--- a/src/frontend/Komponenter/Behandling/Fanemeny/Fanemeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Fanemeny/Fanemeny.tsx
@@ -11,7 +11,6 @@ import Fane from './Fane';
 
 const StickyMedBoxShadow = styled(Sticky)`
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.4);
-    top: 96px;
 `;
 
 const StyledFanemeny = styled.div`

--- a/src/frontend/Komponenter/Behandling/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/Høyremeny.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import BehandlingHistorikk from './BehandlingHistorikk';
 import Totrinnskontroll from '../Totrinnskontroll/Totrinnskontroll';
 import { Back, Next } from '@navikt/ds-icons';
+import navFarger from 'nav-frontend-core';
 
 interface IHøyremenyProps {
     behandlingId: string;
@@ -34,7 +35,7 @@ const StyledNext = styled(Next)`
 const StyledButton = styled.button<StyledButtonProps>`
     position: absolute;
 
-    background-color: #3386e0;
+    background-color: ${navFarger.navBlaLighten20};
 
     right: ${(p) => (p.åpenHøyremeny ? '19rem' : '12px')};
 
@@ -43,7 +44,6 @@ const StyledButton = styled.button<StyledButtonProps>`
     width: 24px;
     height: 24px;
 
-    z-index: 99999;
     border-radius: 50%;
 
     filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));

--- a/src/frontend/Komponenter/Behandling/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/Høyremeny.tsx
@@ -1,14 +1,41 @@
 import * as React from 'react';
-import { useState } from 'react';
+import { useState, Dispatch, SetStateAction } from 'react';
 import Dokumentoversikt from './Dokumentoversikt';
 import Valgvisning from './Valgvisning';
 import styled from 'styled-components';
 import BehandlingHistorikk from './BehandlingHistorikk';
 import Totrinnskontroll from '../Totrinnskontroll/Totrinnskontroll';
+import { Back } from '@navikt/ds-icons';
 
 interface IHøyremenyProps {
     behandlingId: string;
+    åpenHøyremeny: boolean;
+    settÅpenHøyremeny: Dispatch<SetStateAction<boolean>>;
 }
+
+const StyledBack = styled(Back)`
+    border-radius: 0;
+    margin-top: 3px;
+    margin-right: 2px;
+    color: white;
+`;
+
+const StyledButton = styled.button`
+    position: absolute;
+
+    background-color: #3386e0;
+
+    right: 12px;
+    top: 200px;
+
+    width: 24px;
+    height: 24px;
+
+    z-index: 10000;
+    border-radius: 50%;
+
+    filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
+`;
 
 const StyledHøyremeny = styled.div`
     width: 100%;
@@ -20,20 +47,38 @@ export enum Høyremenyvalg {
     Logg = 'Logg',
 }
 
-const Høyremeny: React.FC<IHøyremenyProps> = ({ behandlingId }) => {
+const Høyremeny: React.FC<IHøyremenyProps> = ({
+    behandlingId,
+    åpenHøyremeny,
+    settÅpenHøyremeny,
+}) => {
     const [aktivtValg, settAktivtvalg] = useState<Høyremenyvalg>(Høyremenyvalg.Logg);
     return (
         <>
-            <Totrinnskontroll />
-            <StyledHøyremeny>
-                <Valgvisning aktiv={aktivtValg} settAktiv={settAktivtvalg} />
-                <Dokumentoversikt hidden={aktivtValg !== Høyremenyvalg.Mappe} />
-                <BehandlingHistorikk
-                    hidden={aktivtValg !== Høyremenyvalg.Logg}
-                    behandlingId={behandlingId}
-                />
-                {aktivtValg === Høyremenyvalg.Dialog && <div>Her kommer dialog</div>}
-            </StyledHøyremeny>
+            {åpenHøyremeny ? (
+                <>
+                    <Totrinnskontroll />
+                    <StyledHøyremeny>
+                        <Valgvisning aktiv={aktivtValg} settAktiv={settAktivtvalg} />
+                        <Dokumentoversikt hidden={aktivtValg !== Høyremenyvalg.Mappe} />
+                        <BehandlingHistorikk
+                            hidden={aktivtValg !== Høyremenyvalg.Logg}
+                            behandlingId={behandlingId}
+                        />
+                        {aktivtValg === Høyremenyvalg.Dialog && <div>Her kommer dialog</div>}
+                    </StyledHøyremeny>
+                </>
+            ) : (
+                <div>
+                    <StyledButton
+                        onClick={() => {
+                            settÅpenHøyremeny(!åpenHøyremeny);
+                        }}
+                    >
+                        <StyledBack />
+                    </StyledButton>
+                </div>
+            )}
         </>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/Høyremeny.tsx
@@ -5,7 +5,7 @@ import Valgvisning from './Valgvisning';
 import styled from 'styled-components';
 import BehandlingHistorikk from './BehandlingHistorikk';
 import Totrinnskontroll from '../Totrinnskontroll/Totrinnskontroll';
-import { Back } from '@navikt/ds-icons';
+import { Back, Next } from '@navikt/ds-icons';
 
 interface IHøyremenyProps {
     behandlingId: string;
@@ -20,18 +20,26 @@ const StyledBack = styled(Back)`
     color: white;
 `;
 
+const StyledNext = styled(Next)`
+    border-radius: 0;
+    margin-top: 3px;
+
+    color: white;
+`;
+
 const StyledButton = styled.button`
     position: absolute;
 
     background-color: #3386e0;
 
-    right: 12px;
+    right: ${(p) => (p.åpenHøyremeny ? '19rem' : '12px')};
+
     top: 200px;
 
     width: 24px;
     height: 24px;
 
-    z-index: 10000;
+    z-index: 99999;
     border-radius: 50%;
 
     filter: drop-shadow(0px 4px 4px rgba(0, 0, 0, 0.25));
@@ -59,6 +67,14 @@ const Høyremeny: React.FC<IHøyremenyProps> = ({
                 <>
                     <Totrinnskontroll />
                     <StyledHøyremeny>
+                        <StyledButton
+                            åpenHøyremeny
+                            onClick={() => {
+                                settÅpenHøyremeny(!åpenHøyremeny);
+                            }}
+                        >
+                            <StyledNext />
+                        </StyledButton>
                         <Valgvisning aktiv={aktivtValg} settAktiv={settAktivtvalg} />
                         <Dokumentoversikt hidden={aktivtValg !== Høyremenyvalg.Mappe} />
                         <BehandlingHistorikk

--- a/src/frontend/Komponenter/Behandling/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/Høyremeny.tsx
@@ -13,6 +13,10 @@ interface IHøyremenyProps {
     settÅpenHøyremeny: Dispatch<SetStateAction<boolean>>;
 }
 
+interface StyledButtonProps {
+    åpenHøyremeny: boolean;
+}
+
 const StyledBack = styled(Back)`
     border-radius: 0;
     margin-top: 3px;
@@ -27,7 +31,7 @@ const StyledNext = styled(Next)`
     color: white;
 `;
 
-const StyledButton = styled.button`
+const StyledButton = styled.button<StyledButtonProps>`
     position: absolute;
 
     background-color: #3386e0;


### PR DESCRIPTION
Utbedringer som gjør at løsningen fungerer bedre på liten skjerm. I hovedsak disse endringene:

1. Det legges til en knapp for å ekspandere/minimere høyremenyen.
2. Innholdet (i `InnholdWrapper`) havner bak vertikal scroll når skjermen blir for smal.
3. Kutter teksten og legger til ellipsis på stegene i fanemenyen når skjermen blir for smal.

Liten kommentar: `useEventListener` og `useWindowSize` er ikke i bruk nå. Disse ble først lagt til for at høyremenyen skulle lukkes automatisk dersom skjermen ble smalere enn en viss bredde, men etter å ha tatt en prat med Lars har vi blitt enige om at menyen bare skal åpnes/lukkes manuelt nå. Lar likevel de nye hooksa være der i tilfelle vi trenger de senere.

Se [Favro-sak](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-7914).