### PR TITLE
Viser g-omregning i lenken i behandlingstype for å vite at årsaken er…

### DIFF
--- a/src/frontend/App/typer/tilkjentytelse.ts
+++ b/src/frontend/App/typer/tilkjentytelse.ts
@@ -1,6 +1,7 @@
 import { Behandlingstype } from './behandlingstype';
 import { EAktivitet, EPeriodetype, ESamordningsfradragtype } from './vedtak';
 import { Sanksjonsårsak } from './Sanksjonsårsak';
+import { Behandlingsårsak } from './Behandlingsårsak';
 
 export interface TilkjentYtelse {
     andeler: AndelTilkjentYtelse[];
@@ -42,6 +43,7 @@ export interface AndelHistorikk {
     erSanksjon: boolean;
     periodeType?: EPeriodetype;
     behandlingType: Behandlingstype;
+    behandlingÅrsak: Behandlingsårsak;
     sanksjonsårsak?: Sanksjonsårsak;
 }
 

--- a/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderOvergangsstønad.tsx
@@ -16,9 +16,20 @@ import {
     HistorikkRad,
     HistorikkTabell,
 } from './vedtakshistorikkUtil';
+import { Behandlingsårsak, behandlingsårsakTilTekst } from '../../../App/typer/Behandlingsårsak';
+
+const lenketekst = (andel: AndelHistorikk) => {
+    if (
+        andel.behandlingÅrsak === Behandlingsårsak.G_OMREGNING ||
+        andel.behandlingÅrsak === Behandlingsårsak.MIGRERING
+    ) {
+        return behandlingsårsakTilTekst[andel.behandlingÅrsak];
+    } else {
+        return behandlingstypeTilTekst[andel.behandlingType];
+    }
+};
 
 const historikkRad = (andel: AndelHistorikk) => {
-    const erMigrering = andel.periodeType === EPeriodetype.MIGRERING;
     const erSanksjon = andel.periodeType === EPeriodetype.SANKSJON;
     return (
         <HistorikkRad type={andel.endring?.type}>
@@ -44,7 +55,7 @@ const historikkRad = (andel: AndelHistorikk) => {
             <td>{andel.saksbehandler}</td>
             <td>
                 <Link className="lenke" to={{ pathname: `/behandling/${andel.behandlingId}` }}>
-                    {erMigrering ? 'Migrering' : behandlingstypeTilTekst[andel.behandlingType]}
+                    {lenketekst(andel)}
                 </Link>
             </td>
             <td>{historikkEndring(andel.endring)}</td>


### PR DESCRIPTION
… g-omregning i vedtakshistorikken

* https://github.com/navikt/familie-ef-sak/pull/1541

https://nav-it.slack.com/archives/C01087QRJ2U/p1653513145531569?thread_ts=1653499992.334259&cid=C01087QRJ2U

![image](https://user-images.githubusercontent.com/937168/170936220-1e94a83a-83cd-47fa-b5f4-02e4a5844490.png)
