### PR TITLE
skal kunne vise vedtaksdato for behandling pi behandlingsoversikten

### DIFF
--- a/src/frontend/App/typer/fagsak.ts
+++ b/src/frontend/App/typer/fagsak.ts
@@ -42,6 +42,7 @@ export interface Behandling {
     resultat: BehandlingResultat;
     behandlingsårsak: Behandlingsårsak;
     stønadstype: Stønadstype;
+    vedtaksdato?: string;
 }
 
 export interface IEndringerRegistergrunnlag {

--- a/src/frontend/Komponenter/Personoversikt/BehandlingsoversiktTabell.tsx
+++ b/src/frontend/Komponenter/Personoversikt/BehandlingsoversiktTabell.tsx
@@ -23,16 +23,11 @@ import { BehandlingApplikasjon } from './Behandlingsoversikt';
 import { PartialRecord } from '../../App/typer/common';
 import styled from 'styled-components';
 import { tilbakekrevingBaseUrl } from '../../App/utils/miljø';
-import { Normaltekst } from 'nav-frontend-typografi';
 
 const StyledTable = styled.table`
     width: 60%;
     padding: 2rem;
     margin-left: 1rem;
-`;
-
-const SentrertTekst = styled(Normaltekst)`
-    text-align: center;
 `;
 
 const TabellData: PartialRecord<keyof Behandling | 'vedtaksdato', string> = {
@@ -107,18 +102,6 @@ export const BehandlingsoversiktTabell: React.FC<{
             ? behandlingOgTilbakekrevingsårsakTilTekst[behandling.årsak]
             : '-';
 
-    const utledKolonneForVedtaksdato = (
-        behandlingsresultat?: BehandlingResultat | TilbakekrevingBehandlingsresultatstype,
-        vedtaksdato?: string
-    ) => {
-        if (behandlingsresultat === BehandlingResultat.HENLAGT) {
-            return <SentrertTekst>--------</SentrertTekst>;
-        } else if (vedtaksdato) {
-            return formaterIsoDatoTid(vedtaksdato);
-        }
-        return '';
-    };
-
     return (
         <StyledTable className="tabell">
             <thead>
@@ -148,10 +131,8 @@ export const BehandlingsoversiktTabell: React.FC<{
                             <td>{finnÅrsak(behandling)}</td>
                             <td>{formatterEnumVerdi(behandling.status)}</td>
                             <td>
-                                {utledKolonneForVedtaksdato(
-                                    behandling.resultat,
-                                    behandling.vedtaksdato
-                                )}
+                                {behandling.vedtaksdato &&
+                                    formaterIsoDatoTid(behandling.vedtaksdato)}
                             </td>
                             <td>
                                 {behandling.type === Behandlingstype.TEKNISK_OPPHØR &&

--- a/src/frontend/Komponenter/Personoversikt/BehandlingsoversiktTabell.tsx
+++ b/src/frontend/Komponenter/Personoversikt/BehandlingsoversiktTabell.tsx
@@ -23,11 +23,16 @@ import { BehandlingApplikasjon } from './Behandlingsoversikt';
 import { PartialRecord } from '../../App/typer/common';
 import styled from 'styled-components';
 import { tilbakekrevingBaseUrl } from '../../App/utils/miljø';
+import { Normaltekst } from 'nav-frontend-typografi';
 
 const StyledTable = styled.table`
-    width: 50%;
+    width: 60%;
     padding: 2rem;
     margin-left: 1rem;
+`;
+
+const SentrertTekst = styled(Normaltekst)`
+    text-align: center;
 `;
 
 const TabellData: PartialRecord<keyof Behandling | 'vedtaksdato', string> = {
@@ -64,6 +69,7 @@ export const BehandlingsoversiktTabell: React.FC<{
                 status: behandling.status,
                 resultat: behandling.resultat,
                 opprettet: behandling.opprettet,
+                vedtaksdato: behandling.vedtaksdato,
                 applikasjon: BehandlingApplikasjon.EF_SAK,
             };
         }
@@ -101,6 +107,18 @@ export const BehandlingsoversiktTabell: React.FC<{
             ? behandlingOgTilbakekrevingsårsakTilTekst[behandling.årsak]
             : '-';
 
+    const utledKolonneForVedtaksdato = (
+        behandlingsresultat?: BehandlingResultat | TilbakekrevingBehandlingsresultatstype,
+        vedtaksdato?: string
+    ) => {
+        if (behandlingsresultat === BehandlingResultat.HENLAGT) {
+            return <SentrertTekst>--------</SentrertTekst>;
+        } else if (vedtaksdato) {
+            return formaterIsoDatoTid(vedtaksdato);
+        }
+        return '';
+    };
+
     return (
         <StyledTable className="tabell">
             <thead>
@@ -130,8 +148,10 @@ export const BehandlingsoversiktTabell: React.FC<{
                             <td>{finnÅrsak(behandling)}</td>
                             <td>{formatterEnumVerdi(behandling.status)}</td>
                             <td>
-                                {behandling.vedtaksdato &&
-                                    formaterIsoDatoTid(behandling.vedtaksdato)}
+                                {utledKolonneForVedtaksdato(
+                                    behandling.resultat,
+                                    behandling.vedtaksdato
+                                )}
                             </td>
                             <td>
                                 {behandling.type === Behandlingstype.TEKNISK_OPPHØR &&


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8228)
[Backend](https://github.com/navikt/familie-ef-sak/pull/1460)

Før:
<img width="959" alt="Skjermbilde 2022-05-04 kl  21 09 25" src="https://user-images.githubusercontent.com/32769446/166808526-79649dca-fb68-4fbd-ad30-6f92e457a995.png">

Etter:
<img width="1115" alt="Skjermbilde 2022-05-04 kl  21 07 24" src="https://user-images.githubusercontent.com/32769446/166808550-020402f3-a107-4126-941c-e19883abe200.png">

