### PR TITLE
Fiks sticky fanemeny

### DIFF
--- a/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
@@ -49,7 +49,7 @@ const InnholdWrapper = styled.div<InnholdWrapperProps>`
 
     overflow-x: scroll;
 
-    min-height: 90vh;
+    height: 90vh;
 
     max-width: ${(p) => (p.åpenHøyremeny ? 'calc(100% - 20rem)' : '100%')};
 `;


### PR DESCRIPTION
For at fanemenyen skal være sticky, må foreldrekomponenten ha satt en
eksplisitt høyde når man har satt overflow: scroll.