### PR TITLE
Vise stønadstype i behandling

### DIFF
--- a/src/frontend/App/typer/behandlingstema.ts
+++ b/src/frontend/App/typer/behandlingstema.ts
@@ -19,6 +19,12 @@ export const stønadstypeTilTekst: Record<Stønadstype, string> = {
     BARNETILSYN: 'Barnetilsyn',
 };
 
+export const stønadstypeTilTekstKort: Record<Stønadstype, string> = {
+    OVERGANGSSTØNAD: 'OS',
+    SKOLEPENGER: 'SP',
+    BARNETILSYN: 'BT',
+};
+
 export const behandlingstemaTilStønadstype = (
     behandlingstema: Behandlingstema | undefined
 ): Stønadstype | undefined => {

--- a/src/frontend/App/typer/behandlingstype.ts
+++ b/src/frontend/App/typer/behandlingstype.ts
@@ -13,3 +13,11 @@ export const behandlingstypeTilTekst: Record<Behandlingstype, string> = {
     TEKNISK_OPPHØR: 'Teknisk opphør',
     TILBAKEKREVING: 'Tilbakekreving',
 };
+
+export const behandlingstypeTilTekstKort: Record<Behandlingstype, string> = {
+    FØRSTEGANGSBEHANDLING: 'F',
+    REVURDERING: 'R',
+    BLANKETT: 'B',
+    TEKNISK_OPPHØR: 'TO',
+    TILBAKEKREVING: 'T',
+};

--- a/src/frontend/Felles/Visittkort/Status/StatusElementer.tsx
+++ b/src/frontend/Felles/Visittkort/Status/StatusElementer.tsx
@@ -9,6 +9,7 @@ import { behandlingstypeTilTekst } from '../../../App/typer/behandlingstype';
 import { formaterIsoDatoTid } from '../../../App/utils/formatter';
 import { Normaltekst } from 'nav-frontend-typografi';
 import styled from 'styled-components';
+import { stønadstypeTilTekst } from '../../../App/typer/behandlingstema';
 
 interface StatusMenyInnholdProps {
     åpen: boolean;
@@ -54,6 +55,12 @@ const StatusMenyInnhold = styled.div`
 
 const VisStatuserKnapp = styled(Button)`
     color: ${navFarger.navGra60};
+`;
+
+const VisStønadOgBehandlingstypePåLitenSkjerm = styled.div`
+    @media screen and (min-width: 760px) {
+        display: none;
+    }
 `;
 
 export const Statuser = styled.div`
@@ -107,6 +114,24 @@ export const StatusMeny: FC<{ behandling: Behandling }> = ({ behandling }) => {
             </VisStatuserKnapp>
             <StatusMenyInnhold åpen={åpenStatusMeny}>
                 <ul>
+                    <VisStønadOgBehandlingstypePåLitenSkjerm>
+                        <li>
+                            <Status>
+                                <GråTekst>Stønadstype</GråTekst>
+                                <Normaltekst>
+                                    {stønadstypeTilTekst[behandling.stønadstype]}
+                                </Normaltekst>
+                            </Status>
+                        </li>
+                        <li>
+                            <Status>
+                                <GråTekst>Behandlingstype</GråTekst>
+                                <Normaltekst>
+                                    {behandlingstypeTilTekst[behandling.type]}
+                                </Normaltekst>
+                            </Status>
+                        </li>
+                    </VisStønadOgBehandlingstypePåLitenSkjerm>
                     <li>
                         <Status>
                             <GråTekst>Behandlingsstatus</GråTekst>
@@ -142,10 +167,6 @@ export const StatusMeny: FC<{ behandling: Behandling }> = ({ behandling }) => {
 export const AlleStatuser: FC<{ behandling: Behandling }> = ({ behandling }) => {
     return (
         <Statuser>
-            <Status>
-                <GråTekst>Behandlingstype</GråTekst>
-                <Normaltekst>{behandlingstypeTilTekst[behandling.type]}</Normaltekst>
-            </Status>
             <Status>
                 <GråTekst>Behandlingsstatus</GråTekst>
                 <Normaltekst>{behandlingStatusTilTekst[behandling.status]}</Normaltekst>

--- a/src/frontend/Felles/Visittkort/Visittkort.tsx
+++ b/src/frontend/Felles/Visittkort/Visittkort.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { Element, Normaltekst } from 'nav-frontend-typografi';
 import PersonStatusVarsel from '../Varsel/PersonStatusVarsel';
 import AdressebeskyttelseVarsel from '../Varsel/AdressebeskyttelseVarsel';
-import { EtikettFokus, EtikettInfo } from 'nav-frontend-etiketter';
+import { EtikettFokus, EtikettInfo, EtikettSuksess } from 'nav-frontend-etiketter';
 import { Behandling } from '../../App/typer/fagsak';
 import navFarger from 'nav-frontend-core';
 import { Sticky } from '../Visningskomponenter/Sticky';
@@ -18,7 +18,7 @@ import { IPersonIdent } from '../../App/typer/felles';
 import Alertstripe from 'nav-frontend-alertstriper';
 import { Hamburgermeny } from './Hamburgermeny';
 import { erBehandlingRedigerbar } from '../../App/typer/behandlingstatus';
-import { behandlingstypeTilTekst } from '../../App/typer/behandlingstype';
+import { Behandlingstype, behandlingstypeTilTekst } from '../../App/typer/behandlingstype';
 import {
     StatuserLitenSkjerm,
     StatusMeny,
@@ -72,6 +72,19 @@ const stønadstypeTilTag = (stønadstype: Stønadstype) => {
             return 'BT';
         case Stønadstype.SKOLEPENGER:
             return 'SP';
+        default:
+            return '';
+    }
+};
+
+const behandlingstypeTilTag = (behandlingstype: Behandlingstype) => {
+    switch (behandlingstype) {
+        case Behandlingstype.FØRSTEGANGSBEHANDLING:
+            return 'F';
+        case Behandlingstype.REVURDERING:
+            return 'R';
+        default:
+            return '';
     }
 };
 
@@ -120,6 +133,9 @@ const VisittkortComponent: FC<{ data: IPersonopplysninger; behandling?: Behandli
         // eslint-disable-next-line
     }, []);
 
+    const behandlingstypeTag = behandling && behandlingstypeTilTag(behandling.type);
+    const stønadstypeTag = behandling && stønadstypeTilTag(behandling.stønadstype);
+
     return (
         <VisittkortWrapper>
             {feilFagsakHenting && <Alertstripe type="feil">Kunne ikke hente fagsak</Alertstripe>}
@@ -165,9 +181,14 @@ const VisittkortComponent: FC<{ data: IPersonopplysninger; behandling?: Behandli
                         <EtikettFokus mini>Fullmakt</EtikettFokus>
                     </ElementWrapper>
                 )}
-                {behandling && (
+                {behandlingstypeTag && (
                     <ElementWrapper>
-                        <EtikettInfo mini>{stønadstypeTilTag(behandling.stønadstype)}</EtikettInfo>
+                        <EtikettSuksess mini>{stønadstypeTag}</EtikettSuksess>
+                    </ElementWrapper>
+                )}
+                {behandlingstypeTag && (
+                    <ElementWrapper>
+                        <EtikettSuksess mini>{behandlingstypeTag}</EtikettSuksess>
                     </ElementWrapper>
                 )}
                 {vergemål.length > 0 && (

--- a/src/frontend/Felles/Visittkort/Visittkort.tsx
+++ b/src/frontend/Felles/Visittkort/Visittkort.tsx
@@ -2,7 +2,7 @@ import React, { FC, useEffect, useState } from 'react';
 import { IPersonopplysninger } from '../../App/typer/personopplysninger';
 import Visittkort from '@navikt/familie-visittkort';
 import styled from 'styled-components';
-import { Element, Normaltekst } from 'nav-frontend-typografi';
+import { Element } from 'nav-frontend-typografi';
 import PersonStatusVarsel from '../Varsel/PersonStatusVarsel';
 import AdressebeskyttelseVarsel from '../Varsel/AdressebeskyttelseVarsel';
 import { EtikettFokus, EtikettInfo, EtikettSuksess } from 'nav-frontend-etiketter';
@@ -18,15 +18,12 @@ import { IPersonIdent } from '../../App/typer/felles';
 import Alertstripe from 'nav-frontend-alertstriper';
 import { Hamburgermeny } from './Hamburgermeny';
 import { erBehandlingRedigerbar } from '../../App/typer/behandlingstatus';
-import { Behandlingstype, behandlingstypeTilTekst } from '../../App/typer/behandlingstype';
 import {
-    StatuserLitenSkjerm,
-    StatusMeny,
-    Status,
-    AlleStatuser,
-    GråTekst,
-} from './Status/StatusElementer';
-import { Stønadstype } from '../../App/typer/behandlingstema';
+    behandlingstypeTilTekst,
+    behandlingstypeTilTekstKort,
+} from '../../App/typer/behandlingstype';
+import { StatuserLitenSkjerm, StatusMeny, AlleStatuser } from './Status/StatusElementer';
+import { stønadstypeTilTekst, stønadstypeTilTekstKort } from '../../App/typer/behandlingstema';
 
 const Visningsnavn = styled(Element)`
     text-overflow: ellipsis;
@@ -38,6 +35,22 @@ const ResponsivLenke = styled(Lenke)`
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
+`;
+
+const TagsLitenSkjerm = styled.div`
+    @media screen and (min-width: 946px) {
+        display: none;
+    }
+
+    @media screen and (max-width: 760px) {
+        display: none;
+    }
+`;
+
+const TagsStorSkjerm = styled.div`
+    @media screen and (max-width: 946px) {
+        display: none;
+    }
 `;
 
 export const VisittkortWrapper = styled(Sticky)`
@@ -63,30 +76,6 @@ const StyledHamburgermeny = styled(Hamburgermeny)`
 const ElementWrapper = styled.div`
     margin-left: 1rem;
 `;
-
-const stønadstypeTilTag = (stønadstype: Stønadstype) => {
-    switch (stønadstype) {
-        case Stønadstype.OVERGANGSSTØNAD:
-            return 'OS';
-        case Stønadstype.BARNETILSYN:
-            return 'BT';
-        case Stønadstype.SKOLEPENGER:
-            return 'SP';
-        default:
-            return '';
-    }
-};
-
-const behandlingstypeTilTag = (behandlingstype: Behandlingstype) => {
-    switch (behandlingstype) {
-        case Behandlingstype.FØRSTEGANGSBEHANDLING:
-            return 'F';
-        case Behandlingstype.REVURDERING:
-            return 'R';
-        default:
-            return '';
-    }
-};
 
 const VisittkortComponent: FC<{ data: IPersonopplysninger; behandling?: Behandling }> = ({
     data,
@@ -133,9 +122,6 @@ const VisittkortComponent: FC<{ data: IPersonopplysninger; behandling?: Behandli
         // eslint-disable-next-line
     }, []);
 
-    const behandlingstypeTag = behandling && behandlingstypeTilTag(behandling.type);
-    const stønadstypeTag = behandling && stønadstypeTilTag(behandling.stønadstype);
-
     return (
         <VisittkortWrapper>
             {feilFagsakHenting && <Alertstripe type="feil">Kunne ikke hente fagsak</Alertstripe>}
@@ -181,14 +167,34 @@ const VisittkortComponent: FC<{ data: IPersonopplysninger; behandling?: Behandli
                         <EtikettFokus mini>Fullmakt</EtikettFokus>
                     </ElementWrapper>
                 )}
-                {behandlingstypeTag && (
+                {behandling && (
                     <ElementWrapper>
-                        <EtikettSuksess mini>{stønadstypeTag}</EtikettSuksess>
+                        <>
+                            <TagsLitenSkjerm>
+                                <EtikettSuksess mini>
+                                    {stønadstypeTilTekstKort[behandling.stønadstype]}
+                                </EtikettSuksess>
+                            </TagsLitenSkjerm>
+                            <TagsStorSkjerm>
+                                <EtikettSuksess mini>
+                                    {stønadstypeTilTekst[behandling.stønadstype]}
+                                </EtikettSuksess>
+                            </TagsStorSkjerm>
+                        </>
                     </ElementWrapper>
                 )}
-                {behandlingstypeTag && (
+                {behandling && (
                     <ElementWrapper>
-                        <EtikettSuksess mini>{behandlingstypeTag}</EtikettSuksess>
+                        <TagsLitenSkjerm>
+                            <EtikettInfo mini>
+                                {behandlingstypeTilTekstKort[behandling.type]}
+                            </EtikettInfo>
+                        </TagsLitenSkjerm>
+                        <TagsStorSkjerm>
+                            <EtikettInfo mini>
+                                {behandlingstypeTilTekst[behandling.type]}
+                            </EtikettInfo>
+                        </TagsStorSkjerm>
                     </ElementWrapper>
                 )}
                 {vergemål.length > 0 && (
@@ -207,10 +213,6 @@ const VisittkortComponent: FC<{ data: IPersonopplysninger; behandling?: Behandli
                 <>
                     <AlleStatuser behandling={behandling} />
                     <StatuserLitenSkjerm>
-                        <Status kunEttElement={true}>
-                            <GråTekst>Behandlingstype</GråTekst>
-                            <Normaltekst>{behandlingstypeTilTekst[behandling.type]}</Normaltekst>
-                        </Status>
                         <StatusMeny behandling={behandling} />
                     </StatuserLitenSkjerm>
                 </>

--- a/src/frontend/Felles/Visittkort/Visittkort.tsx
+++ b/src/frontend/Felles/Visittkort/Visittkort.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { Element, Normaltekst } from 'nav-frontend-typografi';
 import PersonStatusVarsel from '../Varsel/PersonStatusVarsel';
 import AdressebeskyttelseVarsel from '../Varsel/AdressebeskyttelseVarsel';
-import { EtikettFokus } from 'nav-frontend-etiketter';
+import { EtikettFokus, EtikettInfo } from 'nav-frontend-etiketter';
 import { Behandling } from '../../App/typer/fagsak';
 import navFarger from 'nav-frontend-core';
 import { Sticky } from '../Visningskomponenter/Sticky';
@@ -26,6 +26,7 @@ import {
     AlleStatuser,
     GråTekst,
 } from './Status/StatusElementer';
+import { Stønadstype } from '../../App/typer/behandlingstema';
 
 const Visningsnavn = styled(Element)`
     text-overflow: ellipsis;
@@ -62,6 +63,17 @@ const StyledHamburgermeny = styled(Hamburgermeny)`
 const ElementWrapper = styled.div`
     margin-left: 1rem;
 `;
+
+const stønadstypeTilTag = (stønadstype: Stønadstype) => {
+    switch (stønadstype) {
+        case Stønadstype.OVERGANGSSTØNAD:
+            return 'OS';
+        case Stønadstype.BARNETILSYN:
+            return 'BT';
+        case Stønadstype.SKOLEPENGER:
+            return 'SP';
+    }
+};
 
 const VisittkortComponent: FC<{ data: IPersonopplysninger; behandling?: Behandling }> = ({
     data,
@@ -151,6 +163,11 @@ const VisittkortComponent: FC<{ data: IPersonopplysninger; behandling?: Behandli
                 {fullmakt.some((f) => erEtterDagensDato(f.gyldigTilOgMed)) && (
                     <ElementWrapper>
                         <EtikettFokus mini>Fullmakt</EtikettFokus>
+                    </ElementWrapper>
+                )}
+                {behandling && (
+                    <ElementWrapper>
+                        <EtikettInfo mini>{stønadstypeTilTag(behandling.stønadstype)}</EtikettInfo>
                     </ElementWrapper>
                 )}
                 {vergemål.length > 0 && (


### PR DESCRIPTION
Viser stønadstype i behandling. Løser [denne Favro-oppgaven](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8289)..

Stor skjerm:
<img width="1132" alt="Skjermbilde 2022-05-16 kl  13 05 51" src="https://user-images.githubusercontent.com/1413265/168579575-05ea2f13-544c-46b3-9a7b-32ee96aa1a8e.png">

Mindre skjerm:
<img width="746" alt="Skjermbilde 2022-05-16 kl  13 06 10" src="https://user-images.githubusercontent.com/1413265/168579614-370e8cc0-c8a8-405b-9f35-a2c8d40c8a69.png">

Ved endra mindre skjerm forsvinner tags helt og legges bak dropdown:
<img width="723" alt="Skjermbilde 2022-05-16 kl  13 06 28" src="https://user-images.githubusercontent.com/1413265/168579653-51d5d813-7036-4986-ae6f-abda995d48d6.png">

