### PR TITLE
Småfiks Bostedsadresse

### DIFF
--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
@@ -117,6 +117,7 @@ const Inngangsvilkår: FC<Props> = ({ behandlingId }) => {
                             ikkeVurderVilkår={ikkeVurderVilkår}
                             skalViseSøknadsdata={skalViseSøknadsdata}
                             behandlingId={behandlingId}
+                            behandlingsstatus={behandling.status}
                         />
                         <Aleneomsorg
                             nullstillVurdering={nullstillVurdering}

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Samliv/Bosituasjon.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Samliv/Bosituasjon.tsx
@@ -6,15 +6,13 @@ import { IPersonDetaljer } from '../Sivilstand/typer';
 import { BooleanTekst } from '../../../../Felles/Visningskomponenter/BooleanTilTekst';
 import { ESøkerDelerBolig, IBosituasjon, ISivilstandsplaner } from './typer';
 import { hentPersonInfo } from '../utils';
-import { Bostedsadresse } from './Bostedsadresse';
 
 interface Props {
     bosituasjon: IBosituasjon;
     sivilstandsplaner?: ISivilstandsplaner;
-    behandlingId: string;
 }
 
-export const Bosituasjon: FC<Props> = ({ bosituasjon, sivilstandsplaner, behandlingId }) => {
+export const Bosituasjon: FC<Props> = ({ bosituasjon, sivilstandsplaner }) => {
     return (
         <>
             {bosituasjon.delerDuBolig === ESøkerDelerBolig.harEkteskapsliknendeForhold && (
@@ -45,8 +43,6 @@ export const Bosituasjon: FC<Props> = ({ bosituasjon, sivilstandsplaner, behandl
                 ESøkerDelerBolig.tidligereSamboerFortsattRegistrertPåAdresse,
             ].includes(bosituasjon.delerDuBolig) &&
                 sivilstandsplaner && <Sivilstandsplaner sivilstandsplaner={sivilstandsplaner} />}
-
-            <Bostedsadresse behandlingId={behandlingId} />
         </>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Samliv/Samliv.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Samliv/Samliv.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import { InngangsvilkårType } from '../vilkår';
 import ToKolonnerLayout from '../../../../Felles/Visningskomponenter/ToKolonnerLayout';
 import VisEllerEndreVurdering from '../../Vurdering/VisEllerEndreVurdering';
-import { VilkårPropsMedBehandlingId } from '../vilkårprops';
+import { VilkårPropsMedBehandlingsstatus } from '../vilkårprops';
 import SamlivInfo from './SamlivInfo';
 import { Vilkårstittel } from '../Vilkårstittel';
 
-export const Samliv: React.FC<VilkårPropsMedBehandlingId> = ({
+export const Samliv: React.FC<VilkårPropsMedBehandlingsstatus> = ({
     vurderinger,
     grunnlag,
     lagreVurdering,
@@ -15,6 +15,7 @@ export const Samliv: React.FC<VilkårPropsMedBehandlingId> = ({
     feilmeldinger,
     skalViseSøknadsdata,
     behandlingId,
+    behandlingsstatus,
 }) => {
     const vurdering = vurderinger.find((v) => v.vilkårType === InngangsvilkårType.SAMLIV);
     if (!vurdering) {
@@ -34,6 +35,7 @@ export const Samliv: React.FC<VilkårPropsMedBehandlingId> = ({
                             behandlingId={behandlingId}
                             grunnlag={grunnlag}
                             skalViseSøknadsdata={skalViseSøknadsdata}
+                            behandlingsstatus={behandlingsstatus}
                         />
                     </>
                 ),

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Samliv/SamlivInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Samliv/SamlivInfo.tsx
@@ -9,14 +9,21 @@ import { Bosituasjon } from './Bosituasjon';
 import { SøkerDelerBoligTilTekst } from './typer';
 import { ÅrsakEnsligTilTekst } from '../Sivilstand/typer';
 import { Bostedsadresse } from './Bostedsadresse';
+import { BehandlingStatus } from '../../../../App/typer/behandlingstatus';
 
 interface Props {
     grunnlag: IVilkårGrunnlag;
     skalViseSøknadsdata: boolean;
     behandlingId: string;
+    behandlingsstatus: BehandlingStatus;
 }
 
-const SamlivInfo: FC<Props> = ({ grunnlag, skalViseSøknadsdata, behandlingId }) => {
+const SamlivInfo: FC<Props> = ({
+    grunnlag,
+    skalViseSøknadsdata,
+    behandlingId,
+    behandlingsstatus,
+}) => {
     const { sivilstand, bosituasjon, sivilstandsplaner } = grunnlag;
 
     return (
@@ -55,7 +62,10 @@ const SamlivInfo: FC<Props> = ({ grunnlag, skalViseSøknadsdata, behandlingId })
                             />
                         </>
                     )}
-                    <Bostedsadresse behandlingId={behandlingId} />
+
+                    {behandlingsstatus !== BehandlingStatus.FERDIGSTILT && (
+                        <Bostedsadresse behandlingId={behandlingId} />
+                    )}
                 </GridTabell>
             )}
         </>

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Samliv/SamlivInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Samliv/SamlivInfo.tsx
@@ -8,6 +8,7 @@ import ÅrsakEnslig from './ÅrsakEnslig';
 import { Bosituasjon } from './Bosituasjon';
 import { SøkerDelerBoligTilTekst } from './typer';
 import { ÅrsakEnsligTilTekst } from '../Sivilstand/typer';
+import { Bostedsadresse } from './Bostedsadresse';
 
 interface Props {
     grunnlag: IVilkårGrunnlag;
@@ -20,36 +21,41 @@ const SamlivInfo: FC<Props> = ({ grunnlag, skalViseSøknadsdata, behandlingId })
 
     return (
         <>
-            {skalViseSøknadsdata && sivilstand.søknadsgrunnlag && bosituasjon && sivilstandsplaner && (
+            {sivilstand.søknadsgrunnlag && bosituasjon && sivilstandsplaner && (
                 <GridTabell>
-                    {sivilstand.registergrunnlag.type !== SivilstandType.GIFT && (
+                    {skalViseSøknadsdata && (
                         <>
+                            {sivilstand.registergrunnlag.type !== SivilstandType.GIFT && (
+                                <>
+                                    <Søknadsgrunnlag />
+                                    <Normaltekst>Alene med barn fordi</Normaltekst>
+                                    <Normaltekst>
+                                        {(sivilstand.søknadsgrunnlag.årsakEnslig &&
+                                            ÅrsakEnsligTilTekst[
+                                                sivilstand.søknadsgrunnlag?.årsakEnslig
+                                            ]) ||
+                                            ''}
+                                    </Normaltekst>
+                                    <ÅrsakEnslig søknadsgrunnlag={sivilstand.søknadsgrunnlag} />
+                                </>
+                            )}
+
                             <Søknadsgrunnlag />
-                            <Normaltekst>Alene med barn fordi</Normaltekst>
-                            <Normaltekst>
-                                {(sivilstand.søknadsgrunnlag.årsakEnslig &&
-                                    ÅrsakEnsligTilTekst[sivilstand.søknadsgrunnlag?.årsakEnslig]) ||
-                                    ''}
-                            </Normaltekst>
-                            <ÅrsakEnslig søknadsgrunnlag={sivilstand.søknadsgrunnlag} />
+                            {bosituasjon && (
+                                <>
+                                    <Normaltekst>Bosituasjon</Normaltekst>
+                                    <Normaltekst>
+                                        {SøkerDelerBoligTilTekst[bosituasjon.delerDuBolig] || ''}
+                                    </Normaltekst>
+                                </>
+                            )}
+                            <Bosituasjon
+                                bosituasjon={bosituasjon}
+                                sivilstandsplaner={sivilstandsplaner}
+                            />
                         </>
                     )}
-
-                    <Søknadsgrunnlag />
-                    {bosituasjon && (
-                        <>
-                            <Normaltekst>Bosituasjon</Normaltekst>
-                            <Normaltekst>
-                                {SøkerDelerBoligTilTekst[bosituasjon.delerDuBolig] || ''}
-                            </Normaltekst>
-                        </>
-                    )}
-
-                    <Bosituasjon
-                        behandlingId={behandlingId}
-                        bosituasjon={bosituasjon}
-                        sivilstandsplaner={sivilstandsplaner}
-                    />
+                    <Bostedsadresse behandlingId={behandlingId} />
                 </GridTabell>
             )}
         </>

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/vilkårprops.ts
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/vilkårprops.ts
@@ -7,6 +7,7 @@ import {
 } from './vilkår';
 import { RessursFeilet, RessursSuksess } from '../../../App/typer/ressurs';
 import { Stønadstype } from '../../../App/typer/behandlingstema';
+import { BehandlingStatus } from '../../../App/typer/behandlingstatus';
 
 export interface VilkårProps {
     vurderinger: IVurdering[];
@@ -30,5 +31,10 @@ export interface VilkårPropsMedStønadstype extends VilkårProps {
 }
 
 export interface VilkårPropsMedBehandlingId extends VilkårProps {
+    behandlingId: string;
+}
+
+export interface VilkårPropsMedBehandlingsstatus extends VilkårProps {
+    behandlingsstatus: BehandlingStatus;
     behandlingId: string;
 }


### PR DESCRIPTION
Løser to ting:

- "Se beboere" skal vises når vi skjuler søknadsdata, slik at det vises ved revurdering
- Vi unngår å vise "Se beboere" når saken er ferdigstilt