### PR TITLE
dersom beregnet beløp for satsjustering er shøyere enn det maksimale …

### DIFF
--- a/src/frontend/App/typer/vedtak.ts
+++ b/src/frontend/App/typer/vedtak.ts
@@ -26,6 +26,7 @@ export interface IBeløpsperiode {
 export interface IBeregningsperiodeBarnetilsyn {
     periode: { fradato: string; tildato: string };
     beløp: number;
+    beløpFørSatsjustering: number;
     beregningsgrunnlag: IBeregningsgrunnlagBarnetilsyn;
 }
 

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtregnignstabellBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtregnignstabellBarnetilsyn.tsx
@@ -2,18 +2,19 @@ import React from 'react';
 import { IBeregningsperiodeBarnetilsyn } from '../../../../App/typer/vedtak';
 import { Ressurs } from '../../../../App/typer/ressurs';
 import DataViewer from '../../../../Felles/DataViewer/DataViewer';
-import { Heading } from '@navikt/ds-react';
+import { Heading, HelpText } from '@navikt/ds-react';
 import styled from 'styled-components';
 import { Element, Normaltekst } from 'nav-frontend-typografi';
 import {
     formaterNullableMånedÅr,
     formaterTallMedTusenSkille,
 } from '../../../../App/utils/formatter';
+import { utledHjelpetekstForBeløpFørSatsjustering } from '../Felles/utils';
 
 const Rad = styled.div<{ erTittelRad?: boolean }>`
     display: grid;
-    grid-template-area: periode antallBarn utgifter kontantstøtte tilleggsstønad beløp;
-    grid-template-columns: 8rem 5.5rem 4rem 6rem 7rem 8rem;
+    grid-template-area: periode antallBarn utgifter kontantstøtte tilleggsstønad beløp notifikasjon;
+    grid-template-columns: 8rem 5.5rem 4rem 6rem 7rem 8rem 2rem;
     grid-gap: 1rem;
     margin-bottom: ${(props) => (props.erTittelRad ? '0.5rem' : '0')};
 `;
@@ -24,6 +25,10 @@ const HøyrejustertNormaltekst = styled(Normaltekst)`
 
 const HøyrejusterElement = styled(Element)`
     text-align: right;
+`;
+
+const VenstrejustertElement = styled(Element)`
+    text-align: left;
 `;
 
 export const UtregningstabellBarnetilsyn: React.FC<{
@@ -70,6 +75,13 @@ export const UtregningstabellBarnetilsyn: React.FC<{
                             <HøyrejustertNormaltekst>
                                 {formaterTallMedTusenSkille(rad.beløp)}
                             </HøyrejustertNormaltekst>
+                            {rad.beløpFørSatsjustering > rad.beløp && (
+                                <VenstrejustertElement>
+                                    <HelpText title="Hvor kommer beløpet fra?" placement={'right'}>
+                                        {utledHjelpetekstForBeløpFørSatsjustering(rad)}
+                                    </HelpText>
+                                </VenstrejustertElement>
+                            )}
                         </Rad>
                     ))}
                 </>

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/konstanter.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/konstanter.ts
@@ -1,1 +1,9 @@
 export const VEDTAK_OG_BEREGNING = 'vedtak-og-beregning';
+
+// TODO: Legge til satser for flere år tilbake i tid
+// Det første elementet i listen tilsvarer satsen for 1 barn, det andre elementet for 2 barn og det tredje elementet for 3 barn
+export const årTilSatsBeløpForBarnetislyn: Record<number, number[]> = {
+    2020: [4053, 5289, 5993],
+    2021: [4195, 5474, 6203],
+    2022: [4250, 5545, 6284],
+};

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
@@ -9,6 +9,9 @@ import {
     VilkårType,
 } from '../../Inngangsvilkår/vilkår';
 import { vilkårStatusAleneomsorg } from '../../Vurdering/VurderingUtil';
+import { IBeregningsperiodeBarnetilsyn } from '../../../../App/typer/vedtak';
+import { årTilSatsBeløpForBarnetislyn } from './konstanter';
+import { formaterIsoÅr } from '../../../../App/utils/formatter';
 
 export const mapVilkårtypeTilResultat = (
     vurderinger: IVurdering[]
@@ -106,4 +109,28 @@ export const eksistererIkkeOppfyltVilkårForOvergangsstønad = (vilkår: IVilkå
         eksistererVilkårsResultat(resultater, Vilkårsresultat.IKKE_OPPFYLT) ||
         vilkårStatusAleneomsorg(vilkårsresultatAleneomsorg) === Vilkårsresultat.IKKE_OPPFYLT
     );
+};
+
+export const utledHjelpetekstForBeløpFørSatsjustering = (
+    beregningsresultat: IBeregningsperiodeBarnetilsyn
+): string => {
+    const innskuttSetning =
+        beregningsresultat.beregningsgrunnlag.antallBarn >= 3 ? 'eller flere' : '';
+
+    return `Beløpet er redusert fra ${
+        beregningsresultat.beløpFørSatsjustering
+    } kr til ${satsForBarnetilsyn(beregningsresultat)} kr som er maksimalt beløp pr måned for ${
+        beregningsresultat.beregningsgrunnlag.antallBarn
+    } ${innskuttSetning} barn`;
+};
+
+export const satsForBarnetilsyn = (beregningsresultat: IBeregningsperiodeBarnetilsyn): number => {
+    const år = formaterIsoÅr(beregningsresultat.periode.fradato);
+    const årTilSats = årTilSatsBeløpForBarnetislyn[år];
+    const antallBarnTilIndex =
+        beregningsresultat.beregningsgrunnlag.antallBarn > 3
+            ? 2
+            : beregningsresultat.beregningsgrunnlag.antallBarn - 1;
+
+    return årTilSats[antallBarnTilIndex];
 };

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
@@ -119,7 +119,7 @@ export const utledHjelpetekstForBeløpFørSatsjustering = (
 
     return `Beløpet er redusert fra ${
         beregningsresultat.beløpFørSatsjustering
-    } kr til ${satsForBarnetilsyn(beregningsresultat)} kr som er maksimalt beløp pr måned for ${
+    } kr til ${satsForBarnetilsyn(beregningsresultat)} kr, som er maksimalt beløp pr måned for ${
         beregningsresultat.beregningsgrunnlag.antallBarn
     } ${innskuttSetning} barn`;
 };


### PR DESCRIPTION
…satasbeløpet skal dette vises i frontend.

- https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8501

Dersom det utbetalte beløpet er nedjustert i forhold til gjeldende satser skal dette vises i frontend.
Varslinger vises for de to øverste periodene siden disse beløpene er nedjustert til makssats:
![Skjermbilde 2022-04-21 kl  13 41 03](https://user-images.githubusercontent.com/32769446/164463483-a5a63e82-31ec-4a47-89e3-f6790717c4d5.png)
![Skjermbilde 2022-04-21 kl  13 41 10](https://user-images.githubusercontent.com/32769446/164463485-f71d92e3-1b19-4793-a316-aff3701c98db.png)

