### PR TITLE
Journalføring av dokumenter tillater ikke dokumenter med blanke titler

### DIFF
--- a/src/frontend/Komponenter/Journalforing/JournalforingApp.tsx
+++ b/src/frontend/Komponenter/Journalforing/JournalforingApp.tsx
@@ -79,11 +79,14 @@ const harTittelForAlleDokumenter = (
     journalResponse: IJojurnalpostResponse,
     journalpostState: JournalføringStateRequest
 ) =>
-    journalResponse.journalpost.dokumenter.every(
-        (d) =>
-            d.tittel ||
-            (journalpostState.dokumentTitler && journalpostState.dokumentTitler[d.dokumentInfoId])
-    );
+    journalResponse.journalpost.dokumenter
+        .map(
+            (d) =>
+                d.tittel ||
+                (journalpostState.dokumentTitler &&
+                    journalpostState.dokumentTitler[d.dokumentInfoId])
+        )
+        .every((tittel) => tittel && tittel.trim());
 
 const erUstrukturertSøknadOgManglerDokumentasjonsType = (
     journalResponse: IJojurnalpostResponse,


### PR DESCRIPTION
Vi fikk en feil som jeg tror kan være pga tittel som var blank, som vi likevel burde håndtere
https://nav-it.slack.com/archives/C033WGAFAQ1/p1657192574089989
```js
[undefined].map(i => i).every(i => i && i.trim()) // false
[""].map(i => i).every(i => i && i.trim()) // false
["  "].map(i => i).every(i => i && i.trim()) // false
["  a  "].map(i => i).every(i => i && i.trim()) // true

```