### PR TITLE
skalViseSøknadsdata=true når årsak er papirsøknad for å kunne vise te…

### DIFF
--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
@@ -46,7 +46,9 @@ const Inngangsvilkår: FC<Props> = ({ behandlingId }) => {
     return (
         <DataViewer response={{ vilkår, behandling }}>
             {({ vilkår, behandling }) => {
-                const skalViseSøknadsdata = behandling.behandlingsårsak === Behandlingsårsak.SØKNAD;
+                const årsak = behandling.behandlingsårsak;
+                const skalViseSøknadsdata =
+                    årsak === Behandlingsårsak.SØKNAD || årsak === Behandlingsårsak.PAPIRSØKNAD;
                 const grunnlagsdataInnhentetDato = formaterIsoDatoTidMedSekunder(
                     vilkår.grunnlag.registeropplysningerOpprettetTid
                 );


### PR DESCRIPTION
…rmindato på terminbarn

Feil fra demo, då årsak nå er satt til papirsøknad 

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8383