### PR TITLE
nÃmedia query for vedtaksoppsummeringsheader skal tilpasses etter om …

### DIFF
--- a/src/frontend/App/context/BehandlingContext.tsx
+++ b/src/frontend/App/context/BehandlingContext.tsx
@@ -50,6 +50,7 @@ const [BehandlingProvider, useBehandling] = constate(() => {
 
     const [visBrevmottakereModal, settVisBrevmottakereModal] = useState(false);
     const [visHenleggModal, settVisHenleggModal] = useState(false);
+    const [åpenHøyremeny, settÅpenHøyremeny] = useState(true);
 
     return {
         behandling,
@@ -66,6 +67,8 @@ const [BehandlingProvider, useBehandling] = constate(() => {
         settVisBrevmottakereModal,
         visHenleggModal,
         settVisHenleggModal,
+        åpenHøyremeny,
+        settÅpenHøyremeny,
     };
 });
 

--- a/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect } from 'react';
 import Høyremeny from './Høyremeny/Høyremeny';
 import styled from 'styled-components';
 import Fanemeny from './Fanemeny/Fanemeny';
@@ -68,8 +68,7 @@ const BehandlingContent: FC<{
     personopplysninger: IPersonopplysninger;
 }> = ({ behandling, personopplysninger }) => {
     useSetValgtFagsakId(behandling.fagsakId);
-
-    const [åpenHøyremeny, settÅpenHøyremeny] = useState(true);
+    const { åpenHøyremeny } = useBehandling();
 
     return (
         <>
@@ -86,11 +85,7 @@ const BehandlingContent: FC<{
                     <HenleggModal behandling={behandling} />
                 </InnholdWrapper>
                 <HøyreMenyWrapper åpenHøyremeny={åpenHøyremeny}>
-                    <Høyremeny
-                        åpenHøyremeny={åpenHøyremeny}
-                        behandlingId={behandling.id}
-                        settÅpenHøyremeny={settÅpenHøyremeny}
-                    />
+                    <Høyremeny åpenHøyremeny={åpenHøyremeny} behandlingId={behandling.id} />
                 </HøyreMenyWrapper>
             </Container>
         </>

--- a/src/frontend/Komponenter/Behandling/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/Høyremeny.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useState, Dispatch, SetStateAction } from 'react';
+import { useState } from 'react';
 import Dokumentoversikt from './Dokumentoversikt';
 import Valgvisning from './Valgvisning';
 import styled from 'styled-components';
@@ -7,11 +7,11 @@ import BehandlingHistorikk from './BehandlingHistorikk';
 import Totrinnskontroll from '../Totrinnskontroll/Totrinnskontroll';
 import { Back, Next } from '@navikt/ds-icons';
 import navFarger from 'nav-frontend-core';
+import { useBehandling } from '../../../App/context/BehandlingContext';
 
 interface IHøyremenyProps {
     behandlingId: string;
     åpenHøyremeny: boolean;
-    settÅpenHøyremeny: Dispatch<SetStateAction<boolean>>;
 }
 
 interface StyledButtonProps {
@@ -59,12 +59,10 @@ export enum Høyremenyvalg {
     Logg = 'Logg',
 }
 
-const Høyremeny: React.FC<IHøyremenyProps> = ({
-    behandlingId,
-    åpenHøyremeny,
-    settÅpenHøyremeny,
-}) => {
+const Høyremeny: React.FC<IHøyremenyProps> = ({ behandlingId, åpenHøyremeny }) => {
     const [aktivtValg, settAktivtvalg] = useState<Høyremenyvalg>(Høyremenyvalg.Logg);
+    const { settÅpenHøyremeny } = useBehandling();
+
     return (
         <>
             {åpenHøyremeny ? (

--- a/src/frontend/Komponenter/Behandling/Vilkårresultat/Vedtaksoppsummering.tsx
+++ b/src/frontend/Komponenter/Behandling/Vilkårresultat/Vedtaksoppsummering.tsx
@@ -13,13 +13,14 @@ import { Heading } from '@navikt/ds-react';
 import navFarger from 'nav-frontend-core';
 import { Behandling } from '../../../App/typer/fagsak';
 import { Behandlingsårsak } from '../../../App/typer/Behandlingsårsak';
+import { useBehandling } from '../../../App/context/BehandlingContext';
 
-const OppsummeringContainer = styled.div`
+const OppsummeringContainer = styled.div<{ åpenHøyremeny: boolean }>`
     display: flex;
     flex-direction: row;
     justify-content: flex-start;
     margin-right: 0.5rem;
-    @media only screen and (max-width: 1450px) {
+    @media only screen and (max-width: ${(p) => (p.åpenHøyremeny ? '1450px' : '1150px')}) {
         flex-wrap: wrap;
     }
 `;
@@ -39,9 +40,10 @@ export const Vedtaksoppsummering: React.FC<{
     const inngangsvilkår = sorterUtInngangsvilkår(vilkår);
     const aktivitetsvilkår = sorterUtAktivitetsVilkår(vilkår);
     const tidligereVedtaksvilkår = sorterUtTidligereVedtaksvilkår(vilkår);
+    const { åpenHøyremeny } = useBehandling();
 
     return (
-        <OppsummeringContainer>
+        <OppsummeringContainer åpenHøyremeny={åpenHøyremeny}>
             <Oppsummeringsboks>
                 <Heading spacing size="small" level="5">
                     Vilkårsvurdering


### PR DESCRIPTION
…høyremenyen er åpen eller lukket.

Nå som høyremenyen kan åpnes og lukkes manuelt kan frontenden i vedtak-og-beregning "klare seg" med smalere skjerm dersom høyremenyen er lukket.

Før:
<img width="1441" alt="Skjermbilde 2022-03-01 kl  22 49 53" src="https://user-images.githubusercontent.com/32769446/156254828-3f45d181-8e58-4136-b4b4-c19a532f00d2.png">

Etter:
<img width="1178" alt="Skjermbilde 2022-03-01 kl  22 50 08" src="https://user-images.githubusercontent.com/32769446/156254854-b685fede-b565-4409-9da8-376069a9ec52.png">

