### PR TITLE
alertstripe som opptrer ved feil ved henting av beboere under samliv-…

### DIFF
--- a/src/frontend/Felles/DataViewer/DataViewer.tsx
+++ b/src/frontend/Felles/DataViewer/DataViewer.tsx
@@ -9,7 +9,9 @@ import SystemetLaster from '../SystemetLaster/SystemetLaster';
 import { AlertStripeFeil } from 'nav-frontend-alertstriper';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
-import AlertStripeFeilPreWrap from '../Visningskomponenter/AlertStripeFeilPreWrap';
+import AlertStripeFeilPreWrap, {
+    AlertStripeVariant,
+} from '../Visningskomponenter/AlertStripeFeilPreWrap';
 
 /**
  * Input: { behandling: Ressurss<Behandling>, personopslyninger: Ressurss<IPersonopplysninger> }
@@ -21,6 +23,7 @@ import AlertStripeFeilPreWrap from '../Visningskomponenter/AlertStripeFeilPreWra
 interface DataViewerProps<T extends Record<string, unknown>> {
     response: { [P in keyof T]: Ressurs<T[P]> };
     children: ((data: T) => React.ReactElement | null) | ReactNode;
+    alertStripeVariant?: AlertStripeVariant;
 }
 
 const StyledLenke = styled(Link)`
@@ -28,7 +31,7 @@ const StyledLenke = styled(Link)`
 `;
 
 // eslint-disable-next-line
-const renderFeil = (responses: Ressurs<any>[]) => (
+const renderFeil = (responses: Ressurs<any>[], alertOption: AlertStripeVariant) => (
     <>
         {responses.map((feilet, index) => {
             if (
@@ -36,7 +39,7 @@ const renderFeil = (responses: Ressurs<any>[]) => (
                 feilet.status === RessursStatus.FEILET
             ) {
                 return (
-                    <AlertStripeFeilPreWrap key={index}>
+                    <AlertStripeFeilPreWrap key={index} alertVariant={alertOption}>
                         {feilet.frontendFeilmelding}
                     </AlertStripeFeilPreWrap>
                 );
@@ -44,9 +47,11 @@ const renderFeil = (responses: Ressurs<any>[]) => (
                 return null;
             }
         })}
-        <StyledLenke className="lenke" to={{ pathname: '/oppgavebenk' }}>
-            Gå til oppgavebenk
-        </StyledLenke>
+        {alertOption === AlertStripeVariant.IKKE_VALGT && (
+            <StyledLenke className="lenke" to={{ pathname: '/oppgavebenk' }}>
+                Gå til oppgavebenk
+            </StyledLenke>
+        )}
     </>
 );
 
@@ -66,10 +71,13 @@ const renderChildren = (children: any, response: any): ReactElement => {
 function DataViewer<T extends Record<string, unknown>>(
     props: DataViewerProps<T>
 ): JSX.Element | null {
-    const { response, children } = props;
+    const { response, children, alertStripeVariant } = props;
     const responses = Object.values(response);
     if (harNoenRessursMedStatus(responses, RessursStatus.FUNKSJONELL_FEIL, RessursStatus.FEILET)) {
-        return renderFeil(responses);
+        return renderFeil(
+            responses,
+            alertStripeVariant ? alertStripeVariant : AlertStripeVariant.IKKE_VALGT
+        );
     } else if (harNoenRessursMedStatus(responses, RessursStatus.IKKE_TILGANG)) {
         return <AlertStripeFeil children="Ikke tilgang!" />;
     } else if (harNoenRessursMedStatus(responses, RessursStatus.HENTER)) {

--- a/src/frontend/Felles/Visningskomponenter/AlertStripeFeilPreWrap.tsx
+++ b/src/frontend/Felles/Visningskomponenter/AlertStripeFeilPreWrap.tsx
@@ -1,9 +1,16 @@
 import styled from 'styled-components';
 import { AlertStripeFeil } from 'nav-frontend-alertstriper';
 
-const AlertStripeFeilPreWrap = styled(AlertStripeFeil)`
+const AlertStripeFeilPreWrap = styled(AlertStripeFeil)<{ alertVariant?: AlertStripeVariant }>`
     white-space: pre-wrap;
     word-wrap: break-word;
+    grid-column: ${(props) =>
+        props.alertVariant === AlertStripeVariant.SAMLIV_VILKÅR ? '1 / span 3' : ''};
 `;
+
+export enum AlertStripeVariant {
+    IKKE_VALGT = 'IKKE_VALGT',
+    SAMLIV_VILKÅR = 'SAMLIV_VILKÅR',
+}
 
 export default AlertStripeFeilPreWrap;

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Samliv/Bostedsadresse.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Samliv/Bostedsadresse.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Registergrunnlag } from '../../../../Felles/Ikoner/DataGrunnlagIkoner';
 import { Normaltekst } from 'nav-frontend-typografi';
 import { Td } from '../../../../Felles/Personopplysninger/TabellWrapper';
@@ -10,6 +10,7 @@ import styled from 'styled-components';
 import LenkeKnapp from '../../../../Felles/Knapper/LenkeKnapp';
 import { Collapse, Expand } from '@navikt/ds-icons';
 import { useBehandling } from '../../../../App/context/BehandlingContext';
+import { AlertStripeVariant } from '../../../../Felles/Visningskomponenter/AlertStripeFeilPreWrap';
 
 interface BeboereTabellProps {
     vis: boolean;
@@ -53,7 +54,6 @@ export const Bostedsadresse = ({ behandlingId }: BostedsadresseProps) => {
         },
         [axiosRequest]
     );
-
     useEffect(() => {
         if (visBeboere && beboere.status !== RessursStatus.SUKSESS) {
             hentBeboerePåSammeAdresse(behandlingId);
@@ -87,32 +87,37 @@ export const Bostedsadresse = ({ behandlingId }: BostedsadresseProps) => {
                     );
                 }}
             </DataViewer>
-            <DataViewer response={{ beboere }}>
-                {({ beboere }) => {
-                    return (
-                        <>
-                            <BeboereTabell vis={visBeboere} className="tabell">
-                                <thead>
-                                    <Td>Navn</Td>
-                                    <Td>Fødselsnummer</Td>
-                                    <Td>Adresse</Td>
-                                </thead>
-                                <tbody>
-                                    {beboere.hits.map((beboer) => {
-                                        return (
-                                            <tr>
-                                                <Td>{beboer.visningsnavn}</Td>
-                                                <Td>{beboer.personIdent}</Td>
-                                                <Td>{beboer.visningsadresse}</Td>
-                                            </tr>
-                                        );
-                                    })}
-                                </tbody>
-                            </BeboereTabell>
-                        </>
-                    );
-                }}
-            </DataViewer>
+            {visBeboere && (
+                <DataViewer
+                    response={{ beboere }}
+                    alertStripeVariant={AlertStripeVariant.SAMLIV_VILKÅR}
+                >
+                    {({ beboere }) => {
+                        return (
+                            <>
+                                <BeboereTabell vis={visBeboere} className="tabell">
+                                    <thead>
+                                        <Td>Navn</Td>
+                                        <Td>Fødselsnummer</Td>
+                                        <Td>Adresse</Td>
+                                    </thead>
+                                    <tbody>
+                                        {beboere.hits.map((beboer) => {
+                                            return (
+                                                <tr>
+                                                    <Td>{beboer.visningsnavn}</Td>
+                                                    <Td>{beboer.personIdent}</Td>
+                                                    <Td>{beboer.visningsadresse}</Td>
+                                                </tr>
+                                            );
+                                        })}
+                                    </tbody>
+                                </BeboereTabell>
+                            </>
+                        );
+                    }}
+                </DataViewer>
+            )}
         </>
     );
 };


### PR DESCRIPTION
…vilkår skal opptre på venstresiden av skjermen. 

Alertstripen kan nå også lukkes ved å trykke på `se beboere` knappen igjen
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-9100)

Før:
![image](https://user-images.githubusercontent.com/32769446/180765958-23e5a2bd-9935-4ba7-a57c-5c06d52e408a.png)
![image](https://user-images.githubusercontent.com/32769446/180765984-17887c5c-1f58-420f-82f1-758ab9b2deae.png)

Etter:
![Skjermbilde 2022-07-25 kl  13 15 38](https://user-images.githubusercontent.com/32769446/180766033-91f6a113-7cb3-439a-9e1e-a736f9b830ec.png)

