### PR TITLE
Skolepenger vedtak og beregning styling

### DIFF
--- a/src/frontend/Felles/Knapper/FjernKnappMedTekst.tsx
+++ b/src/frontend/Felles/Knapper/FjernKnappMedTekst.tsx
@@ -10,7 +10,7 @@ const StyledKnapp = styled(Flatknapp)`
     height: 2rem;
 `;
 
-const FjernKnapp: React.FC<{ onClick: () => void; knappetekst: string }> = ({
+const FjernKnappMedTekst: React.FC<{ onClick: () => void; knappetekst: string }> = ({
     onClick,
     knappetekst,
 }) => {
@@ -22,4 +22,4 @@ const FjernKnapp: React.FC<{ onClick: () => void; knappetekst: string }> = ({
     );
 };
 
-export default hiddenIf(FjernKnapp);
+export default hiddenIf(FjernKnappMedTekst);

--- a/src/frontend/Felles/Knapper/FjernKnappMedTekst.tsx
+++ b/src/frontend/Felles/Knapper/FjernKnappMedTekst.tsx
@@ -1,0 +1,25 @@
+import { Delete } from '@navikt/ds-icons';
+import React from 'react';
+import { Flatknapp } from 'nav-frontend-knapper';
+import hiddenIf from '../HiddenIf/hiddenIf';
+import styled from 'styled-components';
+
+const StyledKnapp = styled(Flatknapp)`
+    padding: 0;
+    margin-bottom: 0.25rem;
+    height: 2rem;
+`;
+
+const FjernKnapp: React.FC<{ onClick: () => void; knappetekst: string }> = ({
+    onClick,
+    knappetekst,
+}) => {
+    return (
+        <StyledKnapp onClick={onClick} htmlType="button">
+            <Delete />
+            <span>{knappetekst}</span>
+        </StyledKnapp>
+    );
+};
+
+export default hiddenIf(FjernKnapp);

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/SkoleårsperioderSkolepenger.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/SkoleårsperioderSkolepenger.tsx
@@ -80,8 +80,6 @@ const SkoleårsperioderSkolepenger: React.FC<Props> = ({
                     index === skoleårsperioder.value.length - 1 &&
                     index !== 0 &&
                     !inneholderLåsteUtgifter;
-                const erSisteSkoleår = index + 1 === skoleårsperioder.value.length;
-                const skalViseLeggTilSkoleår = behandlingErRedigerbar && erSisteSkoleår;
                 return (
                     <>
                         <Skoleårsperiode key={index}>
@@ -127,14 +125,14 @@ const SkoleårsperioderSkolepenger: React.FC<Props> = ({
                                 />
                             )}
                         </Skoleårsperiode>
-                        <LeggTilKnapp
-                            onClick={() => skoleårsperioder.push(tomSkoleårsperiodeSkolepenger())}
-                            knappetekst="Legg til skoleår"
-                            hidden={!skalViseLeggTilSkoleår}
-                        />
                     </>
                 );
             })}
+            <LeggTilKnapp
+                onClick={() => skoleårsperioder.push(tomSkoleårsperiodeSkolepenger())}
+                knappetekst="Legg til skoleår"
+                hidden={!behandlingErRedigerbar}
+            />
         </>
     );
 };

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/SkoleårsperioderSkolepenger.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/SkoleårsperioderSkolepenger.tsx
@@ -11,9 +11,16 @@ import { VEDTAK_OG_BEREGNING } from '../../Felles/konstanter';
 import SkoleårDelårsperiode from './SkoleårDelårsperiode';
 import UtgiftsperiodeSkolepenger from './UtgiftsperiodeSkolepenger';
 import { tomSkoleårsperiodeSkolepenger } from '../typer';
-import FjernKnapp from '../../../../../Felles/Knapper/FjernKnapp';
+import navFarger from 'nav-frontend-core';
+import FjernKnappMedTekst from '../../../../../Felles/Knapper/FjernKnappMedTekst';
 
-const Skoleårsperiode = styled.div``;
+const Skoleårsperiode = styled.div`
+    margin: 1rem;
+    margin-right: 0.5rem;
+    margin-left: 0rem;
+    padding: 1rem;
+    background-color: ${navFarger.navGraBakgrunn};
+`;
 
 interface Props {
     skoleårsperioder: ListState<ISkoleårsperiodeSkolepenger>;
@@ -76,44 +83,56 @@ const SkoleårsperioderSkolepenger: React.FC<Props> = ({
                 const erSisteSkoleår = index + 1 === skoleårsperioder.value.length;
                 const skalViseLeggTilSkoleår = behandlingErRedigerbar && erSisteSkoleår;
                 return (
-                    <Skoleårsperiode key={index}>
-                        <SkoleårDelårsperiode
-                            data={skoleårsperiode.perioder}
-                            oppdater={(perioder) =>
-                                oppdaterSkoleårsperioder(index, 'perioder', perioder)
-                            }
-                            behandlingErRedigerbar={behandlingErRedigerbar}
-                            valideringsfeil={valideringsfeil && valideringsfeil[index]?.perioder}
-                            settValideringsFeil={(oppdaterteFeil) =>
-                                oppdaterValideringsfeil(index, 'perioder', oppdaterteFeil)
-                            }
-                        />
-                        <UtgiftsperiodeSkolepenger
-                            data={skoleårsperiode.utgiftsperioder}
-                            oppdater={(utgiftsperioder) =>
-                                oppdaterSkoleårsperioder(index, 'utgiftsperioder', utgiftsperioder)
-                            }
-                            behandlingErRedigerbar={behandlingErRedigerbar}
-                            valideringsfeil={
-                                valideringsfeil && valideringsfeil[index]?.utgiftsperioder
-                            }
-                            settValideringsFeil={(oppdaterteFeil) =>
-                                oppdaterValideringsfeil(index, 'utgiftsperioder', oppdaterteFeil)
-                            }
-                            låsteUtgiftIder={låsteUtgiftIder}
-                        />
-                        {skalViseFjernKnapp && (
-                            <FjernKnapp
-                                onClick={() => fjernSkoleårsperiode(index)}
-                                knappetekst="Fjern skoleår"
+                    <>
+                        <Skoleårsperiode key={index}>
+                            <SkoleårDelårsperiode
+                                data={skoleårsperiode.perioder}
+                                oppdater={(perioder) =>
+                                    oppdaterSkoleårsperioder(index, 'perioder', perioder)
+                                }
+                                behandlingErRedigerbar={behandlingErRedigerbar}
+                                valideringsfeil={
+                                    valideringsfeil && valideringsfeil[index]?.perioder
+                                }
+                                settValideringsFeil={(oppdaterteFeil) =>
+                                    oppdaterValideringsfeil(index, 'perioder', oppdaterteFeil)
+                                }
                             />
-                        )}
+                            <UtgiftsperiodeSkolepenger
+                                data={skoleårsperiode.utgiftsperioder}
+                                oppdater={(utgiftsperioder) =>
+                                    oppdaterSkoleårsperioder(
+                                        index,
+                                        'utgiftsperioder',
+                                        utgiftsperioder
+                                    )
+                                }
+                                behandlingErRedigerbar={behandlingErRedigerbar}
+                                valideringsfeil={
+                                    valideringsfeil && valideringsfeil[index]?.utgiftsperioder
+                                }
+                                settValideringsFeil={(oppdaterteFeil) =>
+                                    oppdaterValideringsfeil(
+                                        index,
+                                        'utgiftsperioder',
+                                        oppdaterteFeil
+                                    )
+                                }
+                                låsteUtgiftIder={låsteUtgiftIder}
+                            />
+                            {skalViseFjernKnapp && (
+                                <FjernKnappMedTekst
+                                    onClick={() => fjernSkoleårsperiode(index)}
+                                    knappetekst="Fjern skoleår"
+                                />
+                            )}
+                        </Skoleårsperiode>
                         <LeggTilKnapp
                             onClick={() => skoleårsperioder.push(tomSkoleårsperiodeSkolepenger())}
                             knappetekst="Legg til skoleår"
                             hidden={!skalViseLeggTilSkoleår}
                         />
-                    </Skoleårsperiode>
+                    </>
                 );
             })}
         </>

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/SkoleårsperioderSkolepenger.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/SkoleårsperioderSkolepenger.tsx
@@ -73,6 +73,8 @@ const SkoleårsperioderSkolepenger: React.FC<Props> = ({
                     index === skoleårsperioder.value.length - 1 &&
                     index !== 0 &&
                     !inneholderLåsteUtgifter;
+                const erSisteSkoleår = index + 1 === skoleårsperioder.value.length;
+                const skalViseLeggTilSkoleår = behandlingErRedigerbar && erSisteSkoleår;
                 return (
                     <Skoleårsperiode key={index}>
                         <SkoleårDelårsperiode
@@ -109,7 +111,7 @@ const SkoleårsperioderSkolepenger: React.FC<Props> = ({
                         <LeggTilKnapp
                             onClick={() => skoleårsperioder.push(tomSkoleårsperiodeSkolepenger())}
                             knappetekst="Legg til skoleår"
-                            hidden={!behandlingErRedigerbar}
+                            hidden={!skalViseLeggTilSkoleår}
                         />
                     </Skoleårsperiode>
                 );

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/UtgiftsperiodeSkolepenger.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/UtgiftsperiodeSkolepenger.tsx
@@ -23,8 +23,9 @@ const StyledInputMedTusenSkille = styled(InputMedTusenSkille)`
     text-align: left;
 `;
 
-const FlexRow = styled.div`
+const FlexRow = styled.div<{ lesevisning?: boolean }>`
     display: flex;
+    margin-top: ${(props) => (props.lesevisning ? '0.75rem' : '0rem')};
 `;
 
 const FlexColumn = styled.div`
@@ -32,8 +33,9 @@ const FlexColumn = styled.div`
     flex-direction: column;
 `;
 
-const BlåStrek = styled.span`
-    border-left: 3px solid ${navFarger.navBlaLighten40};
+const FargetStrek = styled.span<{ lesevisning?: boolean }>`
+    border-left: 3px solid
+        ${(props) => (props.lesevisning ? navFarger.navGra80 : navFarger.navBlaLighten40)};
     margin-right: 0.5rem;
     margin-left: 0.5rem;
     margin-bottom: 0.75rem;
@@ -66,8 +68,8 @@ const UtgiftsperiodeSkolepenger: React.FC<
     };
 
     return (
-        <FlexRow>
-            <BlåStrek />
+        <FlexRow lesevisning={erLesevisning}>
+            <FargetStrek lesevisning={erLesevisning} />
             <div style={{ marginLeft: '1rem' }}>
                 <FlexColumn>
                     <Utgiftsrad erHeader={true}>

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/UtgiftsperiodeSkolepenger.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/UtgiftsperiodeSkolepenger.tsx
@@ -8,6 +8,7 @@ import FjernKnapp from '../../../../../Felles/Knapper/FjernKnapp';
 import LeggTilKnapp from '../../../../../Felles/Knapper/LeggTilKnapp';
 import { tomUtgift, ValideringsPropsMedOppdatering } from '../typer';
 import InputMedTusenSkille from '../../../../../Felles/Visningskomponenter/InputMedTusenskille';
+import navFarger from 'nav-frontend-core';
 
 const Utgiftsrad = styled.div<{ lesevisning?: boolean; erHeader?: boolean }>`
     display: grid;
@@ -15,11 +16,27 @@ const Utgiftsrad = styled.div<{ lesevisning?: boolean; erHeader?: boolean }>`
     grid-template-columns: ${(props) =>
         props.lesevisning ? '10rem 10rem 5rem' : '12rem 12rem 5rem 4rem'};
     grid-gap: ${(props) => (props.lesevisning ? '0.5rem' : '1rem')};
-    margin-bottom: ${(props) => (props.erHeader ? '0,5rem' : 0)};
+    margin-bottom: ${(props) => (props.erHeader ? '0rem' : '0.5rem')};
 `;
 
 const StyledInputMedTusenSkille = styled(InputMedTusenSkille)`
     text-align: left;
+`;
+
+const FlexRow = styled.div`
+    display: flex;
+`;
+
+const FlexColumn = styled.div`
+    display: flex;
+    flex-direction: column;
+`;
+
+const BlåStrek = styled.span`
+    border-left: 3px solid ${navFarger.navBlaLighten40};
+    margin-right: 0.5rem;
+    margin-left: 0.5rem;
+    margin-bottom: 0.75rem;
 `;
 
 const UtgiftsperiodeSkolepenger: React.FC<
@@ -49,70 +66,85 @@ const UtgiftsperiodeSkolepenger: React.FC<
     };
 
     return (
-        <div style={{ marginLeft: '1rem' }}>
-            <Utgiftsrad>
-                <Element>Utbetalingsmåned</Element>
-                <Element>Utgifter</Element>
-                <Element>Stønad</Element>
-            </Utgiftsrad>
-            {data.map((utgift, index) => {
-                const erLåstFraForrigeBehandling = låsteUtgiftIder.indexOf(utgift.id) > -1;
-                const skalViseFjernKnapp =
-                    behandlingErRedigerbar &&
-                    index === data.length - 1 &&
-                    index !== 0 &&
-                    !erLåstFraForrigeBehandling;
-                return (
-                    <Utgiftsrad key={index}>
-                        <MånedÅrVelger
-                            årMånedInitiell={utgift.årMånedFra}
-                            //label={datoFraTekst}
-                            onEndret={(verdi) => {
-                                oppdaterUtgift(index, 'årMånedFra', verdi);
-                            }}
-                            antallÅrTilbake={10}
-                            antallÅrFrem={4}
-                            lesevisning={erLesevisning}
-                            feilmelding={valideringsfeil && valideringsfeil[index]?.årMånedFra}
-                            disabled={erLåstFraForrigeBehandling}
-                        />
-                        <StyledInputMedTusenSkille
-                            onKeyPress={tilHeltall}
-                            type="number"
-                            value={harTallverdi(utgift.utgifter) ? utgift.utgifter : ''}
-                            feil={valideringsfeil && valideringsfeil[index]?.utgifter}
-                            onChange={(e) => {
-                                oppdaterUtgift(index, 'utgifter', tilTallverdi(e.target.value));
-                            }}
-                            erLesevisning={erLesevisning}
-                            disabled={erLåstFraForrigeBehandling}
-                        />
-                        <StyledInputMedTusenSkille
-                            onKeyPress={tilHeltall}
-                            type="number"
-                            value={harTallverdi(utgift.stønad) ? utgift.stønad : ''}
-                            feil={valideringsfeil && valideringsfeil[index]?.stønad}
-                            onChange={(e) => {
-                                oppdaterUtgift(index, 'stønad', tilTallverdi(e.target.value));
-                            }}
-                            erLesevisning={erLesevisning}
-                            disabled={erLåstFraForrigeBehandling}
-                        />
-                        {skalViseFjernKnapp && (
-                            <FjernKnapp
-                                onClick={() => fjernUtgift(index)}
-                                knappetekst="Fjern vedtaksperiode"
-                            />
-                        )}
+        <FlexRow>
+            <BlåStrek />
+            <div style={{ marginLeft: '1rem' }}>
+                <FlexColumn>
+                    <Utgiftsrad erHeader={true}>
+                        <Element>Utbetalingsmåned</Element>
+                        <Element>Utgifter</Element>
+                        <Element>Stønad</Element>
                     </Utgiftsrad>
-                );
-            })}
-            <LeggTilKnapp
-                onClick={() => oppdater([...data, tomUtgift()])}
-                knappetekst="Legg til utgift"
-                hidden={!behandlingErRedigerbar}
-            />
-        </div>
+                    {data.map((utgift, index) => {
+                        const erLåstFraForrigeBehandling = låsteUtgiftIder.indexOf(utgift.id) > -1;
+                        const skalViseFjernKnapp =
+                            behandlingErRedigerbar &&
+                            index === data.length - 1 &&
+                            index !== 0 &&
+                            !erLåstFraForrigeBehandling;
+                        return (
+                            <Utgiftsrad erHeader={false} key={index}>
+                                <MånedÅrVelger
+                                    årMånedInitiell={utgift.årMånedFra}
+                                    //label={datoFraTekst}
+                                    onEndret={(verdi) => {
+                                        oppdaterUtgift(index, 'årMånedFra', verdi);
+                                    }}
+                                    antallÅrTilbake={10}
+                                    antallÅrFrem={4}
+                                    lesevisning={erLesevisning}
+                                    feilmelding={
+                                        valideringsfeil && valideringsfeil[index]?.årMånedFra
+                                    }
+                                    disabled={erLåstFraForrigeBehandling}
+                                />
+                                <StyledInputMedTusenSkille
+                                    onKeyPress={tilHeltall}
+                                    type="number"
+                                    value={harTallverdi(utgift.utgifter) ? utgift.utgifter : ''}
+                                    feil={valideringsfeil && valideringsfeil[index]?.utgifter}
+                                    onChange={(e) => {
+                                        oppdaterUtgift(
+                                            index,
+                                            'utgifter',
+                                            tilTallverdi(e.target.value)
+                                        );
+                                    }}
+                                    erLesevisning={erLesevisning}
+                                    disabled={erLåstFraForrigeBehandling}
+                                />
+                                <StyledInputMedTusenSkille
+                                    onKeyPress={tilHeltall}
+                                    type="number"
+                                    value={harTallverdi(utgift.stønad) ? utgift.stønad : ''}
+                                    feil={valideringsfeil && valideringsfeil[index]?.stønad}
+                                    onChange={(e) => {
+                                        oppdaterUtgift(
+                                            index,
+                                            'stønad',
+                                            tilTallverdi(e.target.value)
+                                        );
+                                    }}
+                                    erLesevisning={erLesevisning}
+                                    disabled={erLåstFraForrigeBehandling}
+                                />
+                                {skalViseFjernKnapp && (
+                                    <FjernKnapp
+                                        onClick={() => fjernUtgift(index)}
+                                        knappetekst="Fjern vedtaksperiode"
+                                    />
+                                )}
+                            </Utgiftsrad>
+                        );
+                    })}
+                </FlexColumn>
+                <LeggTilKnapp
+                    onClick={() => oppdater([...data, tomUtgift()])}
+                    knappetekst="Legg til utgift"
+                    hidden={!behandlingErRedigerbar}
+                />
+            </div>
+        </FlexRow>
     );
 };
 


### PR DESCRIPTION
Har oppdatert visningen for vedtak og beregning for skolepenger i redigeringsmodus og visningsmodus.

Redigeringsmodus
FØR:
![Skjermbilde 2022-06-10 kl  11 54 07](https://user-images.githubusercontent.com/32769446/173040604-d71705d3-56c3-4474-84c0-f1b01ab60ff9.png)

ETTER:
![Skjermbilde 2022-06-10 kl  11 53 50](https://user-images.githubusercontent.com/32769446/173040618-9c9e3483-d05e-44d9-8c8f-5d806678013e.png)

Visningsmodus
FØR:
![Skjermbilde 2022-06-10 kl  13 23 45](https://user-images.githubusercontent.com/32769446/173054915-8ec5d5dc-3352-4d82-a812-a8fb1c559262.png)

ETTER:
![Skjermbilde 2022-06-10 kl  13 23 34](https://user-images.githubusercontent.com/32769446/173054930-09e8b291-a1e3-4d3f-baf9-25fa91e18b29.png)

