### PR TITLE
Vedtak og beregning småplukk sp

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/SkoleårDelårsperiode.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/SkoleårDelårsperiode.tsx
@@ -20,9 +20,9 @@ const SkoleårsperiodeRad = styled.div<{ lesevisning?: boolean; erHeader?: boole
     display: grid;
     grid-template-areas: 'studietype fraOgMedVelger tilOgMedVelger antallMnd studiebelastning';
     grid-template-columns: ${(props) =>
-        props.lesevisning ? '10rem 9rem 9rem 5rem 7rem' : '12rem 12rem 11.5rem 4rem 8rem'};
+        props.lesevisning ? '10rem 9rem 9rem 5rem 7rem' : '12rem 12rem 11.5rem 4rem 8rem 4rem'};
     grid-gap: ${(props) => (props.lesevisning ? '0.5rem' : '1rem')};
-    margin-bottom: ${(props) => (props.erHeader ? '0,5rem' : 0)};
+    margin-bottom: ${(props) => (props.erHeader ? '0rem' : '0.5rem')};
 `;
 
 const AntallMåneder = styled(Normaltekst)<{ erLesevisning: boolean }>`

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/SkoleårsperioderSkolepenger.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/SkoleårsperioderSkolepenger.tsx
@@ -27,6 +27,7 @@ interface Props {
     låsteUtgiftIder: string[];
     valideringsfeil?: FormErrors<InnvilgeVedtakForm>['skoleårsperioder'];
     settValideringsFeil: Dispatch<SetStateAction<FormErrors<InnvilgeVedtakForm>>>;
+    oppdaterHarUtførtBeregning: (beregningUtført: boolean) => void;
 }
 
 const SkoleårsperioderSkolepenger: React.FC<Props> = ({
@@ -34,6 +35,7 @@ const SkoleårsperioderSkolepenger: React.FC<Props> = ({
     låsteUtgiftIder,
     valideringsfeil,
     settValideringsFeil,
+    oppdaterHarUtførtBeregning,
 }) => {
     const { behandlingErRedigerbar } = useBehandling();
     const { settIkkePersistertKomponent } = useApp();
@@ -45,6 +47,7 @@ const SkoleårsperioderSkolepenger: React.FC<Props> = ({
             skoleårsperioder: (prevState.skoleårsperioder || []).filter((_, i) => index !== i),
         }));
         settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
+        oppdaterHarUtførtBeregning(false);
     };
 
     const oppdaterSkoleårsperioder = <T extends ISkoleårsperiodeSkolepenger>(
@@ -55,6 +58,7 @@ const SkoleårsperioderSkolepenger: React.FC<Props> = ({
         const skoleårsperiode = skoleårsperioder.value[index];
         skoleårsperioder.update({ ...skoleårsperiode, [property]: value }, index);
         settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
+        oppdaterHarUtførtBeregning(false);
     };
 
     const oppdaterValideringsfeil = <T extends ISkoleårsperiodeSkolepenger, T2 extends T[keyof T]>(

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/VedtaksformSkolepenger.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/VedtaksformSkolepenger.tsx
@@ -89,6 +89,10 @@ export const VedtaksformSkolepenger: React.FC<{
         ? forrigeVedtak.skoleårsperioder.flatMap((p) => p.utgiftsperioder.map((u) => u.id))
         : [];
 
+    const oppdaterHarUtførtBeregning = (harUtførtBeregning: boolean) => {
+        settHarUtførtBeregning(harUtførtBeregning);
+    };
+
     const lagreVedtak = (vedtaksRequest: IInnvilgeVedtakForSkolepenger) => {
         settLaster(true);
 
@@ -171,6 +175,7 @@ export const VedtaksformSkolepenger: React.FC<{
                 låsteUtgiftIder={utgiftsIderForrigeBehandling}
                 valideringsfeil={formState.errors.skoleårsperioder}
                 settValideringsFeil={formState.setErrors}
+                oppdaterHarUtførtBeregning={oppdaterHarUtførtBeregning}
             />
             <EnsligTextArea
                 erLesevisning={!behandlingErRedigerbar}
@@ -201,7 +206,10 @@ export const VedtaksformSkolepenger: React.FC<{
                 </WrapperDobbelMarginTop>
             )}
             <WrapperDobbelMarginTop>
-                <UtregningstabellSkolepenger beregningsresultat={beregningsresultat} />
+                <UtregningstabellSkolepenger
+                    beregningsresultat={beregningsresultat}
+                    skjulVisning={!harUtførtBeregning}
+                />
             </WrapperDobbelMarginTop>
             {behandlingErRedigerbar && (
                 <WrapperDobbelMarginTop>

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/UtregnignstabellSkolepenger.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/UtregnignstabellSkolepenger.tsx
@@ -28,7 +28,11 @@ const HøyrejusterElement = styled(Element)`
 
 export const UtregningstabellSkolepenger: React.FC<{
     beregningsresultat: Ressurs<IBeregningSkolepengerResponse>;
-}> = ({ beregningsresultat }) => {
+    skjulVisning: boolean;
+}> = ({ beregningsresultat, skjulVisning }) => {
+    if (skjulVisning) {
+        return null;
+    }
     return (
         <DataViewer response={{ beregningsresultat }}>
             {({ beregningsresultat }) => (


### PR DESCRIPTION
Litt småoppgaver angående vedtaksiden:
- Dersom bruker endrer på beregningsdata etter å ha beregnet må bruker beregne på nytt
- Flyttet slett-knapp opp på samme rad som delårsperioden vises:

Knapp før:
<img width="969" alt="Skjermbilde 2022-06-16 kl  12 36 20" src="https://user-images.githubusercontent.com/32769446/174052485-79d09473-94d4-43ca-a2bf-8718b90f65e5.png">

Knapp etter:
<img width="933" alt="Skjermbilde 2022-06-16 kl  12 35 53" src="https://user-images.githubusercontent.com/32769446/174052507-ca0cb37b-e8ea-4d4f-aedd-6aad527717ef.png">

