### PR TITLE
Bare tillat heltall

### DIFF
--- a/src/frontend/App/utils/utils.ts
+++ b/src/frontend/App/utils/utils.ts
@@ -1,3 +1,4 @@
+import { KeyboardEvent } from 'react';
 import { OrNothing } from '../hooks/felles/useSorteringState';
 import { isAfter, isBefore } from 'date-fns';
 import { IOppgaveRequest } from '../../Komponenter/Oppgavebenk/typer/oppgaverequest';
@@ -76,6 +77,12 @@ export const tilTallverdi = (verdi: number | string | undefined): number | strin
         return verdi;
     }
     return Number(verdi);
+};
+
+export const tilHeltall = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (!/[0-9]/.test(event.key)) {
+        event.preventDefault();
+    }
 };
 
 export const range = (start: number, end: number): number[] =>

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/KontantstøtteValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/KontantstøtteValg.tsx
@@ -17,7 +17,7 @@ import { FormErrors } from '../../../../App/hooks/felles/useFormState';
 import { InnvilgeVedtakForm } from './Vedtaksform';
 import FjernKnapp from '../../../../Felles/Knapper/FjernKnapp';
 import InputMedTusenSkille from '../../../../Felles/Visningskomponenter/InputMedTusenskille';
-import { harTallverdi, tilTallverdi } from '../../../../App/utils/utils';
+import { harTallverdi, tilHeltall, tilTallverdi } from '../../../../App/utils/utils';
 import LeggTilKnapp from '../../../../Felles/Knapper/LeggTilKnapp';
 import { FieldState } from '../../../../App/hooks/felles/useFieldState';
 import { FamilieRadioGruppe } from '@navikt/familie-form-elements';
@@ -153,6 +153,7 @@ const KontantstøtteValg: React.FC<Props> = ({
                                     />
                                     <StyledInput
                                         type="number"
+                                        onKeyPress={tilHeltall}
                                         value={harTallverdi(beløp) ? beløp : ''}
                                         onChange={(e) => {
                                             settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/Tilleggsstønadsvalg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/Tilleggsstønadsvalg.tsx
@@ -17,7 +17,7 @@ import { FormErrors } from '../../../../App/hooks/felles/useFormState';
 import { InnvilgeVedtakForm } from './Vedtaksform';
 import FjernKnapp from '../../../../Felles/Knapper/FjernKnapp';
 import InputMedTusenSkille from '../../../../Felles/Visningskomponenter/InputMedTusenskille';
-import { harTallverdi, tilTallverdi } from '../../../../App/utils/utils';
+import { harTallverdi, tilHeltall, tilTallverdi } from '../../../../App/utils/utils';
 import LeggTilKnapp from '../../../../Felles/Knapper/LeggTilKnapp';
 import { FieldState } from '../../../../App/hooks/felles/useFieldState';
 import { EnsligTextArea } from '../../../../Felles/Input/TekstInput/EnsligTextArea';
@@ -188,6 +188,7 @@ const TilleggsstønadValg: React.FC<Props> = ({
                                     />
                                     <StyledInput
                                         type="number"
+                                        onKeyPress={tilHeltall}
                                         value={harTallverdi(beløp) ? beløp : ''}
                                         onChange={(e) => {
                                             settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtgiftsperiodeValg.tsx
@@ -12,7 +12,7 @@ import { InnvilgeVedtakForm } from './Vedtaksform';
 import { VEDTAK_OG_BEREGNING } from '../Felles/konstanter';
 import { useApp } from '../../../../App/context/AppContext';
 import { FamilieReactSelect, ISelectOption } from '@navikt/familie-form-elements';
-import { harTallverdi, tilTallverdi } from '../../../../App/utils/utils';
+import { harTallverdi, tilTallverdi, tilHeltall } from '../../../../App/utils/utils';
 import InputMedTusenSkille from '../../../../Felles/Visningskomponenter/InputMedTusenskille';
 import { IBarnMedSamvær } from '../../Inngangsvilkår/Aleneomsorg/typer';
 import { datoTilAlder } from '../../../../App/utils/dato';
@@ -145,6 +145,7 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
                                 : 0
                         }`}</AntallBarn>
                         <StyledInput
+                            onKeyPress={tilHeltall}
                             type="number"
                             value={harTallverdi(utgifter) ? utgifter : ''}
                             onChange={(e) => {


### PR DESCRIPTION
Hindrer at man skriver inn noe annet enn heltall for utgifter, kontantstøtte og stønadsreduksjon. Om man skriver noe annet enn tall, dukker det ikke opp noe i inputfeltet. [Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8481).