### PR TITLE
SKal vise tidligere vedtaksperioder for søker og andre foreldre i vil…

### DIFF
--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/NyttBarnSammePartner/NyttBarnSammePartner.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/NyttBarnSammePartner/NyttBarnSammePartner.tsx
@@ -34,6 +34,7 @@ export const NyttBarnSammePartner: React.FC<VilkårProps> = ({
                         />
                         <NyttBarnSammePartnerInfo
                             barnMedSamvær={barnMedSamvær}
+                            tidligereVedtaksperioder={grunnlag.tidligereVedtaksperioder}
                             skalViseSøknadsdata={skalViseSøknadsdata}
                         />
                     </>

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/NyttBarnSammePartner/NyttBarnSammePartnerInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/NyttBarnSammePartner/NyttBarnSammePartnerInfo.tsx
@@ -5,20 +5,27 @@ import { mapTilRegistergrunnlagNyttBarn, mapTilSøknadsgrunnlagNyttBarn, Overskr
 import { FlexDiv } from '../../../Oppgavebenk/OppgaveFiltrering';
 import RegistergrunnlagNyttBarn from './RegistergrunnlagNyttBarn';
 import SøknadgrunnlagNyttBarn from './SøknadsgrunnlagNyttBarn';
-import AnnenForelderTidligereVedtaksperioder from './AnnenForelderTidligereVedtaksperioder';
+import TidligereVedtaksperioderSøkerOgAndreForeldre from './AnnenForelderTidligereVedtaksperioder';
+import { ITidligereVedtaksperioder } from '../../TidligereVedtaksperioder/typer';
 
 interface Props {
     barnMedSamvær: IBarnMedSamvær[];
+    tidligereVedtaksperioder: ITidligereVedtaksperioder;
     skalViseSøknadsdata: boolean;
 }
 
-const NyttBarnSammePartnerInfo: FC<Props> = ({ barnMedSamvær, skalViseSøknadsdata }) => {
+const NyttBarnSammePartnerInfo: FC<Props> = ({
+    barnMedSamvær,
+    tidligereVedtaksperioder,
+    skalViseSøknadsdata,
+}) => {
     const registergrunnlagNyttBarn = mapTilRegistergrunnlagNyttBarn(barnMedSamvær);
     const søknadsgrunnlagNyttBarn = mapTilSøknadsgrunnlagNyttBarn(barnMedSamvær);
     return (
         <>
             <div>
-                <AnnenForelderTidligereVedtaksperioder
+                <TidligereVedtaksperioderSøkerOgAndreForeldre
+                    tidligereVedtaksperioder={tidligereVedtaksperioder}
                     registergrunnlagNyttBarn={registergrunnlagNyttBarn}
                 />
             </div>

--- a/src/frontend/Komponenter/Behandling/Tabell/TabellVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Tabell/TabellVisning.tsx
@@ -29,6 +29,7 @@ export interface Kolonndata<T> {
 
 export interface Kolonner<T> {
     overskrift: string;
+    underskrift?: string;
     tekstVerdi: (data: T) => React.ReactNode;
 }
 
@@ -64,9 +65,10 @@ function TabellVisning<T>(props: Kolonndata<T>): React.ReactElement<Kolonndata<T
 
             <>
                 {kolonner.map((kolonne, index) => (
-                    <Element className={index === 0 ? 'førsteDataKolonne' : ''} key={index}>
-                        {kolonne.overskrift}
-                    </Element>
+                    <div key={index} className={index === 0 ? 'førsteDataKolonne' : ''}>
+                        <Element>{kolonne.overskrift}</Element>
+                        {kolonne.underskrift && <Normaltekst> {kolonne.underskrift}</Normaltekst>}
+                    </div>
                 ))}
                 {verdier.map((item) =>
                     kolonner.map((kolonne, index) => (


### PR DESCRIPTION
…kåret for nytt barn med samme partner, dette fordi det ikke er et eget vilkår for andre stønader enn overgangsstønad

Burde kanskje gått vekk fra å bruke `TabellVisning` her. Tanken med den var ju å ha lik bredde på tabeller på denne siden, for å ikke få før mye zig-zag mellom tabeller. Samtidig så hadde denne dataen kanskje kunnet trengt litt annen type bredde. Lars sa at dette var greit nå. 

![image](https://user-images.githubusercontent.com/937168/176892570-7a4f5147-2efe-4176-8ba9-679cde15b941.png)
