### PR TITLE
Vil vise logiske vedlegg i dokumentoversikt

### DIFF
--- a/src/frontend/App/typer/dokumentliste.ts
+++ b/src/frontend/App/typer/dokumentliste.ts
@@ -1,4 +1,4 @@
-import { ILogiskVedlegg, Journalposttype, Journalstatus } from '@navikt/familie-typer';
+import { Journalposttype, Journalstatus } from '@navikt/familie-typer';
 
 export interface Dokumentinfo {
     dokumentinfoId: string;
@@ -8,5 +8,9 @@ export interface Dokumentinfo {
     dato: string;
     journalposttype: Journalposttype;
     journalstatus: Journalstatus;
-    logiskeVedlegg?: ILogiskVedlegg[];
+    logiskeVedlegg: ILogiskVedlegg[];
+}
+
+export interface ILogiskVedlegg {
+    tittel: string;
 }

--- a/src/frontend/App/typer/dokumentliste.ts
+++ b/src/frontend/App/typer/dokumentliste.ts
@@ -1,4 +1,4 @@
-import { Journalposttype, Journalstatus } from '@navikt/familie-typer';
+import { ILogiskVedlegg, Journalposttype, Journalstatus } from '@navikt/familie-typer';
 
 export interface Dokumentinfo {
     dokumentinfoId: string;
@@ -8,4 +8,5 @@ export interface Dokumentinfo {
     dato: string;
     journalposttype: Journalposttype;
     journalstatus: Journalstatus;
+    logiskeVedlegg?: ILogiskVedlegg[];
 }

--- a/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
@@ -28,6 +28,10 @@ const LenkeVenstreMargin = styled.a`
     margin-left: 2rem;
 `;
 
+const DivMedVenstreMargin = styled.div`
+    margin-left: 2rem;
+`;
+
 const Dokumenter: React.FC<{ personopplysninger: IPersonopplysninger }> = ({
     personopplysninger,
 }) => {
@@ -58,6 +62,10 @@ const Dokumenter: React.FC<{ personopplysninger: IPersonopplysninger }> = ({
                 >
                     {dokument.tittel}
                 </LenkeVenstreMargin>
+                {dokument.logiskeVedlegg &&
+                    dokument.logiskeVedlegg?.map((logiskVedlegg) => (
+                        <DivMedVenstreMargin>{logiskVedlegg.tittel}</DivMedVenstreMargin>
+                    ))}
             </Td>
             <Td></Td>
         </tr>

--- a/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
@@ -62,10 +62,11 @@ const Dokumenter: React.FC<{ personopplysninger: IPersonopplysninger }> = ({
                 >
                     {dokument.tittel}
                 </LenkeVenstreMargin>
-                {dokument.logiskeVedlegg &&
-                    dokument.logiskeVedlegg?.map((logiskVedlegg) => (
-                        <DivMedVenstreMargin>{logiskVedlegg.tittel}</DivMedVenstreMargin>
-                    ))}
+                {dokument.logiskeVedlegg.map((logiskVedlegg, index) => (
+                    <DivMedVenstreMargin key={`${logiskVedlegg.tittel}${index}`}>
+                        {logiskVedlegg.tittel}
+                    </DivMedVenstreMargin>
+                ))}
             </Td>
             <Td></Td>
         </tr>


### PR DESCRIPTION
Skal løse [dette favrokortet](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-7698)
Logiske vedlegg settes typisk av saksbehandler for manuelt skannet dokumenter. Blir seende ut som dette:

<img width="961" alt="image" src="https://user-images.githubusercontent.com/21220467/155947345-c3cfc6fa-a1e6-4d3e-b744-6263a7a43a42.png">

Tar dokumentoversikten i høyremenyen i annen PR.