### PR TITLE
Det skal være mulig å legge til peridoer 8-12mnd frem i tiden, hvis d…

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
@@ -57,7 +57,9 @@ export const validerVedtaksperioder = ({
     perioder: IVedtaksperiode[];
     inntekter: IInntektsperiode[];
 }> => {
+    const syvMånederFremITiden = tilÅrMåned(plusMåneder(new Date(), 7));
     const tolvMånederFremITiden = tilÅrMåned(plusMåneder(new Date(), 12));
+    let harPeriodeFør7mndFremITiden = false;
     const feilIVedtaksPerioder = perioder.map((vedtaksperiode, index) => {
         const { årMånedFra, årMånedTil, aktivitet, periodeType } = vedtaksperiode;
         let vedtaksperiodeFeil: FormErrors<IVedtaksperiode> = {
@@ -84,6 +86,7 @@ export const validerVedtaksperioder = ({
         if (!årMånedTil || !årMånedFra) {
             return { ...vedtaksperiodeFeil, årMånedFra: 'Mangelfull utfylling av vedtaksperiode' };
         }
+
         if (!erMånedÅrEtterEllerLik(årMånedFra, årMånedTil)) {
             return {
                 ...vedtaksperiodeFeil,
@@ -99,7 +102,18 @@ export const validerVedtaksperioder = ({
                 };
             }
         }
-        if (erMånedÅrEtter(tolvMånederFremITiden, årMånedFra)) {
+
+        // Det er gyldig med periode etter 7mnd frem i tiden, hvis det finnes en periode før 7mnd frem i tiden
+        if (!erMånedÅrEtter(syvMånederFremITiden, årMånedFra)) {
+            harPeriodeFør7mndFremITiden = true;
+        }
+        if (erMånedÅrEtter(syvMånederFremITiden, årMånedFra) && !harPeriodeFør7mndFremITiden) {
+            return {
+                ...vedtaksperiodeFeil,
+                årMånedFra: `Startdato (${årMånedFra}) mer enn 7mnd frem i tid`,
+            };
+        }
+        if (erMånedÅrEtter(tolvMånederFremITiden, årMånedFra) && harPeriodeFør7mndFremITiden) {
             return {
                 ...vedtaksperiodeFeil,
                 årMånedFra: `Startdato (${årMånedFra}) mer enn 12mnd frem i tid`,


### PR DESCRIPTION
…et finnes en periode som starter før 7mnd frem i tiden

Det ble feil i forrige PR
* https://github.com/navikt/familie-ef-sak-frontend/pull/1124

Det skal kun være mulig å legge inn en periode 8-12 mnd frem i tiden hvis det finnes en periode før den perioden

Sånn att hvis man legger inn EN periode nå 8mnd frem i tiden, så får man en feilmelding om at den er etter 7mnd frem i tiden
Hvis man legger inn en periode noen gang, og sen har en periode 8-12mnd frem i tiden går det fint

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8588
https://nav-it.slack.com/archives/C01087QRJ2U/p1651147602405089 