### PR TITLE
Lagt til visning av sanksjon i vedtakshistorikk for barnetilsyn

### DIFF
--- a/src/frontend/App/typer/tilkjentytelse.ts
+++ b/src/frontend/App/typer/tilkjentytelse.ts
@@ -37,6 +37,7 @@ export interface AndelHistorikk {
     endring?: AndelHistorikkEndring;
     aktivitet?: EAktivitet;
     aktivitetArbeid?: AktivitetArbeid;
+    erSanksjon: boolean;
     periodeType?: EPeriodetype;
     behandlingType: Behandlingstype;
     sanksjonsårsak?: Sanksjonsårsak;

--- a/src/frontend/App/typer/vedtak.ts
+++ b/src/frontend/App/typer/vedtak.ts
@@ -292,7 +292,7 @@ export const behandlingResultatTilTekst: Record<EBehandlingResultat, string> = {
     SANKSJONERE: 'Sanksjonere',
 };
 
-export const aktivitetTilTekst: Record<EAktivitet, string> = {
+export const aktivitetTilTekst: Record<EAktivitet | '', string> = {
     IKKE_AKTIVITETSPLIKT: '',
     BARN_UNDER_ETT_ÅR: 'Barn er under 1 år',
     FORSØRGER_I_ARBEID: 'Forsørger er i arbeid (§15-6 første ledd)',
@@ -316,6 +316,7 @@ export const aktivitetTilTekst: Record<EAktivitet, string> = {
         'Stønad i påvente av oppstart kvalifiseringsprogram',
     FORLENGELSE_STØNAD_PÅVENTE_TILSYNSORDNING:
         'Stønad i påvente av tilsynsordning (§15-8 femte ledd)',
+    '': '',
 };
 
 export const avslagÅrsakTilTekst: Record<EAvslagÅrsak, string> = {

--- a/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderBarnetilsyn.tsx
@@ -6,17 +6,19 @@ import {
     formaterNullableMånedÅr,
     formaterTallMedTusenSkille,
 } from '../../../App/utils/formatter';
-import { EPeriodetype } from '../../../App/typer/vedtak';
 import { Sanksjonsårsak, sanksjonsårsakTilTekst } from '../../../App/typer/Sanksjonsårsak';
 import React from 'react';
-import { historikkEndring, HistorikkRad, HistorikkTabell } from './vedtakshistorikkUtil';
+import {
+    etikettType,
+    historikkEndring,
+    HistorikkRad,
+    HistorikkTabell,
+} from './vedtakshistorikkUtil';
+import { EPeriodetype, periodetypeTilTekst } from '../../../App/typer/vedtak';
+import EtikettBase from 'nav-frontend-etiketter';
 
-/**
- * TODO håndtere sanksjon for barnetilsyn
- */
-const historikkRad = (andel: AndelHistorikk) => {
-    const erMigrering = andel.periodeType === EPeriodetype.MIGRERING;
-    const erSanksjon = andel.periodeType === EPeriodetype.SANKSJON;
+const historikkRad = (andel: AndelHistorikk, sanksjonFinnes: boolean) => {
+    const erSanksjon = andel.erSanksjon;
     return (
         <HistorikkRad type={andel.endring?.type}>
             <td>
@@ -24,6 +26,15 @@ const historikkRad = (andel: AndelHistorikk) => {
                 {' - '}
                 {formaterNullableMånedÅr(andel.andel.stønadTil)}
             </td>
+            {sanksjonFinnes && (
+                <td>
+                    {erSanksjon && (
+                        <EtikettBase mini type={etikettType(EPeriodetype.SANKSJON)}>
+                            {periodetypeTilTekst[EPeriodetype.SANKSJON]}
+                        </EtikettBase>
+                    )}
+                </td>
+            )}
             <td>
                 {erSanksjon
                     ? sanksjonsårsakTilTekst[andel.sanksjonsårsak as Sanksjonsårsak]
@@ -37,7 +48,7 @@ const historikkRad = (andel: AndelHistorikk) => {
             <td>{andel.saksbehandler}</td>
             <td>
                 <Link className="lenke" to={{ pathname: `/behandling/${andel.behandlingId}` }}>
-                    {erMigrering ? 'Migrering' : behandlingstypeTilTekst[andel.behandlingType]}
+                    {behandlingstypeTilTekst[andel.behandlingType]}
                 </Link>
             </td>
             <td>{historikkEndring(andel.endring)}</td>
@@ -46,11 +57,13 @@ const historikkRad = (andel: AndelHistorikk) => {
 };
 
 const VedtaksperioderBarnetilsyn: React.FC<{ andeler: AndelHistorikk[] }> = ({ andeler }) => {
+    const sanksjonFinnes = andeler.some((andel) => andel.erSanksjon);
     return (
         <HistorikkTabell className="tabell">
             <thead>
                 <tr>
                     <th>Periode (fom-tom)</th>
+                    {sanksjonFinnes && <th></th>}
                     <th>Aktivitet</th>
                     <th>Antall barn</th>
                     <th>Utgifter</th>
@@ -62,7 +75,7 @@ const VedtaksperioderBarnetilsyn: React.FC<{ andeler: AndelHistorikk[] }> = ({ a
                     <th>Endring</th>
                 </tr>
             </thead>
-            <tbody>{andeler.map((periode) => historikkRad(periode))}</tbody>
+            <tbody>{andeler.map((periode) => historikkRad(periode, sanksjonFinnes))}</tbody>
         </HistorikkTabell>
     );
 };

--- a/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderOvergangsstønad.tsx
@@ -29,13 +29,13 @@ const historikkRad = (andel: AndelHistorikk) => {
             </td>
             <td>
                 <EtikettBase mini type={etikettType(andel.periodeType)}>
-                    {periodetypeTilTekst[andel.periodeType]}
+                    {periodetypeTilTekst[andel.periodeType || '']}
                 </EtikettBase>
             </td>
             <td>
                 {erSanksjon
                     ? sanksjonsårsakTilTekst[andel.sanksjonsårsak as Sanksjonsårsak]
-                    : aktivitetTilTekst[andel.aktivitet]}
+                    : aktivitetTilTekst[andel.aktivitet || '']}
             </td>
             <td>{!erSanksjon && formaterTallMedTusenSkille(andel.andel.inntekt)}</td>
             <td>{!erSanksjon && formaterTallMedTusenSkille(andel.andel.samordningsfradrag)}</td>

--- a/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/vedtakshistorikkUtil.tsx
+++ b/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/vedtakshistorikkUtil.tsx
@@ -33,7 +33,7 @@ export const historikkEndring = (endring?: AndelHistorikkEndring) =>
         </Link>
     );
 
-export const etikettType = (periodeType: EPeriodetype) => {
+export const etikettType = (periodeType?: EPeriodetype) => {
     switch (periodeType) {
         case EPeriodetype.HOVEDPERIODE:
             return 'suksess';


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/937168/164723556-60c8f524-430c-4de3-864f-267ed73e30b8.png)

Kolonnen for sanksjon vises kun hvis sanksjon finnes
https://www.figma.com/file/JEmXg4WqG0DFItNGpoX696/Skisser-EF-sak?node-id=7792%3A98168 

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8492

Koblet til:
* https://github.com/navikt/familie-ef-sak/pull/1415