### PR TITLE
utbedret alert og hjelpetekst i forbindelse med nullebløp pga kontant…

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtregnignstabellBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtregnignstabellBarnetilsyn.tsx
@@ -36,7 +36,7 @@ const VenstrejustertElement = styled(Element)`
 
 const AdvarselContainter = styled.div`
     margin-top: 1rem;
-    width: 21rem;
+    max-width: 43.5rem;
 `;
 
 export const UtregningstabellBarnetilsyn: React.FC<{
@@ -100,8 +100,15 @@ export const UtregningstabellBarnetilsyn: React.FC<{
                     ))}
                     {blirNullUtbetalingPgaOverstigendeKontantstøtte(beregningsresultat) && (
                         <AdvarselContainter>
-                            <Alert variant={'warning'} size={'small'}>
-                                Avslag, kontantstøtte overstiger utgifter
+                            <Alert variant={'warning'} size={'medium'}>
+                                <Heading spacing size="xsmall" level="5">
+                                    Avslag/Opphør - kontantstøtte overstiger tilsynsutgifter.
+                                </Heading>
+                                <Normaltekst>
+                                    Siden kontantstøttebeløpet overstiger utgiftsbeløpet er
+                                    vedtaksresultatet automatisk endret til "Avslag/opphør pga
+                                    kontantstøtte"
+                                </Normaltekst>
                             </Alert>
                         </AdvarselContainter>
                     )}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/SelectVedtaksresultat.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/SelectVedtaksresultat.tsx
@@ -101,18 +101,16 @@ const SelectVedtaksresultat = (props: Props): JSX.Element => {
                         </option>
                     )}
                 </StyledSelect>
-                {nullUtbetalingPgaKontantstøtte && (
-                    <HjelpeTekst title="Hvor kommer dette fra?" placement={'right'}>
-                        <div>
-                            Siden kontantstøttebeløpet overstiger utgiftsbeløpet vil dette medføre
-                            et avslag eller et opphør.
-                        </div>
-                        <TekstLinje>
-                            Dersom bruker tidligere har fått utbetaling for noen av periodene vil
-                            dette resultere i opphør.
-                        </TekstLinje>
-                    </HjelpeTekst>
-                )}
+                <HjelpeTekst title="Hvor kommer dette fra?" placement={'right'}>
+                    <div>
+                        Hvis kontantstøtten overstiger tilsynsutgiftene skal saksbehandler likevel
+                        velge "Innvilge" som vedtaksresultat.
+                    </div>
+                    <TekstLinje>
+                        Utgifter og kontantsstøtte fylles inn som normalt og systemet vil beregne at
+                        det blir et avslag.
+                    </TekstLinje>
+                </HjelpeTekst>
             </FlexDiv>
         </section>
     );


### PR DESCRIPTION
…støtte for barnetilsyn.

Løser kommentarene i [denne oppgave](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8476)

Før:
<img width="1052" alt="Skjermbilde 2022-05-11 kl  11 16 19" src="https://user-images.githubusercontent.com/32769446/167814994-15bd4ea7-df34-46ee-84f6-4e684638ddc5.png">
<img width="804" alt="Skjermbilde 2022-05-11 kl  11 16 24" src="https://user-images.githubusercontent.com/32769446/167815005-aaa91e0a-81c3-4887-b0dd-c459e3df00da.png">

Etter:
<img width="1169" alt="Skjermbilde 2022-05-11 kl  11 16 04" src="https://user-images.githubusercontent.com/32769446/167815049-0501e9bf-56ab-4bb1-af54-09a88bf256d6.png">
<img width="766" alt="Skjermbilde 2022-05-11 kl  11 15 56" src="https://user-images.githubusercontent.com/32769446/167815067-213e9431-7067-4837-896f-2b1a467236b1.png">

