### PR TITLE
Legger til støtte for eksternid i EksternRedirectContainer

### DIFF
--- a/src/frontend/App/utils/utils.ts
+++ b/src/frontend/App/utils/utils.ts
@@ -122,3 +122,6 @@ export const groupBy = <T, K extends keyof any>(list: T[], getKey: (item: T) => 
         previous[group].push(currentItem);
         return previous;
     }, {} as Record<K, T[]>);
+
+const REGEXP_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+export const isUUID = (value: string): boolean => REGEXP_UUID.test(value);

--- a/src/frontend/App/utils/utils.ts
+++ b/src/frontend/App/utils/utils.ts
@@ -2,6 +2,7 @@ import { KeyboardEvent } from 'react';
 import { OrNothing } from '../hooks/felles/useSorteringState';
 import { isAfter, isBefore } from 'date-fns';
 import { IOppgaveRequest } from '../../Komponenter/Oppgavebenk/typer/oppgaverequest';
+import { validate } from 'uuid';
 
 export const datoFeil = (valgtDatoFra?: string, valgtDatoTil?: string): OrNothing<string> => {
     if (!valgtDatoFra || !valgtDatoTil) {
@@ -123,5 +124,4 @@ export const groupBy = <T, K extends keyof any>(list: T[], getKey: (item: T) => 
         return previous;
     }, {} as Record<K, T[]>);
 
-const REGEXP_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-export const isUUID = (value: string): boolean => REGEXP_UUID.test(value);
+export const isUUID = (value: string): boolean => validate(value);

--- a/src/frontend/Komponenter/Redirect/FagsakTilFagsakPersonRedirect.tsx
+++ b/src/frontend/Komponenter/Redirect/FagsakTilFagsakPersonRedirect.tsx
@@ -1,25 +1,35 @@
 import React, { FC, useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { byggTomRessurs, Ressurs, RessursStatus } from '../../App/typer/ressurs';
+import { byggFeiletRessurs, byggTomRessurs, Ressurs, RessursStatus } from '../../App/typer/ressurs';
 import { useApp } from '../../App/context/AppContext';
 import DataViewer from '../../Felles/DataViewer/DataViewer';
 import { Fagsak } from '../../App/typer/fagsak';
+import { isUUID } from '../../App/utils/utils';
 
 type IFagsakParams = {
     fagsakId: string;
 };
 
 const EksternRedirectContainer: FC = () => {
-    const { fagsakId } = useParams<IFagsakParams>();
+    const fagsakId = useParams<IFagsakParams>().fagsakId as string;
     const [fagsak, settFagsak] = useState<Ressurs<Fagsak>>(byggTomRessurs());
     const { axiosRequest } = useApp();
     const navigate = useNavigate();
 
     const hentFagsak = () => {
-        axiosRequest<Fagsak, null>({
-            method: 'GET',
-            url: `/familie-ef-sak/api/fagsak/${fagsakId}`,
-        }).then(settFagsak);
+        if (!isNaN(Number(fagsakId))) {
+            axiosRequest<Fagsak, null>({
+                method: 'GET',
+                url: `/familie-ef-sak/api/fagsak/ekstern/${fagsakId}`,
+            }).then(settFagsak);
+        } else if (!isUUID(fagsakId)) {
+            settFagsak(byggFeiletRessurs(`"${fagsakId}" er ikke en gyldig verdi for fagsak`));
+        } else {
+            axiosRequest<Fagsak, null>({
+                method: 'GET',
+                url: `/familie-ef-sak/api/fagsak/${fagsakId}`,
+            }).then(settFagsak);
+        }
     };
 
     useEffect(() => {


### PR DESCRIPTION
Noen bruker `https://ensligmorellerfar.dev.intern.nav.no/fagsak/<id>` med eksternId, så legger til at vi henter fagsak på eksternid for å unngå error i loggen