### PR TITLE
Fjerner å kunne velge alle enheter fra oppgavebenken.

### DIFF
--- a/src/frontend/Komponenter/Oppgavebenk/OppgaveFiltrering.tsx
+++ b/src/frontend/Komponenter/Oppgavebenk/OppgaveFiltrering.tsx
@@ -6,7 +6,7 @@ import { oppgaveTypeTilTekst } from './typer/oppgavetema';
 import { behandlingstemaTilTekst } from '../../App/typer/behandlingstema';
 import { useApp } from '../../App/context/AppContext';
 import CustomSelect from './CustomSelect';
-import { enhetTilTekst, FortroligEnhet } from './typer/enhet';
+import { enhetTilTekst, FortroligEnhet, IkkeFortroligEnhet } from './typer/enhet';
 import DatoPeriode from './DatoPeriode';
 import { datoFeil, oppdaterFilter } from '../../App/utils/utils';
 import { IOppgaveRequest } from './typer/oppgaverequest';
@@ -62,6 +62,24 @@ interface Feil {
 
 const initFeilObjekt = {} as Feil;
 
+const oppgaveRequestMedDefaultEnhet = (
+    oppgaveRequest: IOppgaveRequest,
+    harSaksbehandlerStrengtFortroligRolle: boolean
+): IOppgaveRequest => {
+    if (harSaksbehandlerStrengtFortroligRolle) {
+        return {
+            ...oppgaveRequest,
+            enhet: FortroligEnhet.VIKAFOSSEN,
+        };
+    } else {
+        const enhet = oppgaveRequest.enhet;
+        return {
+            ...oppgaveRequest,
+            enhet: enhet && enhet !== FortroligEnhet.VIKAFOSSEN ? enhet : IkkeFortroligEnhet.NAY,
+        };
+    }
+};
+
 const OppgaveFiltrering: React.FC<IOppgaveFiltrering> = ({
     hentOppgaver,
     mapper,
@@ -75,7 +93,7 @@ const OppgaveFiltrering: React.FC<IOppgaveFiltrering> = ({
     );
     const tomOppgaveRequest = harSaksbehandlerStrengtFortroligRolle
         ? { enhet: FortroligEnhet.VIKAFOSSEN }
-        : {};
+        : { enhet: IkkeFortroligEnhet.NAY };
     const [oppgaveRequest, settOppgaveRequest] = useState<IOppgaveRequest>({});
     const [periodeFeil, settPerioderFeil] = useState<Feil>(initFeilObjekt);
 
@@ -98,25 +116,17 @@ const OppgaveFiltrering: React.FC<IOppgaveFiltrering> = ({
     }, [oppgaveRequest.opprettetFom, oppgaveRequest.opprettetTom]);
 
     useEffect(() => {
-        const fraLocalStorage = hentFraLocalStorage(
+        const fraLocalStorage = hentFraLocalStorage<IOppgaveRequest>(
             oppgaveRequestKey(innloggetSaksbehandler.navIdent),
             {}
         );
-        if (fraLocalStorage) {
-            if (harSaksbehandlerStrengtFortroligRolle) {
-                settOppgaveRequest({
-                    ...fraLocalStorage,
-                    enhet: FortroligEnhet.VIKAFOSSEN,
-                });
-            } else {
-                settOppgaveRequest(fraLocalStorage);
-            }
-            hentOppgaver(fraLocalStorage);
-        } else {
-            if (harSaksbehandlerStrengtFortroligRolle) {
-                settOppgaveRequest({ enhet: FortroligEnhet.VIKAFOSSEN });
-            }
-        }
+
+        const oppgaveRequestMedEnhet = oppgaveRequestMedDefaultEnhet(
+            fraLocalStorage,
+            harSaksbehandlerStrengtFortroligRolle
+        );
+        settOppgaveRequest(oppgaveRequestMedEnhet);
+        hentOppgaver(oppgaveRequestMedEnhet);
     }, [hentOppgaver, harSaksbehandlerStrengtFortroligRolle, innloggetSaksbehandler.navIdent]);
 
     const saksbehandlerTekst =
@@ -175,7 +185,7 @@ const OppgaveFiltrering: React.FC<IOppgaveFiltrering> = ({
                     options={enhetTilTekst(harSaksbehandlerStrengtFortroligRolle)}
                     value={oppgaveRequest.enhet}
                     sortDesc={true}
-                    skalSkjuleValgetAlle={harSaksbehandlerStrengtFortroligRolle}
+                    skalSkjuleValgetAlle={true}
                 />
                 <MappeVelger
                     onChange={(val) => settOppgave('mappeId')(parseInt(val))}

--- a/src/frontend/Komponenter/Oppgavebenk/typer/enhet.ts
+++ b/src/frontend/Komponenter/Oppgavebenk/typer/enhet.ts
@@ -17,9 +17,8 @@ export const enhetTilTekstFortrolig: Record<FortroligEnhet, string> = {
 };
 
 export const enhetTilTekstPåString: Record<string, string> = {
-    '4489': '4489 NAY',
-    '4483': '4483 Egne ansatte',
-    '2103': '2103 NAV Vikafossen',
+    ...enhetTilTekstIkkeFortrolig,
+    ...enhetTilTekstFortrolig,
 };
 
 export const enhetTilTekst = (


### PR DESCRIPTION
Setter default enhet på oppgaverequest hvis man ikke har fortrolig rolle

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8905

Litt uklart hva som er tenkt med kommentaren
> I gosys ser man alle oppgaver som ligger på bruker på personoversikten etter at man har søkt opp en spesifikk bruker. 

Med denne endring kommer man ikke kunne se oppgaver på personen for andre enheter. Litt uklart om det er dette som ønskes.

I forrige løsning:
Hvis man hadde `harSaksbehandlerStrengtFortroligRolle=true`, så ble det fortsatt søkt opp oppgaver til alle enheter først, når man sen søkte på nytt så ble enheten brukt