### PR TITLE
Vedtak og beregning barnetilsyn

### DIFF
--- a/src/frontend/App/typer/fagsak.ts
+++ b/src/frontend/App/typer/fagsak.ts
@@ -41,6 +41,7 @@ export interface Behandling {
     opprettet: string;
     resultat: BehandlingResultat;
     behandlingsårsak: Behandlingsårsak;
+    stønadstype: Stønadstype;
 }
 
 export interface IEndringerRegistergrunnlag {

--- a/src/frontend/Komponenter/Behandling/Sanksjon/Sanksjonsfastsettelse.tsx
+++ b/src/frontend/Komponenter/Behandling/Sanksjon/Sanksjonsfastsettelse.tsx
@@ -26,7 +26,7 @@ import {
 } from '../../../App/typer/vedtak';
 import { Ressurs, RessursStatus } from '../../../App/typer/ressurs';
 import useFormState, { FormState } from '../../../App/hooks/felles/useFormState';
-import { validerSanksjonereVedtakForm } from '../VedtakOgBeregning/vedtaksvalidering';
+import { validerSanksjonereVedtakForm } from '../VedtakOgBeregning/Overgangsstønad/vedtaksvalidering';
 import { FieldState } from '../../../App/hooks/felles/useFieldState';
 import { EnsligTextArea } from '../../../Felles/Input/TekstInput/EnsligTextArea';
 import { FamilieSelect } from '@navikt/familie-form-elements';

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
@@ -1,0 +1,14 @@
+import React, { FC } from 'react';
+import { Behandling } from '../../../../App/typer/fagsak';
+import { IVilkår } from '../../Inngangsvilkår/vilkår';
+
+interface Props {
+    behandling?: Behandling;
+    vilkår?: IVilkår;
+}
+
+const VedtakOgBeregningBarnetilsyn: FC<Props> = () => {
+    return <p>TODO</p>;
+};
+
+export default VedtakOgBeregningBarnetilsyn;

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/VedtaksoppsummeringBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/VedtaksoppsummeringBarnetilsyn.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { IVilkår } from '../../Inngangsvilkår/vilkår';
+import { Behandling } from '../../../../App/typer/fagsak';
+
+export const VedtaksoppsummeringBarnetilsyn: React.FC<{
+    vilkår?: IVilkår;
+    behandling?: Behandling;
+}> = () => {
+    return <p>TODO</p>;
+};

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/InnvilgeVedtak/InnvilgeVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/InnvilgeVedtak/InnvilgeVedtak.tsx
@@ -25,7 +25,10 @@ import { ListState } from '../../../../App/hooks/felles/useListState';
 import { IngenBegrunnelseOppgitt } from './IngenBegrunnelseOppgitt';
 import Utregningstabell from './Utregningstabell';
 import useFormState, { FormState } from '../../../../App/hooks/felles/useFormState';
-import { validerInnvilgetVedtakForm, validerVedtaksperioder } from '../vedtaksvalidering';
+import {
+    validerInnvilgetVedtakForm,
+    validerVedtaksperioder,
+} from '../Overgangsstønad/vedtaksvalidering';
 import AlertStripeFeilPreWrap from '../../../../Felles/Visningskomponenter/AlertStripeFeilPreWrap';
 import { EnsligTextArea } from '../../../../Felles/Input/TekstInput/EnsligTextArea';
 import { VEDTAK_OG_BEREGNING } from '../konstanter';

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/SelectVedtaksresultat.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/SelectVedtaksresultat.tsx
@@ -1,12 +1,12 @@
-import { behandlingResultatTilTekst, EBehandlingResultat } from '../../../App/typer/vedtak';
+import { behandlingResultatTilTekst, EBehandlingResultat } from '../../../../App/typer/vedtak';
 import React from 'react';
 import styled from 'styled-components';
 import { FamilieSelect } from '@navikt/familie-form-elements';
-import { useBehandling } from '../../../App/context/BehandlingContext';
-import { Behandling } from '../../../App/typer/fagsak';
-import { Behandlingstype } from '../../../App/typer/behandlingstype';
-import { VEDTAK_OG_BEREGNING } from './konstanter';
-import { useApp } from '../../../App/context/AppContext';
+import { useBehandling } from '../../../../App/context/BehandlingContext';
+import { Behandling } from '../../../../App/typer/fagsak';
+import { Behandlingstype } from '../../../../App/typer/behandlingstype';
+import { VEDTAK_OG_BEREGNING } from '../konstanter';
+import { useApp } from '../../../../App/context/AppContext';
 import { Heading } from '@navikt/ds-react';
 
 interface Props {

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/Søknadsdatoer.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/Søknadsdatoer.tsx
@@ -1,15 +1,15 @@
-import { Søknadsgrunnlag } from '../../../Felles/Ikoner/DataGrunnlagIkoner';
+import { Søknadsgrunnlag } from '../../../../Felles/Ikoner/DataGrunnlagIkoner';
 import { Normaltekst } from 'nav-frontend-typografi';
-import { formaterNullableIsoDato, formaterNullableMånedÅr } from '../../../App/utils/formatter';
+import { formaterNullableIsoDato, formaterNullableMånedÅr } from '../../../../App/utils/formatter';
 import React, { useMemo } from 'react';
-import DataViewer from '../../../Felles/DataViewer/DataViewer';
-import { Ressurs } from '../../../App/typer/ressurs';
-import { ISøknadData } from '../../../App/typer/beregningssøknadsdata';
-import { useDataHenter } from '../../../App/hooks/felles/useDataHenter';
+import DataViewer from '../../../../Felles/DataViewer/DataViewer';
+import { Ressurs } from '../../../../App/typer/ressurs';
+import { ISøknadData } from '../../../../App/typer/beregningssøknadsdata';
+import { useDataHenter } from '../../../../App/hooks/felles/useDataHenter';
 import { AxiosRequestConfig } from 'axios';
 import styled from 'styled-components';
 import { Heading, Label } from '@navikt/ds-react';
-import { FlexDiv } from '../../Oppgavebenk/OppgaveFiltrering';
+import { FlexDiv } from '../../../Oppgavebenk/OppgaveFiltrering';
 
 const BoldTekst = styled(Label)`
     margin-left: 0.25rem;

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/VedtakOgBeregningOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/VedtakOgBeregningOvergangsstønad.tsx
@@ -1,14 +1,14 @@
 import React, { FC, useEffect, useState } from 'react';
 import styled from 'styled-components';
-import { RessursStatus } from '../../../App/typer/ressurs';
-import DataViewer from '../../../Felles/DataViewer/DataViewer';
-import { EBehandlingResultat } from '../../../App/typer/vedtak';
+import { RessursStatus } from '../../../../App/typer/ressurs';
+import DataViewer from '../../../../Felles/DataViewer/DataViewer';
+import { EBehandlingResultat } from '../../../../App/typer/vedtak';
 import VedtaksresultatSwitch from './VedtaksresultatSwitch';
 import SelectVedtaksresultat from './SelectVedtaksresultat';
-import { Behandling } from '../../../App/typer/fagsak';
-import { useHentVedtak } from '../../../App/hooks/useHentVedtak';
-import { IVilkår } from '../Inngangsvilkår/vilkår';
-import { erAlleVilkårOppfylt, eksistererIkkeOppfyltVilkår } from '../Vilkårresultat/utils';
+import { Behandling } from '../../../../App/typer/fagsak';
+import { useHentVedtak } from '../../../../App/hooks/useHentVedtak';
+import { IVilkår } from '../../Inngangsvilkår/vilkår';
+import { erAlleVilkårOppfylt, eksistererIkkeOppfyltVilkår } from '../../Vilkårresultat/utils';
 
 interface Props {
     behandling: Behandling;

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/VedtaksoppsummeringOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/VedtaksoppsummeringOvergangsstønad.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
-import { IVilkår } from '../Inngangsvilkår/vilkår';
+import { IVilkår } from '../../Inngangsvilkår/vilkår';
 import styled from 'styled-components';
-import { ResultatVisning } from './ResultatVisning';
-import TidligereVedtakOppsummering from './TidligereVedtakOppsummering';
+import { ResultatVisning } from '../../Vilkårresultat/ResultatVisning';
+import TidligereVedtakOppsummering from '../../Vilkårresultat/TidligereVedtakOppsummering';
 import {
     sorterUtAktivitetsVilkår,
     sorterUtInngangsvilkår,
     sorterUtTidligereVedtaksvilkår,
-} from './utils';
-import { Søknadsdatoer } from '../VedtakOgBeregning/Søknadsdatoer';
+} from '../../Vilkårresultat/utils';
+import { Søknadsdatoer } from './Søknadsdatoer';
 import { Heading } from '@navikt/ds-react';
 import navFarger from 'nav-frontend-core';
-import { Behandling } from '../../../App/typer/fagsak';
-import { Behandlingsårsak } from '../../../App/typer/Behandlingsårsak';
-import { useBehandling } from '../../../App/context/BehandlingContext';
+import { Behandling } from '../../../../App/typer/fagsak';
+import { Behandlingsårsak } from '../../../../App/typer/Behandlingsårsak';
+import { useBehandling } from '../../../../App/context/BehandlingContext';
 
 const OppsummeringContainer = styled.div<{ åpenHøyremeny: boolean }>`
     display: flex;
@@ -32,7 +32,7 @@ const Oppsummeringsboks = styled.div`
     background-color: ${navFarger.navGraBakgrunn};
 `;
 
-export const Vedtaksoppsummering: React.FC<{
+export const VedtaksoppsummeringOvergangsstønad: React.FC<{
     vilkår: IVilkår;
     behandling: Behandling;
 }> = ({ vilkår, behandling }) => {

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/VedtaksresultatSwitch.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/VedtaksresultatSwitch.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { EBehandlingResultat, IVedtak } from '../../../App/typer/vedtak';
-import { Behandling } from '../../../App/typer/fagsak';
-import { InnvilgeVedtak } from './InnvilgeVedtak/InnvilgeVedtak';
-import { BehandleIGosys } from './BehandleIGosys/BehandleIGosys';
-import { AvslåVedtak } from './AvslåVedtak/AvslåVedtak';
-import { Opphør } from './Opphør/Opphør';
+import { EBehandlingResultat, IVedtak } from '../../../../App/typer/vedtak';
+import { Behandling } from '../../../../App/typer/fagsak';
+import { InnvilgeVedtak } from '../InnvilgeVedtak/InnvilgeVedtak';
+import { BehandleIGosys } from '../BehandleIGosys/BehandleIGosys';
+import { AvslåVedtak } from '../AvslåVedtak/AvslåVedtak';
+import { Opphør } from '../Opphør/Opphør';
 
 interface Props {
     vedtaksresultatType?: EBehandlingResultat;

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
@@ -3,17 +3,17 @@ import {
     EPeriodetype,
     IInntektsperiode,
     IVedtaksperiode,
-} from '../../../App/typer/vedtak';
+} from '../../../../App/typer/vedtak';
 import {
     erMånedÅrEtter,
     erMånedÅrEtterEllerLik,
     erMånedÅrLik,
     plusMåneder,
     tilÅrMåned,
-} from '../../../App/utils/dato';
-import { InnvilgeVedtakForm } from './InnvilgeVedtak/InnvilgeVedtak';
-import { FormErrors } from '../../../App/hooks/felles/useFormState';
-import { SanksjonereVedtakForm } from '../Sanksjon/Sanksjonsfastsettelse';
+} from '../../../../App/utils/dato';
+import { InnvilgeVedtakForm } from '../InnvilgeVedtak/InnvilgeVedtak';
+import { FormErrors } from '../../../../App/hooks/felles/useFormState';
+import { SanksjonereVedtakForm } from '../../Sanksjon/Sanksjonsfastsettelse';
 
 export const validerInnvilgetVedtakForm = ({
     perioder,

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/VedtakOgBeregningOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/VedtakOgBeregningOvergangsstønad.tsx
@@ -19,7 +19,7 @@ const Wrapper = styled.div`
     padding: 1rem 2rem;
 `;
 
-const VedtakOgBeregning: FC<Props> = ({ behandling, vilkår }) => {
+const VedtakOgBeregningOvergangsstønad: FC<Props> = ({ behandling, vilkår }) => {
     const behandlingId = behandling.id;
     const [resultatType, settResultatType] = useState<EBehandlingResultat>();
     const { vedtak, hentVedtak } = useHentVedtak(behandlingId);
@@ -62,4 +62,4 @@ const VedtakOgBeregning: FC<Props> = ({ behandling, vilkår }) => {
     );
 };
 
-export default VedtakOgBeregning;
+export default VedtakOgBeregningOvergangsstønad;

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/VedtakOgBeregningSide.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/VedtakOgBeregningSide.tsx
@@ -4,15 +4,15 @@ import { Steg } from '../Høyremeny/Steg';
 import { Element } from 'nav-frontend-typografi';
 import styled from 'styled-components';
 import AlertStripe from 'nav-frontend-alertstriper';
-import { Vedtaksoppsummering } from '../Vilkårresultat/Vedtaksoppsummering';
-import VedtakOgBeregningOvergangsstønad from './VedtakOgBeregningOvergangsstønad';
+import { VedtaksoppsummeringOvergangsstønad } from './Overgangsstønad/VedtaksoppsummeringOvergangsstønad';
+import VedtakOgBeregningOvergangsstønad from './Overgangsstønad/VedtakOgBeregningOvergangsstønad';
+import VedtakOgBeregningBarnetilsyn from './Barnetilsyn/VedtakOgBeregningBarnetilsyn';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { useHentVilkår } from '../../../App/hooks/useHentVilkår';
-import { useHentFagsak } from '../../../App/hooks/useHentFagsak';
-import { RessursStatus } from '../../../App/typer/ressurs';
 import { Stønadstype } from '../../../App/typer/behandlingstema';
 import { IVilkår } from '../Inngangsvilkår/vilkår';
 import { Behandling } from '../../../App/typer/fagsak';
+import { VedtaksoppsummeringBarnetilsyn } from './Barnetilsyn/VedtaksoppsummeringBarnetilsyn';
 
 const AlertStripeLeft = styled(AlertStripe)`
     margin-left: 2rem;
@@ -27,19 +27,12 @@ const AlertStripeIkkeFerdigBehandletVilkår = (): JSX.Element => (
 
 export const VedtakOgBeregningSide: FC<{ behandlingId: string }> = ({ behandlingId }) => {
     const { behandling } = useBehandling();
-    const { fagsak } = useHentFagsak();
 
     const { vilkår, hentVilkår } = useHentVilkår();
 
     const hentVilkårCallback = useCallback(() => {
         hentVilkår(behandlingId);
     }, [behandlingId, hentVilkår]);
-
-    useEffect(() => {
-        if (fagsak.status === RessursStatus.SUKSESS) {
-            console.log(fagsak.data.stønadstype);
-        }
-    }, [fagsak]);
 
     useEffect(() => {
         hentVilkårCallback();
@@ -74,7 +67,7 @@ const VedtakOgBeregningSideOvergangsstønad: React.FC<{
 }> = ({ behandling, vilkår }) => {
     return (
         <>
-            <Vedtaksoppsummering vilkår={vilkår} behandling={behandling} />
+            <VedtaksoppsummeringOvergangsstønad vilkår={vilkår} behandling={behandling} />
             {behandling.steg === Steg.VILKÅR ? (
                 <AlertStripeIkkeFerdigBehandletVilkår />
             ) : (
@@ -90,11 +83,11 @@ const VedtakOgBeregningSideBarnetilsyn: React.FC<{
 }> = ({ behandling, vilkår }) => {
     return (
         <>
-            <Vedtaksoppsummering vilkår={vilkår} behandling={behandling} />
+            <VedtaksoppsummeringBarnetilsyn vilkår={vilkår} behandling={behandling} />
             {behandling.steg === Steg.VILKÅR ? (
                 <AlertStripeIkkeFerdigBehandletVilkår />
             ) : (
-                <VedtakOgBeregningOvergangsstønad behandling={behandling} vilkår={vilkår} />
+                <VedtakOgBeregningBarnetilsyn behandling={behandling} vilkår={vilkår} />
             )}
         </>
     );

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/VedtakOgBeregningSide.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/VedtakOgBeregningSide.tsx
@@ -5,9 +5,14 @@ import { Element } from 'nav-frontend-typografi';
 import styled from 'styled-components';
 import AlertStripe from 'nav-frontend-alertstriper';
 import { Vedtaksoppsummering } from '../Vilkårresultat/Vedtaksoppsummering';
-import VedtakOgBeregning from './VedtakOgBeregning';
+import VedtakOgBeregningOvergangsstønad from './VedtakOgBeregningOvergangsstønad';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { useHentVilkår } from '../../../App/hooks/useHentVilkår';
+import { useHentFagsak } from '../../../App/hooks/useHentFagsak';
+import { RessursStatus } from '../../../App/typer/ressurs';
+import { Stønadstype } from '../../../App/typer/behandlingstema';
+import { IVilkår } from '../Inngangsvilkår/vilkår';
+import { Behandling } from '../../../App/typer/fagsak';
 
 const AlertStripeLeft = styled(AlertStripe)`
     margin-left: 2rem;
@@ -22,6 +27,7 @@ const AlertStripeIkkeFerdigBehandletVilkår = (): JSX.Element => (
 
 export const VedtakOgBeregningSide: FC<{ behandlingId: string }> = ({ behandlingId }) => {
     const { behandling } = useBehandling();
+    const { fagsak } = useHentFagsak();
 
     const { vilkår, hentVilkår } = useHentVilkår();
 
@@ -30,23 +36,66 @@ export const VedtakOgBeregningSide: FC<{ behandlingId: string }> = ({ behandling
     }, [behandlingId, hentVilkår]);
 
     useEffect(() => {
+        if (fagsak.status === RessursStatus.SUKSESS) {
+            console.log(fagsak.data.stønadstype);
+        }
+    }, [fagsak]);
+
+    useEffect(() => {
         hentVilkårCallback();
     }, [hentVilkårCallback]);
-
     return (
         <DataViewer response={{ behandling, vilkår }}>
             {({ behandling, vilkår }) => {
-                return (
-                    <>
-                        <Vedtaksoppsummering vilkår={vilkår} behandling={behandling} />
-                        {behandling.steg === Steg.VILKÅR ? (
-                            <AlertStripeIkkeFerdigBehandletVilkår />
-                        ) : (
-                            <VedtakOgBeregning behandling={behandling} vilkår={vilkår} />
-                        )}
-                    </>
-                );
+                switch (behandling.stønadstype) {
+                    case Stønadstype.OVERGANGSSTØNAD:
+                        return (
+                            <VedtakOgBeregningSideOvergangsstønad
+                                behandling={behandling}
+                                vilkår={vilkår}
+                            />
+                        );
+                    case Stønadstype.BARNETILSYN:
+                        return (
+                            <VedtakOgBeregningSideBarnetilsyn
+                                behandling={behandling}
+                                vilkår={vilkår}
+                            />
+                        );
+                }
             }}
         </DataViewer>
+    );
+};
+
+const VedtakOgBeregningSideOvergangsstønad: React.FC<{
+    behandling: Behandling;
+    vilkår: IVilkår;
+}> = ({ behandling, vilkår }) => {
+    return (
+        <>
+            <Vedtaksoppsummering vilkår={vilkår} behandling={behandling} />
+            {behandling.steg === Steg.VILKÅR ? (
+                <AlertStripeIkkeFerdigBehandletVilkår />
+            ) : (
+                <VedtakOgBeregningOvergangsstønad behandling={behandling} vilkår={vilkår} />
+            )}
+        </>
+    );
+};
+
+const VedtakOgBeregningSideBarnetilsyn: React.FC<{
+    behandling: Behandling;
+    vilkår: IVilkår;
+}> = ({ behandling, vilkår }) => {
+    return (
+        <>
+            <Vedtaksoppsummering vilkår={vilkår} behandling={behandling} />
+            {behandling.steg === Steg.VILKÅR ? (
+                <AlertStripeIkkeFerdigBehandletVilkår />
+            ) : (
+                <VedtakOgBeregningOvergangsstønad behandling={behandling} vilkår={vilkår} />
+            )}
+        </>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Vilkårresultat/ResultatVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Vilkårresultat/ResultatVisning.tsx
@@ -64,9 +64,9 @@ export const ResultatVisning: React.FC<{
             {Object.entries(oppsummeringAvVilkårsresultat)
                 .sort(sorterVilkårsresultat)
                 .map(([vilkårsresultat, antallVilkårsresultat], i) => (
-                    <ResultatGrid>
+                    <ResultatGrid key={i}>
                         <BoldTekst size="small">{i == 0 ? tittel : ''}</BoldTekst>
-                        <ResultatIkonOgTekstWrapper key={i}>
+                        <ResultatIkonOgTekstWrapper>
                             <VilkårsresultatIkon
                                 vilkårsresultat={vilkårsresultat as Vilkårsresultat}
                             />

--- a/src/frontend/Komponenter/Behandling/Vilkårresultat/TidligereVedtakOppsummering.tsx
+++ b/src/frontend/Komponenter/Behandling/Vilkårresultat/TidligereVedtakOppsummering.tsx
@@ -35,11 +35,11 @@ const TidligereVedtakOppsummering: React.FC<Props> = ({ tidligereVedtaksvilkår 
             <Heading spacing size="small" level="5">
                 Tidligere vedtaksperioder
             </Heading>
-            {tidligereVedtaksvilkår.map((vurdering) => {
+            {tidligereVedtaksvilkår.map((vurdering, index) => {
                 return vurdering.delvilkårsvurderinger.map((delvilkår) => {
                     return delvilkår.vurderinger.map((vurdering) => {
                         return (
-                            <Container>
+                            <Container key={index}>
                                 <Label size="small">
                                     {delvilkårTypeTilTekst[vurdering.regelId]}
                                 </Label>


### PR DESCRIPTION
Denne PRen viser vedtak-og-beregningside basert på stønadstypen. Stønadstypen blir lagt til på behandling i [denne PRen.](https://github.com/navikt/familie-ef-sak/pull/1244) (Kan hende dette endres - avhengig av feedback).

Filer flyttes også inn i mapper basert på stønadstype.