### PR TITLE
beløp i brevtabeller skal være justert mot høyre for bedre lesbarhet

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/UtregningstabellBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/UtregningstabellBarnetilsyn.tsx
@@ -5,7 +5,8 @@ export const delmalTilUtregningstabellBT = (beløpsperioder?: IBeregningsperiode
     return { inntektsperioderHtml: lagInntektsperioder(beløpsperioder) };
 };
 
-const borderStyling = 'border: 1px solid black; padding: 3px 5px 3px 5px;';
+const borderStylingCompact = 'border: 1px solid black; padding: 3px 2px 3px 5px;';
+const borderStyling = 'border: 1px solid black; padding: 3px 10px 3px 5px;';
 const lagInntektsperioder = (beløpsperioder?: IBeregningsperiodeBarnetilsyn[]): string => {
     if (!beløpsperioder) {
         return '';
@@ -17,25 +18,25 @@ const lagInntektsperioder = (beløpsperioder?: IBeregningsperiodeBarnetilsyn[]):
         (beløpsperiode) => beløpsperiode.beregningsgrunnlag.tilleggsstønadsbeløp > 0
     );
 
-    return `<table style="margin-left: 2px; border-collapse: collapse; ${borderStyling}">
+    return `<table style="margin-left: 2px; margin-right: 2px; border-collapse: collapse; ${borderStylingCompact}">
                 <thead>
                     <tr>
-                        <th style="width: 100px; ${borderStyling}">Periode</th>
-                        <th style="width: 45px; ${borderStyling}">Ant. barn</th>
-                        <th style="width: 35px; word-wrap: break-word; ${borderStyling}">Utgifter</th>
+                        <th style="width: 100px; ${borderStylingCompact}">Periode</th>
+                        <th style="width: 40px; ${borderStylingCompact}">Ant. barn</th>
+                        <th style="width: 45px; word-wrap: break-word; ${borderStylingCompact}">Utgifter</th>
                         ${
                             harKontantStøtte
-                                ? `<th style="width: 65px; word-wrap: break-word; ${borderStyling}">
+                                ? `<th style="width: 60px; word-wrap: break-word; ${borderStylingCompact}">
                                     Kontantstøtte
                                 </th>`
                                 : ''
                         }
                         ${
                             harTilleggsstønad
-                                ? `<th style="width: 65px; word-wrap: break-word; ${borderStyling}">Tilleggsstønad</th>`
+                                ? `<th style="width: 60px; word-wrap: break-word; ${borderStylingCompact}">Tilleggsstønad</th>`
                                 : ''
                         }
-                        <th style="width: 70px; word-wrap: break-word; ${borderStyling}">Dette får du utbetalt pr. måned</th>
+                        <th style="width: 65px; word-wrap: break-word; ${borderStylingCompact}">Dette får du utbetalt pr. måned</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -63,8 +64,8 @@ const lagRaderForVedtak = (
             );
             const utbetaltBeløp = formaterTallMedTusenSkille(beløpsperiode.beløp);
 
-            return `<tr>
-                        <td style="${borderStyling}">${andelsperiode}</td>
+            return `<tr style="text-align: right;">
+                        <td style="text-align: left; ${borderStylingCompact}">${andelsperiode}</td>
                         <td style="${borderStyling}">${
                 beløpsperiode.beregningsgrunnlag.antallBarn
             }</td>

--- a/src/frontend/Komponenter/Behandling/Brev/UtregningstabellOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/UtregningstabellOvergangsstønad.tsx
@@ -9,7 +9,8 @@ export const delmalTilUtregningstabellOS = (beløpsperioder?: IBeløpsperiode[])
     return { inntektsperioderHtml: lagInntektsperioder(beløpsperioder) };
 };
 
-const borderStyling = 'border: 1px solid black; padding: 3px 5px 3px 5px;';
+const borderStylingCompact = 'border: 1px solid black; padding: 3px 2px 3px 5px;';
+const borderStyling = 'border: 1px solid black; padding: 3px 10px 3px 5px;';
 const lagInntektsperioder = (beløpsperioder?: IBeløpsperiode[]): string => {
     const samordningsfradragstype: ESamordningsfradragtype | null = beløpsperioder
         ? beløpsperioder[0].beregningsgrunnlag.samordningsfradragType
@@ -18,16 +19,16 @@ const lagInntektsperioder = (beløpsperioder?: IBeløpsperiode[]): string => {
         ? samordningsfradagTilTekst[samordningsfradragstype]
         : '';
 
-    return `<table style="margin-left: 2px; border-collapse: collapse; ${borderStyling}">
+    return `<table style="margin-left: 2px; margin-right: 2px; border-collapse: collapse; ${borderStylingCompact}">
                 <thead>
                     <tr>
-                        <th style="width: 160px; ${borderStyling}">Periode</th>
-                        <th style="width: 75px; ${borderStyling}">Årsinntekt</th>
+                        <th style="width: 110px; ${borderStylingCompact}">Periode</th>
+                        <th style="width: 55px; word-wrap: break-word; ${borderStylingCompact}">Årsinntekt</th>
                         ${
                             samordningskolonneTittel &&
-                            `<th style="width: 85px; ${borderStyling}">${samordningskolonneTittel}</th>`
+                            `<th style="width: 90px; word-wrap: break-word; ${borderStylingCompact}">${samordningskolonneTittel}</th>`
                         }
-                        <th style="width: 150px; word-wrap: break-word; ${borderStyling}">Dette får du i overgangsstønad pr. måned</th>
+                        <th style="width: 55px; word-wrap: break-word; ${borderStylingCompact}">Dette får du ubetalt pr. måned</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -54,8 +55,8 @@ const lagRaderForVedtak = (
                 beløpsperiode.periode.fradato
             )} - ${formaterNullableIsoDato(beløpsperiode.periode.tildato)}`;
 
-            return `<tr>
-                        <td style="${borderStyling}">${andelsperiode}</td>
+            return `<tr style="text-align: right;">
+                        <td style="text-align: left; ${borderStylingCompact}">${andelsperiode}</td>
                         <td style="${borderStyling}">${inntekt}</td>
                         ${
                             samordningskolonneTittel &&


### PR DESCRIPTION
Denn PRen løser et lesbarhetsproblem i forbindelse med brevtabellene.

Før:
<img width="561" alt="Skjermbilde 2022-05-11 kl  10 25 00" src="https://user-images.githubusercontent.com/32769446/167804117-c673c130-fa0f-4d65-842b-2eaa2e50f426.png">
<img width="552" alt="Skjermbilde 2022-05-11 kl  10 25 06" src="https://user-images.githubusercontent.com/32769446/167804135-80a02c41-fffc-4c10-828d-e25f0c3da01b.png">

Etter:
<img width="552" alt="Skjermbilde 2022-05-11 kl  10 23 40" src="https://user-images.githubusercontent.com/32769446/167804168-c5446455-f1f6-40de-a761-f7b71bab5be2.png">
<img width="514" alt="Skjermbilde 2022-05-11 kl  10 23 55" src="https://user-images.githubusercontent.com/32769446/167804185-132f97fe-f30a-4768-8271-47528c1e74c2.png">

