### PR TITLE
Mulighet får å ha en vedtaksperiode med 12 mnd frem i tiden

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
@@ -57,7 +57,7 @@ export const validerVedtaksperioder = ({
     perioder: IVedtaksperiode[];
     inntekter: IInntektsperiode[];
 }> => {
-    const elveMånederFremITiden = tilÅrMåned(plusMåneder(new Date(), 11));
+    const tolvMånederFremITiden = tilÅrMåned(plusMåneder(new Date(), 12));
     const feilIVedtaksPerioder = perioder.map((vedtaksperiode, index) => {
         const { årMånedFra, årMånedTil, aktivitet, periodeType } = vedtaksperiode;
         let vedtaksperiodeFeil: FormErrors<IVedtaksperiode> = {
@@ -99,10 +99,10 @@ export const validerVedtaksperioder = ({
                 };
             }
         }
-        if (erMånedÅrEtter(elveMånederFremITiden, årMånedFra)) {
+        if (erMånedÅrEtter(tolvMånederFremITiden, årMånedFra)) {
             return {
                 ...vedtaksperiodeFeil,
-                årMånedFra: `Startdato (${årMånedFra}) mer enn 11mnd frem i tid`,
+                årMånedFra: `Startdato (${årMånedFra}) mer enn 12mnd frem i tid`,
             };
         }
         return vedtaksperiodeFeil;
@@ -133,9 +133,9 @@ export const validerVedtaksperioder = ({
                 };
             }
         }
-        if (erMånedÅrEtter(elveMånederFremITiden, årMånedFra)) {
+        if (erMånedÅrEtter(tolvMånederFremITiden, årMånedFra)) {
             return {
-                årMånedFra: `Startdato (${årMånedFra}) mer enn 11mnd frem i tid`,
+                årMånedFra: `Startdato (${årMånedFra}) mer enn 12mnd frem i tid`,
             };
         }
         return { årMånedFra: undefined };

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
@@ -57,7 +57,7 @@ export const validerVedtaksperioder = ({
     perioder: IVedtaksperiode[];
     inntekter: IInntektsperiode[];
 }> => {
-    const syvMånederFremITiden = tilÅrMåned(plusMåneder(new Date(), 7));
+    const elveMånederFremITiden = tilÅrMåned(plusMåneder(new Date(), 11));
     const feilIVedtaksPerioder = perioder.map((vedtaksperiode, index) => {
         const { årMånedFra, årMånedTil, aktivitet, periodeType } = vedtaksperiode;
         let vedtaksperiodeFeil: FormErrors<IVedtaksperiode> = {
@@ -99,10 +99,10 @@ export const validerVedtaksperioder = ({
                 };
             }
         }
-        if (erMånedÅrEtter(syvMånederFremITiden, årMånedFra)) {
+        if (erMånedÅrEtter(elveMånederFremITiden, årMånedFra)) {
             return {
                 ...vedtaksperiodeFeil,
-                årMånedFra: `Startdato (${årMånedFra}) mer enn 7mnd frem i tid`,
+                årMånedFra: `Startdato (${årMånedFra}) mer enn 11mnd frem i tid`,
             };
         }
         return vedtaksperiodeFeil;
@@ -133,9 +133,9 @@ export const validerVedtaksperioder = ({
                 };
             }
         }
-        if (erMånedÅrEtter(syvMånederFremITiden, årMånedFra)) {
+        if (erMånedÅrEtter(elveMånederFremITiden, årMånedFra)) {
             return {
-                årMånedFra: `Startdato (${årMånedFra}) mer enn 7mnd frem i tid`,
+                årMånedFra: `Startdato (${årMånedFra}) mer enn 11mnd frem i tid`,
             };
         }
         return { årMånedFra: undefined };


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8588

Denne burde kanskje merges etter att https://nav-it.slack.com/archives/C01EH16LAD9/p1651148917791009 er ferdigstilt? 
Vi kan velge å prodsette denne før, men då kan man kun legge inn perioder året ut før august, og fom august kan man legge inn datoer for 12 mnd frem i tiden

Då kommer vi få error i loggen hvis noen prøver å legge inn perider i 2023 akkurat nå, men man får lagt inn perioder året ut.. 