### PR TITLE
Sikre at man ikke validerer barnetogglen når man ikke har nye barn

### DIFF
--- a/src/frontend/Komponenter/Personoversikt/Revurdering/LagRevurdering.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Revurdering/LagRevurdering.tsx
@@ -149,6 +149,8 @@ export const LagRevurdering: React.FunctionComponent<IProps> = ({
                                                 valgtBehandlingsårsak &&
                                                 valgtDato &&
                                                 !(
+                                                    harNyeBarnSidenForrigeBehandling &&
+                                                    kanLeggeTilNyeBarnPåRevurdering &&
                                                     måTaStillingTilBarn &&
                                                     vilkårsbehandleVedMigrering ===
                                                         EVilkårsbehandleBarnValg.IKKE_VALGT


### PR DESCRIPTION
Ref [denne feilen](https://nav-it.slack.com/archives/C01087QRJ2U/p1649402140556929).