### PR TITLE
Vil ikke bruke alle tilkjente ytelser for utleding av vedtaksdato i b…

### DIFF
--- a/src/frontend/App/hooks/useVerdierForBrev.ts
+++ b/src/frontend/App/hooks/useVerdierForBrev.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
-import { TilkjentYtelse } from '../typer/tilkjentytelse';
 import { formaterIsoDato } from '../utils/formatter';
 import { Ressurs, RessursStatus } from '../typer/ressurs';
+import { IBeløpsperiode } from '../typer/vedtak';
 
 enum EBehandlingFlettefelt {
     fomdatoInnvilgelseForstegangsbehandling = 'fomdatoInnvilgelseForstegangsbehandling',
@@ -9,28 +9,28 @@ enum EBehandlingFlettefelt {
 }
 
 export const useVerdierForBrev = (
-    tilkjentYtelse: Ressurs<TilkjentYtelse | undefined>
+    beløpsperioder: Ressurs<IBeløpsperiode[] | undefined>
 ): { flettefeltStore: { [navn: string]: string } } => {
     const [flettefeltStore, settFlettefeltStore] = useState<{ [navn: string]: string }>({});
 
     useEffect(() => {
         if (
-            tilkjentYtelse.status === RessursStatus.SUKSESS &&
-            tilkjentYtelse.data &&
-            tilkjentYtelse.data.andeler.length > 0
+            beløpsperioder.status === RessursStatus.SUKSESS &&
+            beløpsperioder.data &&
+            beløpsperioder.data.length > 0
         ) {
-            const { andeler } = tilkjentYtelse.data;
+            const perioder = beløpsperioder.data;
             settFlettefeltStore((prevState) => ({
                 ...prevState,
                 [EBehandlingFlettefelt.tomdatoInnvilgelseForstegangsbehandling]: formaterIsoDato(
-                    andeler[andeler.length - 1].stønadTil
+                    perioder[perioder.length - 1].periode.tildato
                 ),
                 [EBehandlingFlettefelt.fomdatoInnvilgelseForstegangsbehandling]: formaterIsoDato(
-                    andeler[0].stønadFra
+                    perioder[0].periode.fradato
                 ),
             }));
         }
-    }, [tilkjentYtelse]);
+    }, [beløpsperioder]);
 
     return { flettefeltStore };
 };


### PR DESCRIPTION
…rev. Bruker istedet bare perioder for gjeldende behandling

Var i utgangspunktet tenkt at automatiske utfylte vedtaksdatoer bare skulle fungere for førstegangsbehandlinger, men fordi brevmalen for førstegansgehandlinger også brukes for revurderinger med nye søknader kan brevdatoen bli feil uten denne fiksen.