### PR TITLE
Bt vedtakshistorikk 2.0

### DIFF
--- a/src/frontend/App/typer/tilkjentytelse.ts
+++ b/src/frontend/App/typer/tilkjentytelse.ts
@@ -26,7 +26,7 @@ export interface AndelMedGrunnlag {
     utgifter: number;
     antallBarn: number;
     kontantstøtte: number;
-    tillegsstønad: number;
+    tilleggsstønad: number;
     sats: number;
     beløpFørFratrekkOgSatsJustering: number;
 }

--- a/src/frontend/App/typer/tilkjentytelse.ts
+++ b/src/frontend/App/typer/tilkjentytelse.ts
@@ -28,7 +28,7 @@ export interface AndelMedGrunnlag {
     kontantstøtte: number;
     tillegsstønad: number;
     sats: number;
-    beløpFørSatsJustering: number;
+    beløpFørFratrekkOgSatsJustering: number;
 }
 
 export interface AndelHistorikk {

--- a/src/frontend/App/typer/tilkjentytelse.ts
+++ b/src/frontend/App/typer/tilkjentytelse.ts
@@ -27,6 +27,8 @@ export interface AndelMedGrunnlag {
     antallBarn: number;
     kontantstøtte: number;
     tillegsstønad: number;
+    sats: number;
+    beløpFørSatsJustering: number;
 }
 
 export interface AndelHistorikk {

--- a/src/frontend/App/typer/vedtak.ts
+++ b/src/frontend/App/typer/vedtak.ts
@@ -26,7 +26,7 @@ export interface IBeløpsperiode {
 export interface IBeregningsperiodeBarnetilsyn {
     periode: { fradato: string; tildato: string };
     beløp: number;
-    beløpFørSatsjustering: number;
+    beløpFørFratrekkOgSatsjustering: number;
     sats: number;
     beregningsgrunnlag: IBeregningsgrunnlagBarnetilsyn;
 }

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtregnignstabellBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtregnignstabellBarnetilsyn.tsx
@@ -9,7 +9,7 @@ import {
     formaterNullableMånedÅr,
     formaterTallMedTusenSkille,
 } from '../../../../App/utils/formatter';
-import { utledHjelpetekstForBeløpFørSatsjustering } from '../Felles/utils';
+import { utledHjelpetekstForBeløpFørFratrekkOgSatsjustering } from '../Felles/utils';
 
 const Rad = styled.div<{ erTittelRad?: boolean }>`
     display: grid;
@@ -75,14 +75,17 @@ export const UtregningstabellBarnetilsyn: React.FC<{
                             <HøyrejustertNormaltekst>
                                 {formaterTallMedTusenSkille(rad.beløp)}
                             </HøyrejustertNormaltekst>
-                            {rad.beløpFørSatsjustering > rad.beløp && (
+                            {rad.beløpFørFratrekkOgSatsjustering > rad.sats && (
                                 <VenstrejustertElement>
                                     <HelpText title="Hvor kommer beløpet fra?" placement={'right'}>
-                                        {utledHjelpetekstForBeløpFørSatsjustering(
-                                            rad.beregningsgrunnlag.antallBarn,
-                                            rad.beløpFørSatsjustering,
-                                            rad.sats
-                                        )}
+                                        <div>
+                                            {utledHjelpetekstForBeløpFørFratrekkOgSatsjustering(
+                                                rad.beregningsgrunnlag.antallBarn,
+                                                rad.beløpFørFratrekkOgSatsjustering,
+                                                rad.sats,
+                                                false
+                                            )}
+                                        </div>
                                     </HelpText>
                                 </VenstrejustertElement>
                             )}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtregnignstabellBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtregnignstabellBarnetilsyn.tsx
@@ -46,7 +46,7 @@ export const UtregningstabellBarnetilsyn: React.FC<{
                         <HøyrejusterElement>Ant. barn</HøyrejusterElement>
                         <HøyrejusterElement>Utgifter</HøyrejusterElement>
                         <HøyrejusterElement>Kontantstøtte</HøyrejusterElement>
-                        <HøyrejusterElement>Reduksjonsbeløp</HøyrejusterElement>
+                        <HøyrejusterElement>Tilleggsstønad</HøyrejusterElement>
                         <HøyrejusterElement>Stønadsbeløp</HøyrejusterElement>
                     </Rad>
                     {beregningsresultat.map((rad) => (

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtregnignstabellBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtregnignstabellBarnetilsyn.tsx
@@ -78,7 +78,11 @@ export const UtregningstabellBarnetilsyn: React.FC<{
                             {rad.beløpFørSatsjustering > rad.beløp && (
                                 <VenstrejustertElement>
                                     <HelpText title="Hvor kommer beløpet fra?" placement={'right'}>
-                                        {utledHjelpetekstForBeløpFørSatsjustering(rad)}
+                                        {utledHjelpetekstForBeløpFørSatsjustering(
+                                            rad.beregningsgrunnlag.antallBarn,
+                                            rad.beløpFørSatsjustering,
+                                            rad.sats
+                                        )}
                                     </HelpText>
                                 </VenstrejustertElement>
                             )}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
@@ -9,7 +9,6 @@ import {
     VilkårType,
 } from '../../Inngangsvilkår/vilkår';
 import { vilkårStatusAleneomsorg } from '../../Vurdering/VurderingUtil';
-import { IBeregningsperiodeBarnetilsyn } from '../../../../App/typer/vedtak';
 
 export const mapVilkårtypeTilResultat = (
     vurderinger: IVurdering[]
@@ -110,10 +109,11 @@ export const eksistererIkkeOppfyltVilkårForOvergangsstønad = (vilkår: IVilkå
 };
 
 export const utledHjelpetekstForBeløpFørSatsjustering = (
-    beregningsresultat: IBeregningsperiodeBarnetilsyn
+    antallBarn: number,
+    beløpFørSatsjustering: number,
+    sats: number
 ): string => {
-    const innskuttSetning =
-        beregningsresultat.beregningsgrunnlag.antallBarn >= 3 ? 'eller flere' : '';
-    return `Beløpet er redusert fra ${beregningsresultat.beløpFørSatsjustering} kr til ${beregningsresultat.sats} kr, 
-        som er maksimalt beløp pr måned for ${beregningsresultat.beregningsgrunnlag.antallBarn} ${innskuttSetning} barn`;
+    const innskuttSetning = antallBarn >= 3 ? 'eller flere' : '';
+    return `Beløpet er redusert fra ${beløpFørSatsjustering} kr til ${sats} kr, 
+        som er maksimalt beløp pr måned for ${antallBarn} ${innskuttSetning} barn`;
 };

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
@@ -108,12 +108,47 @@ export const eksistererIkkeOppfyltVilkårForOvergangsstønad = (vilkår: IVilkå
     );
 };
 
-export const utledHjelpetekstForBeløpFørSatsjustering = (
+export const utledHjelpetekstForBeløpFørFratrekkOgSatsjustering = (
     antallBarn: number,
-    beløpFørSatsjustering: number,
-    sats: number
+    beløpFørFratrekkOgSatsjustering: number,
+    sats: number,
+    skalViseredusertPgaTilleggsstønad: boolean
 ): string => {
+    const prefix = skalViseredusertPgaTilleggsstønad ? 'Deretter har beløpet blitt' : 'Beløpet er';
     const innskuttSetning = antallBarn >= 3 ? 'eller flere' : '';
-    return `Beløpet er redusert fra ${beløpFørSatsjustering} kr til ${sats} kr, 
+    return `${prefix} redusert fra ${beløpFørFratrekkOgSatsjustering} kr til ${sats} kr, 
         som er maksimalt beløp pr måned for ${antallBarn} ${innskuttSetning} barn`;
+};
+
+export const utledHjelpetekstForBeløpFørFratrekkOgSatsjusteringForVedtaksside = (
+    redusertPgaSats: boolean,
+    redusertPgaTilleggsstønad: boolean,
+    antallBarn: number,
+    beløpFørFratrekkOgSatsjustering: number,
+    sats: number,
+    tilleggsstønad: number
+): string[] => {
+    const visningstekstTilleggsstønad = `Stønadsbeløpet er redusert med ${tilleggsstønad} kr, som allerede er utbetalt etter tilleggsstønadsforskriften.`;
+
+    if (redusertPgaSats && redusertPgaTilleggsstønad) {
+        return [
+            visningstekstTilleggsstønad,
+            utledHjelpetekstForBeløpFørFratrekkOgSatsjustering(
+                antallBarn,
+                beløpFørFratrekkOgSatsjustering,
+                sats,
+                true
+            ),
+        ];
+    } else if (redusertPgaSats) {
+        return [
+            utledHjelpetekstForBeløpFørFratrekkOgSatsjustering(
+                antallBarn,
+                beløpFørFratrekkOgSatsjustering,
+                sats,
+                false
+            ),
+        ];
+    }
+    return [visningstekstTilleggsstønad];
 };

--- a/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderBarnetilsyn.tsx
@@ -16,8 +16,17 @@ import {
 } from './vedtakshistorikkUtil';
 import { EPeriodetype, periodetypeTilTekst } from '../../../App/typer/vedtak';
 import EtikettBase from 'nav-frontend-etiketter';
+import { utledHjelpetekstForBeløpFørSatsjustering } from '../../Behandling/VedtakOgBeregning/Felles/utils';
+import { HelpText } from '@navikt/ds-react';
+import styled from 'styled-components';
 
 const historikkRad = (andel: AndelHistorikk, sanksjonFinnes: boolean) => {
+    const Rad = styled.div`
+        display: grid;
+        grid-template-area: beløp hjelpetekst;
+        grid-template-columns: 3rem 1.75rem;
+    `;
+
     const erSanksjon = andel.erSanksjon;
     return (
         <HistorikkRad type={andel.endring?.type}>
@@ -43,7 +52,20 @@ const historikkRad = (andel: AndelHistorikk, sanksjonFinnes: boolean) => {
             <td>{!erSanksjon && andel.andel.antallBarn}</td>
             <td>{!erSanksjon && formaterTallMedTusenSkille(andel.andel.utgifter)}</td>
             <td>{!erSanksjon && formaterTallMedTusenSkille(andel.andel.kontantstøtte)}</td>
-            <td>{!erSanksjon && formaterTallMedTusenSkille(andel.andel.beløp)}</td>
+            <td>
+                <Rad>
+                    {!erSanksjon && formaterTallMedTusenSkille(andel.andel.beløp)}
+                    {andel.andel.beløpFørSatsJustering > andel.andel.sats && (
+                        <HelpText title="Hvor kommer beløpet fra?" placement={'right'}>
+                            {utledHjelpetekstForBeløpFørSatsjustering(
+                                andel.andel.antallBarn,
+                                andel.andel.beløpFørSatsJustering,
+                                andel.andel.sats
+                            )}
+                        </HelpText>
+                    )}
+                </Rad>
+            </td>
             <td>{formaterIsoDatoTid(andel.vedtakstidspunkt)}</td>
             <td>{andel.saksbehandler}</td>
             <td>

--- a/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderBarnetilsyn.tsx
@@ -16,7 +16,7 @@ import {
 } from './vedtakshistorikkUtil';
 import { EPeriodetype, periodetypeTilTekst } from '../../../App/typer/vedtak';
 import EtikettBase from 'nav-frontend-etiketter';
-import { utledHjelpetekstForBeløpFørSatsjustering } from '../../Behandling/VedtakOgBeregning/Felles/utils';
+import { utledHjelpetekstForBeløpFørFratrekkOgSatsjusteringForVedtaksside } from '../../Behandling/VedtakOgBeregning/Felles/utils';
 import { HelpText } from '@navikt/ds-react';
 import styled from 'styled-components';
 
@@ -26,6 +26,14 @@ const historikkRad = (andel: AndelHistorikk, sanksjonFinnes: boolean) => {
         grid-template-area: beløp hjelpetekst;
         grid-template-columns: 3rem 1.75rem;
     `;
+
+    const LinjeSplitter = styled.div`
+        margin-top: 0.25rem;
+    `;
+
+    const beløpErRedusertPgaSats = andel.andel.beløpFørFratrekkOgSatsJustering > andel.andel.sats;
+    const beløpErRedusertPgaTilleggsstønad = andel.andel.tillegsstønad > 0;
+    const stønadsbeløpetErRedusert = beløpErRedusertPgaSats || beløpErRedusertPgaTilleggsstønad;
 
     const erSanksjon = andel.erSanksjon;
     return (
@@ -55,13 +63,22 @@ const historikkRad = (andel: AndelHistorikk, sanksjonFinnes: boolean) => {
             <td>
                 <Rad>
                     {!erSanksjon && formaterTallMedTusenSkille(andel.andel.beløp)}
-                    {andel.andel.beløpFørSatsJustering > andel.andel.sats && (
+                    {stønadsbeløpetErRedusert && (
                         <HelpText title="Hvor kommer beløpet fra?" placement={'right'}>
-                            {utledHjelpetekstForBeløpFørSatsjustering(
+                            {utledHjelpetekstForBeløpFørFratrekkOgSatsjusteringForVedtaksside(
+                                beløpErRedusertPgaSats,
+                                beløpErRedusertPgaTilleggsstønad,
                                 andel.andel.antallBarn,
-                                andel.andel.beløpFørSatsJustering,
-                                andel.andel.sats
-                            )}
+                                andel.andel.beløpFørFratrekkOgSatsJustering,
+                                andel.andel.sats,
+                                andel.andel.tillegsstønad
+                            ).map((visningstekst, index) => {
+                                return index === 0 ? (
+                                    <div>{visningstekst}</div>
+                                ) : (
+                                    <LinjeSplitter>{visningstekst}</LinjeSplitter>
+                                );
+                            })}
                         </HelpText>
                     )}
                 </Rad>

--- a/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderBarnetilsyn.tsx
@@ -32,7 +32,7 @@ const historikkRad = (andel: AndelHistorikk, sanksjonFinnes: boolean) => {
     `;
 
     const beløpErRedusertPgaSats = andel.andel.beløpFørFratrekkOgSatsJustering > andel.andel.sats;
-    const beløpErRedusertPgaTilleggsstønad = andel.andel.tillegsstønad > 0;
+    const beløpErRedusertPgaTilleggsstønad = andel.andel.tilleggsstønad > 0;
     const stønadsbeløpetErRedusert = beløpErRedusertPgaSats || beløpErRedusertPgaTilleggsstønad;
 
     const erSanksjon = andel.erSanksjon;
@@ -71,7 +71,7 @@ const historikkRad = (andel: AndelHistorikk, sanksjonFinnes: boolean) => {
                                 andel.andel.antallBarn,
                                 andel.andel.beløpFørFratrekkOgSatsJustering,
                                 andel.andel.sats,
-                                andel.andel.tillegsstønad
+                                andel.andel.tilleggsstønad
                             ).map((visningstekst, index) => {
                                 return index === 0 ? (
                                     <div>{visningstekst}</div>


### PR DESCRIPTION
skal vise i frontend om beløp på vedtakssiden er påvirket av tilleggsstønad eller satsjusteringer.

henger sammen med en [backend-PR](https://github.com/navikt/familie-ef-sak/pull/1440) som må merges inn samtidig.

beløp er satsjustert:
![Skjermbilde 2022-04-29 kl  17 05 13](https://user-images.githubusercontent.com/32769446/165972471-a64e2407-ea9f-4c09-b3c9-3caea1c53956.png)

beløp er trukket fra på grunn av tilleggsstønad:
![Skjermbilde 2022-04-29 kl  17 05 43](https://user-images.githubusercontent.com/32769446/165972482-fee82543-eb5d-450d-aedd-40c930207412.png)


beløp er både satsjustert og trukket fra:
![Skjermbilde 2022-04-29 kl  17 01 55](https://user-images.githubusercontent.com/32769446/165972244-0d1f31ce-5b75-4f65-913e-d3d73d19860d.png)

