### PR TITLE
La innholdet dekke hele siden

### DIFF
--- a/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
@@ -49,6 +49,8 @@ const InnholdWrapper = styled.div<InnholdWrapperProps>`
 
     overflow-x: scroll;
 
+    min-height: 90vh;
+
     max-width: ${(p) => (p.åpenHøyremeny ? 'calc(100% - 20rem)' : '100%')};
 `;
 


### PR DESCRIPTION
Setter minimumshøyde på InnholdWrapper slik at den dekker hele siden (ellers starter den vertikale scrollbaren midt på siden).

Før:
<img width="1434" alt="Skjermbilde 2022-03-03 kl  10 28 07" src="https://user-images.githubusercontent.com/1413265/156536117-d73826dd-cd0a-4212-a1ad-b61b12f52e59.png">
 
Etter: 
<img width="1669" alt="Skjermbilde 2022-03-03 kl  10 28 30" src="https://user-images.githubusercontent.com/1413265/156536186-c75414d5-8701-42ca-8ef0-9d9879c1ee3d.png">

