### PR TITLE
Vedtak og beregning barnetilsyn kontantstøtte

### DIFF
--- a/src/frontend/App/typer/vedtak.ts
+++ b/src/frontend/App/typer/vedtak.ts
@@ -1,4 +1,3 @@
-import { PeriodeVariant } from '../../Felles/Input/MånedÅr/MånedÅrPeriode';
 import { Sanksjonsårsak } from './Sanksjonsårsak';
 
 export type IAvslåVedtakForOvergangsstønad = {
@@ -154,39 +153,6 @@ export const årsakerTilAvslag: EAvslagÅrsak[] = [
     EAvslagÅrsak.MANGLENDE_OPPLYSNINGER,
     EAvslagÅrsak.STØNADSTID_OPPBRUKT,
 ];
-
-export const periodeVariantTilVedtaksperiodeProperty = (
-    periodeVariant: PeriodeVariant
-): EVedtaksperiodeProperty => {
-    switch (periodeVariant) {
-        case PeriodeVariant.ÅR_MÅNED_FRA:
-            return EVedtaksperiodeProperty.årMånedFra;
-        case PeriodeVariant.ÅR_MÅNED_TIL:
-            return EVedtaksperiodeProperty.årMånedTil;
-    }
-};
-
-export const periodeVariantTilUtgiftsperiodeProperty = (
-    periodeVariant: PeriodeVariant
-): EUtgiftsperiodeProperty => {
-    switch (periodeVariant) {
-        case PeriodeVariant.ÅR_MÅNED_FRA:
-            return EUtgiftsperiodeProperty.årMånedFra;
-        case PeriodeVariant.ÅR_MÅNED_TIL:
-            return EUtgiftsperiodeProperty.årMånedTil;
-    }
-};
-
-export const periodeVariantTilKontantstøtteperiodeProperty = (
-    periodeVariant: PeriodeVariant
-): EKontantstøttePeriodeProperty => {
-    switch (periodeVariant) {
-        case PeriodeVariant.ÅR_MÅNED_FRA:
-            return EKontantstøttePeriodeProperty.årMånedFra;
-        case PeriodeVariant.ÅR_MÅNED_TIL:
-            return EKontantstøttePeriodeProperty.årMånedTil;
-    }
-};
 
 export enum EAktivitet {
     IKKE_AKTIVITETSPLIKT = 'IKKE_AKTIVITETSPLIKT',

--- a/src/frontend/App/typer/vedtak.ts
+++ b/src/frontend/App/typer/vedtak.ts
@@ -1,6 +1,5 @@
 import { PeriodeVariant } from '../../Felles/Input/MånedÅr/MånedÅrPeriode';
 import { Sanksjonsårsak } from './Sanksjonsårsak';
-import { Stønadstype } from './behandlingstema';
 
 export type IAvslåVedtakForOvergangsstønad = {
     resultatType: EBehandlingResultat.AVSLÅ;
@@ -35,6 +34,7 @@ export type IInnvilgeVedtakForOvergangsstønad = {
 export type IInnvilgeVedtakForBarnetilsyn = {
     resultatType: EBehandlingResultat.INNVILGE;
     utgiftsperioder: IUtgiftsperiode[];
+    kontantstøtteperioder: IKontantstøttePeriode[];
 };
 
 export type IUtgiftsperiode = {
@@ -42,6 +42,12 @@ export type IUtgiftsperiode = {
     årMånedTil: string;
     barn: string[] | undefined; // TODO: oppdater til riktig type for barn
     utgifter: number | undefined;
+};
+
+export type IKontantstøttePeriode = {
+    årMånedFra: string;
+    årMånedTil: string;
+    beløp: number | undefined;
 };
 
 export type ISanksjonereVedtakForOvergangsstønad = {
@@ -130,6 +136,12 @@ export enum EUtgiftsperiodeProperty {
     utgifter = 'utgifter',
 }
 
+export enum EKontantstøttePeriodeProperty {
+    årMånedFra = 'årMånedFra',
+    årMånedTil = 'årMånedTil',
+    beløp = 'beløp',
+}
+
 export enum EAvslagÅrsak {
     VILKÅR_IKKE_OPPFYLT = 'VILKÅR_IKKE_OPPFYLT',
     BARN_OVER_ÅTTE_ÅR = 'BARN_OVER_ÅTTE_ÅR',
@@ -143,23 +155,36 @@ export const årsakerTilAvslag: EAvslagÅrsak[] = [
     EAvslagÅrsak.STØNADSTID_OPPBRUKT,
 ];
 
-export const periodeVariantTilProperty = (
-    periodeVariant: PeriodeVariant,
-    stønadstype: Stønadstype
-): EVedtaksperiodeProperty | EUtgiftsperiodeProperty => {
-    if (stønadstype === Stønadstype.OVERGANGSSTØNAD) {
-        switch (periodeVariant) {
-            case PeriodeVariant.ÅR_MÅNED_FRA:
-                return EVedtaksperiodeProperty.årMånedFra;
-            case PeriodeVariant.ÅR_MÅNED_TIL:
-                return EVedtaksperiodeProperty.årMånedTil;
-        }
+export const periodeVariantTilVedtaksperiodeProperty = (
+    periodeVariant: PeriodeVariant
+): EVedtaksperiodeProperty => {
+    switch (periodeVariant) {
+        case PeriodeVariant.ÅR_MÅNED_FRA:
+            return EVedtaksperiodeProperty.årMånedFra;
+        case PeriodeVariant.ÅR_MÅNED_TIL:
+            return EVedtaksperiodeProperty.årMånedTil;
     }
+};
+
+export const periodeVariantTilUtgiftsperiodeProperty = (
+    periodeVariant: PeriodeVariant
+): EUtgiftsperiodeProperty => {
     switch (periodeVariant) {
         case PeriodeVariant.ÅR_MÅNED_FRA:
             return EUtgiftsperiodeProperty.årMånedFra;
         case PeriodeVariant.ÅR_MÅNED_TIL:
             return EUtgiftsperiodeProperty.årMånedTil;
+    }
+};
+
+export const periodeVariantTilKontantstøtteperiodeProperty = (
+    periodeVariant: PeriodeVariant
+): EKontantstøttePeriodeProperty => {
+    switch (periodeVariant) {
+        case PeriodeVariant.ÅR_MÅNED_FRA:
+            return EKontantstøttePeriodeProperty.årMånedFra;
+        case PeriodeVariant.ÅR_MÅNED_TIL:
+            return EKontantstøttePeriodeProperty.årMånedTil;
     }
 };
 

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/KontantstøtteValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/KontantstøtteValg.tsx
@@ -4,12 +4,8 @@ import styled from 'styled-components';
 import { useBehandling } from '../../../../App/context/BehandlingContext';
 import { Element } from 'nav-frontend-typografi';
 import { VEDTAK_OG_BEREGNING } from '../konstanter';
-import {
-    EKontantstøttePeriodeProperty,
-    IKontantstøttePeriode,
-    periodeVariantTilKontantstøtteperiodeProperty,
-} from '../../../../App/typer/vedtak';
-import MånedÅrPeriode from '../../../../Felles/Input/MånedÅr/MånedÅrPeriode';
+import { EKontantstøttePeriodeProperty, IKontantstøttePeriode } from '../../../../App/typer/vedtak';
+import MånedÅrPeriode, { PeriodeVariant } from '../../../../Felles/Input/MånedÅr/MånedÅrPeriode';
 import { ListState } from '../../../../App/hooks/felles/useListState';
 import { useApp } from '../../../../App/context/AppContext';
 import { FormErrors } from '../../../../App/hooks/felles/useFormState';
@@ -75,6 +71,17 @@ const KontantstøtteValg: React.FC<Props> = ({
             index
         );
         settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
+    };
+
+    const periodeVariantTilKontantstøtteperiodeProperty = (
+        periodeVariant: PeriodeVariant
+    ): EKontantstøttePeriodeProperty => {
+        switch (periodeVariant) {
+            case PeriodeVariant.ÅR_MÅNED_FRA:
+                return EKontantstøttePeriodeProperty.årMånedFra;
+            case PeriodeVariant.ÅR_MÅNED_TIL:
+                return EKontantstøttePeriodeProperty.årMånedTil;
+        }
     };
 
     return (

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/KontantstøtteValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/KontantstøtteValg.tsx
@@ -1,0 +1,176 @@
+import React, { Dispatch, SetStateAction, useState } from 'react';
+import { Radio, RadioGruppe } from 'nav-frontend-skjema';
+import styled from 'styled-components';
+import { useBehandling } from '../../../../App/context/BehandlingContext';
+import { Element } from 'nav-frontend-typografi';
+import { VEDTAK_OG_BEREGNING } from '../konstanter';
+import {
+    EKontantstøttePeriodeProperty,
+    IKontantstøttePeriode,
+    periodeVariantTilKontantstøtteperiodeProperty,
+} from '../../../../App/typer/vedtak';
+import MånedÅrPeriode from '../../../../Felles/Input/MånedÅr/MånedÅrPeriode';
+import { ListState } from '../../../../App/hooks/felles/useListState';
+import { useApp } from '../../../../App/context/AppContext';
+import { FormErrors } from '../../../../App/hooks/felles/useFormState';
+import { InnvilgeVedtakForm } from './Vedtaksform';
+import FjernKnapp from '../../../../Felles/Knapper/FjernKnapp';
+import InputMedTusenSkille from '../../../../Felles/Visningskomponenter/InputMedTusenskille';
+import { harTallverdi, tilTallverdi } from '../../../../App/utils/utils';
+import LeggTilKnapp from '../../../../Felles/Knapper/LeggTilKnapp';
+
+const KontantstøttePeriodeContainer = styled.div<{ lesevisning?: boolean }>`
+    display: grid;
+    grid-template-areas: 'fraOgMedVelger tilOgMedVelger kontantstøtte slettKnapp';
+    grid-template-columns: ${(props) =>
+        props.lesevisning ? '8rem 10rem 7rem 7rem 7rem' : '12rem 12rem 6rem 4rem'};
+    grid-gap: ${(props) => (props.lesevisning ? '0.5rem' : '1rem')};
+    margin-bottom: 0.75rem;
+`;
+
+const KolonneHeaderWrapper = styled.div<{ lesevisning?: boolean }>`
+    display: grid;
+    grid-template-areas: 'fraOgMedVelger tilOgMedVelger kontantstøtte';
+    grid-template-columns: ${(props) =>
+        props.lesevisning ? '8rem 10rem 7rem' : '12rem 12rem 6rem'};
+    grid-gap: ${(props) => (props.lesevisning ? '0.5rem' : '1rem')};
+    margin-bottom: 0.5rem;
+`;
+
+const StyledInput = styled(InputMedTusenSkille)`
+    text-align: left;
+`;
+
+interface Props {
+    kontantstøttePerioder: ListState<IKontantstøttePeriode>;
+    valideringsfeil?: FormErrors<InnvilgeVedtakForm>['kontantstøtteperioder'];
+    settValideringsFeil: Dispatch<SetStateAction<FormErrors<InnvilgeVedtakForm>>>;
+}
+
+export const tomKontantstøtteRad: IKontantstøttePeriode = {
+    årMånedFra: '',
+    årMånedTil: '',
+    beløp: undefined,
+};
+
+const KontantstøtteValg: React.FC<Props> = ({
+    kontantstøttePerioder,
+    valideringsfeil,
+    settValideringsFeil,
+}) => {
+    const { behandlingErRedigerbar } = useBehandling();
+    const { settIkkePersistertKomponent } = useApp();
+    const [kontantstøtte, settKontantstøtte] = useState(false);
+
+    const oppdaterKontantstøttePeriode = (
+        index: number,
+        property: EKontantstøttePeriodeProperty,
+        value: string | string[] | number | undefined
+    ) => {
+        kontantstøttePerioder.update(
+            {
+                ...kontantstøttePerioder.value[index],
+                [property]: value,
+            },
+            index
+        );
+        settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
+    };
+
+    return (
+        <>
+            <RadioGruppe legend="Er det søkt om, utbetales det eller har det blitt utbetalt kontantstøtte til brukeren eller en brukeren bor med?">
+                <Radio
+                    name={'Kontantstøtte'}
+                    label={'Ja'}
+                    value={'Ja'}
+                    onChange={() => settKontantstøtte(!kontantstøtte)}
+                />
+                <Radio
+                    name={'Kontantstøtte'}
+                    label={'Nei'}
+                    value={'Nei'}
+                    checked={!kontantstøtte}
+                    onChange={() => settKontantstøtte(!kontantstøtte)}
+                />
+            </RadioGruppe>
+            {kontantstøtte && (
+                <>
+                    <KolonneHeaderWrapper lesevisning={!behandlingErRedigerbar}>
+                        <Element>Periode fra og med</Element>
+                        <Element>Periode til og med</Element>
+                        <Element>Kontantstøtte</Element>
+                    </KolonneHeaderWrapper>
+                    {kontantstøttePerioder.value.map((periode, index) => {
+                        const { årMånedFra, årMånedTil, beløp } = periode;
+                        const skalViseFjernKnapp =
+                            behandlingErRedigerbar &&
+                            index === kontantstøttePerioder.value.length - 1 &&
+                            index !== 0;
+                        return (
+                            <>
+                                <KontantstøttePeriodeContainer>
+                                    <MånedÅrPeriode
+                                        årMånedFraInitiell={årMånedFra}
+                                        årMånedTilInitiell={årMånedTil}
+                                        index={index}
+                                        onEndre={(verdi, periodeVariant) => {
+                                            settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
+                                            oppdaterKontantstøttePeriode(
+                                                index,
+                                                periodeVariantTilKontantstøtteperiodeProperty(
+                                                    periodeVariant
+                                                ),
+                                                verdi
+                                            );
+                                        }}
+                                        feilmelding={
+                                            valideringsfeil && valideringsfeil[index]?.årMånedFra
+                                        }
+                                        erLesevisning={!behandlingErRedigerbar}
+                                    />
+                                    <StyledInput
+                                        type="number"
+                                        value={harTallverdi(beløp) ? beløp : ''}
+                                        onChange={(e) => {
+                                            settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
+                                            oppdaterKontantstøttePeriode(
+                                                index,
+                                                EKontantstøttePeriodeProperty.beløp,
+                                                tilTallverdi(e.target.value)
+                                            );
+                                        }}
+                                        erLesevisning={!behandlingErRedigerbar}
+                                    />
+                                    {skalViseFjernKnapp && (
+                                        <FjernKnapp
+                                            onClick={() => {
+                                                kontantstøttePerioder.remove(index);
+                                                settValideringsFeil(
+                                                    (prevState: FormErrors<InnvilgeVedtakForm>) => {
+                                                        const perioder = (
+                                                            prevState.kontantstøtteperioder ?? []
+                                                        ).filter((_, i) => i !== index);
+                                                        return { ...prevState, perioder };
+                                                    }
+                                                );
+                                            }}
+                                            knappetekst="Fjern kontantstøtteperiode"
+                                        />
+                                    )}
+                                </KontantstøttePeriodeContainer>
+                            </>
+                        );
+                    })}
+                    <LeggTilKnapp
+                        onClick={() => kontantstøttePerioder.push(tomKontantstøtteRad)}
+                        knappetekst="Legg til periode"
+                        hidden={!behandlingErRedigerbar}
+                    />
+                </>
+            )}
+        </>
+    );
+};
+
+export default KontantstøtteValg;

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtgiftsperiodeValg.tsx
@@ -1,7 +1,7 @@
 import {
     EUtgiftsperiodeProperty,
     IUtgiftsperiode,
-    periodeVariantTilProperty,
+    periodeVariantTilUtgiftsperiodeProperty,
 } from '../../../../App/typer/vedtak';
 import MånedÅrPeriode from '../../../../Felles/Input/MånedÅr/MånedÅrPeriode';
 import React, { Dispatch, SetStateAction } from 'react';
@@ -18,7 +18,6 @@ import { useApp } from '../../../../App/context/AppContext';
 import { FamilieReactSelect, ISelectOption } from '@navikt/familie-form-elements';
 import { harTallverdi, tilTallverdi } from '../../../../App/utils/utils';
 import InputMedTusenSkille from '../../../../Felles/Visningskomponenter/InputMedTusenskille';
-import { Stønadstype } from '../../../../App/typer/behandlingstema';
 import { barnFormatertForBarnVelger, mapValgtBarnTilNavn } from './mockData';
 
 const UtgiftsperiodeContainer = styled.div<{ lesevisning?: boolean }>`
@@ -104,10 +103,7 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
                                 settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
                                 oppdaterUtgiftsPeriode(
                                     index,
-                                    periodeVariantTilProperty(
-                                        periodeVariant,
-                                        Stønadstype.BARNETILSYN
-                                    ) as EUtgiftsperiodeProperty,
+                                    periodeVariantTilUtgiftsperiodeProperty(periodeVariant),
                                     verdi
                                 );
                             }}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtgiftsperiodeValg.tsx
@@ -33,6 +33,11 @@ const KolonneHeaderWrapper = styled.div<{ lesevisning?: boolean }>`
     margin-bottom: 0.5rem;
 `;
 
+const AntallBarn = styled(Element)<{ lesevisning: boolean }>`
+    margin-top: ${(props) => (props.lesevisning ? '0.65rem' : '0rem')};
+    text-align: center;
+`;
+
 const StyledInput = styled(InputMedTusenSkille)`
     text-align: left;
 `;
@@ -134,11 +139,11 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
                                 );
                             }}
                         />
-                        <Element style={{ marginTop: behandlingErRedigerbar ? '0.65rem' : 0 }}>{`${
+                        <AntallBarn lesevisning={behandlingErRedigerbar}>{`${
                             utgiftsperioder.value[index].barn
                                 ? utgiftsperioder.value[index].barn?.length
                                 : 0
-                        }`}</Element>
+                        }`}</AntallBarn>
                         <StyledInput
                             type="number"
                             value={harTallverdi(utgifter) ? utgifter : ''}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtgiftsperiodeValg.tsx
@@ -1,9 +1,5 @@
-import {
-    EUtgiftsperiodeProperty,
-    IUtgiftsperiode,
-    periodeVariantTilUtgiftsperiodeProperty,
-} from '../../../../App/typer/vedtak';
-import MånedÅrPeriode from '../../../../Felles/Input/MånedÅr/MånedÅrPeriode';
+import { EUtgiftsperiodeProperty, IUtgiftsperiode } from '../../../../App/typer/vedtak';
+import MånedÅrPeriode, { PeriodeVariant } from '../../../../Felles/Input/MånedÅr/MånedÅrPeriode';
 import React, { Dispatch, SetStateAction } from 'react';
 import styled from 'styled-components';
 import { useBehandling } from '../../../../App/context/BehandlingContext';
@@ -75,6 +71,17 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
             index
         );
         settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
+    };
+
+    const periodeVariantTilUtgiftsperiodeProperty = (
+        periodeVariant: PeriodeVariant
+    ): EUtgiftsperiodeProperty => {
+        switch (periodeVariant) {
+            case PeriodeVariant.ÅR_MÅNED_FRA:
+                return EUtgiftsperiodeProperty.årMånedFra;
+            case PeriodeVariant.ÅR_MÅNED_TIL:
+                return EUtgiftsperiodeProperty.årMånedTil;
+        }
     };
 
     return (

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/Vedtaksform.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/Vedtaksform.tsx
@@ -1,6 +1,7 @@
 import {
     EBehandlingResultat,
     IInnvilgeVedtakForBarnetilsyn,
+    IKontantstøttePeriode,
     IUtgiftsperiode,
     IvedtakForBarnetilsyn,
 } from '../../../../App/typer/vedtak';
@@ -14,11 +15,16 @@ import { useBehandling } from '../../../../App/context/BehandlingContext';
 import styled from 'styled-components';
 import { Button, Heading } from '@navikt/ds-react';
 import UtgiftsperiodeValg, { tomUtgiftsperiodeRad } from './UtgiftsperiodeValg';
+import KontantstøtteValg, { tomKontantstøtteRad } from './KontantstøtteValg';
 
 export type InnvilgeVedtakForm = Omit<IInnvilgeVedtakForBarnetilsyn, 'resultatType'>;
 
 const WrapperDobbelMarginTop = styled.div`
     margin-top: 2rem;
+`;
+
+const WrapperMarginTop = styled.div`
+    margin-top: 1rem;
 `;
 
 export const Vedtaksform: React.FC<{
@@ -38,10 +44,16 @@ export const Vedtaksform: React.FC<{
             utgiftsperioder: lagretInnvilgetVedtak
                 ? lagretInnvilgetVedtak.utgiftsperioder
                 : [tomUtgiftsperiodeRad],
+            kontantstøtteperioder: lagretInnvilgetVedtak
+                ? lagretInnvilgetVedtak.kontantstøtteperioder
+                : [tomKontantstøtteRad],
         },
         validerInnvilgetVedtakForm
     );
     const utgiftsperiodeState = formState.getProps('utgiftsperioder') as ListState<IUtgiftsperiode>;
+    const kontantstøtteState = formState.getProps(
+        'kontantstøtteperioder'
+    ) as ListState<IKontantstøttePeriode>;
 
     const lagreVedtak = (vedtaksRequest: IInnvilgeVedtakForBarnetilsyn) => {
         settLaster(true);
@@ -53,6 +65,7 @@ export const Vedtaksform: React.FC<{
         const vedtaksRequest: IInnvilgeVedtakForBarnetilsyn = {
             resultatType: EBehandlingResultat.INNVILGE,
             utgiftsperioder: form.utgiftsperioder,
+            kontantstøtteperioder: form.kontantstøtteperioder,
         };
         lagreVedtak(vedtaksRequest);
     };
@@ -67,6 +80,16 @@ export const Vedtaksform: React.FC<{
                 valideringsfeil={formState.errors.utgiftsperioder}
                 settValideringsFeil={formState.setErrors}
             />
+            <WrapperMarginTop>
+                <Heading spacing size="small" level="5">
+                    Kontantstøtte
+                </Heading>
+                <KontantstøtteValg
+                    kontantstøttePerioder={kontantstøtteState}
+                    valideringsfeil={formState.errors.kontantstøtteperioder}
+                    settValideringsFeil={formState.setErrors}
+                />
+            </WrapperMarginTop>
             {feilmelding && (
                 <AlertStripeFeilPreWrap style={{ marginTop: '2rem' }}>
                     {feilmelding}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/InnvilgeVedtak/VedtaksperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/InnvilgeVedtak/VedtaksperiodeValg.tsx
@@ -3,7 +3,7 @@ import {
     EPeriodetype,
     EVedtaksperiodeProperty,
     IVedtaksperiode,
-    periodeVariantTilProperty,
+    periodeVariantTilVedtaksperiodeProperty,
 } from '../../../../App/typer/vedtak';
 import AktivitetspliktVelger from './AktivitetspliktVelger';
 import MånedÅrPeriode from '../../../../Felles/Input/MånedÅr/MånedÅrPeriode';
@@ -20,7 +20,6 @@ import { FormErrors } from '../../../../App/hooks/felles/useFormState';
 import { InnvilgeVedtakForm } from './InnvilgeVedtak';
 import { VEDTAK_OG_BEREGNING } from '../konstanter';
 import { useApp } from '../../../../App/context/AppContext';
-import { Stønadstype } from '../../../../App/typer/behandlingstema';
 
 const VedtakPeriodeContainer = styled.div<{ lesevisning?: boolean }>`
     display: grid;
@@ -129,10 +128,7 @@ const VedtaksperiodeValg: React.FC<Props> = ({
                             onEndre={(verdi, periodeVariant) => {
                                 oppdaterVedtakslisteElement(
                                     index,
-                                    periodeVariantTilProperty(
-                                        periodeVariant,
-                                        Stønadstype.OVERGANGSSTØNAD
-                                    ) as EVedtaksperiodeProperty,
+                                    periodeVariantTilVedtaksperiodeProperty(periodeVariant),
                                     verdi
                                 );
                             }}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/InnvilgeVedtak/VedtaksperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/InnvilgeVedtak/VedtaksperiodeValg.tsx
@@ -3,10 +3,9 @@ import {
     EPeriodetype,
     EVedtaksperiodeProperty,
     IVedtaksperiode,
-    periodeVariantTilVedtaksperiodeProperty,
 } from '../../../../App/typer/vedtak';
 import AktivitetspliktVelger from './AktivitetspliktVelger';
-import MånedÅrPeriode from '../../../../Felles/Input/MånedÅr/MånedÅrPeriode';
+import MånedÅrPeriode, { PeriodeVariant } from '../../../../Felles/Input/MånedÅr/MånedÅrPeriode';
 import React, { Dispatch, SetStateAction } from 'react';
 import styled from 'styled-components';
 import { useBehandling } from '../../../../App/context/BehandlingContext';
@@ -84,6 +83,17 @@ const VedtaksperiodeValg: React.FC<Props> = ({
             index
         );
         settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
+    };
+
+    const periodeVariantTilVedtaksperiodeProperty = (
+        periodeVariant: PeriodeVariant
+    ): EVedtaksperiodeProperty => {
+        switch (periodeVariant) {
+            case PeriodeVariant.ÅR_MÅNED_FRA:
+                return EVedtaksperiodeProperty.årMånedFra;
+            case PeriodeVariant.ÅR_MÅNED_TIL:
+                return EVedtaksperiodeProperty.årMånedTil;
+        }
     };
 
     return (


### PR DESCRIPTION
Denne PRen implementerer funksjonalitet for å registrere om det er utbetalt eller søkt om kontantstøtte i vedtak-og-beregningsiden. [Skisser](https://www.figma.com/file/JEmXg4WqG0DFItNGpoX696/Skisser-EF-sak?node-id=6862%3A157210)

Bilder:
![Skjermbilde 2022-03-10 kl  15 10 59](https://user-images.githubusercontent.com/32769446/157679583-8db7bd1a-2db6-41b4-850d-dee2e6141a15.png)
![Skjermbilde 2022-03-10 kl  15 11 08](https://user-images.githubusercontent.com/32769446/157679599-7a1e5c5a-b34d-45f5-84c3-6929b6a97b7e.png)
![Skjermbilde 2022-03-10 kl  15 11 32](https://user-images.githubusercontent.com/32769446/157679609-17d1b814-5cb3-428d-8c3f-e85d07503899.png)

