### PR TITLE
Skal ikke velge om å revurdere barn vid årsak g-omregning

### DIFF
--- a/src/frontend/Komponenter/Personoversikt/Revurdering/LagRevurdering.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Revurdering/LagRevurdering.tsx
@@ -68,12 +68,6 @@ export const LagRevurdering: React.FunctionComponent<IProps> = ({
     const { toggles } = useToggles();
     const { axiosRequest } = useApp();
 
-    const måTaStillingTilBarn =
-        behandlinger.some(
-            (behandling) => behandling.behandlingsårsak === Behandlingsårsak.MIGRERING
-        ) &&
-        !behandlinger.some((behandling) => behandling.behandlingsårsak === Behandlingsårsak.SØKNAD);
-
     const kanLeggeTilNyeBarnPåRevurdering = toggles[ToggleName.kanLeggeTilNyeBarnPaaRevurdering];
     const skalViseValgmulighetForSanksjon = toggles[ToggleName.visValgmulighetForSanksjon];
     const skalViseValgmulighetForKorrigering = toggles[ToggleName.visValgmulighetForKorrigering];
@@ -95,9 +89,24 @@ export const LagRevurdering: React.FunctionComponent<IProps> = ({
         });
     }, [axiosRequest, fagsakId]);
 
+    useEffect(() => {
+        settVilkårsbehandleVedMigrering(EVilkårsbehandleBarnValg.IKKE_VALGT);
+    }, [valgtBehandlingsårsak]);
+
+    const erGOmregning = valgtBehandlingsårsak === Behandlingsårsak.G_OMREGNING;
+    const måTaStillingTilBarn =
+        behandlinger.some(
+            (behandling) => behandling.behandlingsårsak === Behandlingsårsak.MIGRERING
+        ) &&
+        !behandlinger.some(
+            (behandling) => behandling.behandlingsårsak === Behandlingsårsak.SØKNAD
+        ) &&
+        !erGOmregning;
+
     const skalTaMedAlleBarn =
-        !måTaStillingTilBarn ||
-        vilkårsbehandleVedMigrering === EVilkårsbehandleBarnValg.VILKÅRSBEHANDLE;
+        (!måTaStillingTilBarn ||
+            vilkårsbehandleVedMigrering === EVilkårsbehandleBarnValg.VILKÅRSBEHANDLE) &&
+        !erGOmregning;
 
     const skalViseÅrsak = (behandlingsårsak: Behandlingsårsak) => {
         switch (behandlingsårsak) {
@@ -117,7 +126,10 @@ export const LagRevurdering: React.FunctionComponent<IProps> = ({
                     const harNyeBarnSidenForrigeBehandling =
                         nyeBarnSidenForrigeBehandling.length > 0;
                     const skalViseNyeBarnValg =
-                        kanLeggeTilNyeBarnPåRevurdering && harNyeBarnSidenForrigeBehandling;
+                        valgtBehandlingsårsak &&
+                        kanLeggeTilNyeBarnPåRevurdering &&
+                        harNyeBarnSidenForrigeBehandling &&
+                        !erGOmregning;
 
                     return (
                         <>

--- a/src/frontend/Komponenter/Personoversikt/Revurdering/NyeBarn.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Revurdering/NyeBarn.tsx
@@ -44,39 +44,23 @@ export const NyeBarn = ({
                 <ul>
                     {nyeBarnSidenForrigeBehandling?.map((nyttBarn) => {
                         return (
-                            <li>
+                            <li key={nyttBarn.personIdent}>
                                 {nyttBarn.navn} ({datoTilAlder(nyttBarn.fødselsdato)} år,{' '}
                                 {nyttBarn.personIdent})
                             </li>
                         );
                     })}
                 </ul>
-                <StyledRadioGroup legend="" size="medium">
-                    <Radio
-                        value={EVilkårsbehandleBarnValg.VILKÅRSBEHANDLE}
-                        checked={
-                            vilkårsbehandleVedMigrering === EVilkårsbehandleBarnValg.VILKÅRSBEHANDLE
-                        }
-                        onChange={() => {
-                            settVilkårsbehandleVedMigrering(
-                                EVilkårsbehandleBarnValg.VILKÅRSBEHANDLE
-                            );
-                        }}
-                    >
+                <StyledRadioGroup
+                    legend=""
+                    size="medium"
+                    value={vilkårsbehandleVedMigrering}
+                    onChange={(val) => settVilkårsbehandleVedMigrering(val)}
+                >
+                    <Radio value={EVilkårsbehandleBarnValg.VILKÅRSBEHANDLE}>
                         Vilkårsbehandle barn i EF Sak
                     </Radio>
-                    <Radio
-                        value={EVilkårsbehandleBarnValg.IKKE_VILKÅRSBEHANDLE}
-                        checked={
-                            vilkårsbehandleVedMigrering ===
-                            EVilkårsbehandleBarnValg.IKKE_VILKÅRSBEHANDLE
-                        }
-                        onChange={() => {
-                            settVilkårsbehandleVedMigrering(
-                                EVilkårsbehandleBarnValg.IKKE_VILKÅRSBEHANDLE
-                            );
-                        }}
-                    >
+                    <Radio value={EVilkårsbehandleBarnValg.IKKE_VILKÅRSBEHANDLE}>
                         Ikke vilkårsbehandle barn i EF Sak
                     </Radio>
                 </StyledRadioGroup>


### PR DESCRIPTION
Nullstiller radio-buttons når man velger årsak

Fikset validering i backend på fredagen men måtte fikse frontend også
* https://github.com/navikt/familie-ef-sak/pull/1603/files
Rapportert på teams