### PR TITLE
Vise eier til behandling

### DIFF
--- a/src/frontend/App/utils/localStorage.ts
+++ b/src/frontend/App/utils/localStorage.ts
@@ -1,7 +1,15 @@
-export const oppgaveRequestKeyPrefix = 'oppgaveFiltreringRequest';
+export enum LocalStorageKey {
+    OPPGAVE_FILTRERING = 'OPPGAVE_FILTRERING',
+    OPPGAVE_TILORDNET = 'OPPGAVE_TILORDNET',
+}
 
-export const oppgaveRequestKey = (innloggetIdent: string): string => {
-    return oppgaveRequestKeyPrefix + innloggetIdent;
+const keyTiltekst: Record<LocalStorageKey, string> = {
+    OPPGAVE_FILTRERING: 'oppgaveFiltreringRequest',
+    OPPGAVE_TILORDNET: 'oppgaveTilordnetRequest',
+};
+
+export const oppgaveRequestKey = (innloggetIdent: string, key: LocalStorageKey): string => {
+    return keyTiltekst[key] + innloggetIdent;
 };
 
 export const lagreTilLocalStorage = <T>(key: string, request: T): void => {

--- a/src/frontend/Felles/PersonHeader/OppgaveAlleredePlukket.tsx
+++ b/src/frontend/Felles/PersonHeader/OppgaveAlleredePlukket.tsx
@@ -30,8 +30,8 @@ const LukkKnapp = styled(Button)`
 
 const InnholdGrid = styled.div`
     display: grid;
-    grid-template-columns: 1.5rem auto 3rem;
-    grid-template-rows: 3rem 2rem 2rem 2rem;
+    grid-template-columns: 3rem auto 3rem;
+    grid-template-rows: 3rem 2rem 2rem 3rem;
 `;
 
 const SaksbehandlerNavn = styled.div`

--- a/src/frontend/Felles/PersonHeader/OppgaveAlleredePlukket.tsx
+++ b/src/frontend/Felles/PersonHeader/OppgaveAlleredePlukket.tsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import styled from 'styled-components';
+import { BodyShort, Button, HelpText, Label } from '@navikt/ds-react';
+import { EtikettInfo } from 'nav-frontend-etiketter';
+import { Close } from '@navikt/ds-icons';
+
+const AdvarselEtikett = styled(EtikettInfo)<{ åpenHøyreMeny?: boolean }>`
+    position: absolute;
+    top: 5rem;
+    left: ${(props) => (props.åpenHøyreMeny ? 'calc(50% - 18rem)' : 'calc(50% - 9rem)')};
+    width: max-content;
+    z-index: 99;
+    box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 15px;
+`;
+
+const NavnTekst = styled(BodyShort)`
+    white-space: nowrap;
+    margin-right: 0.5rem;
+`;
+
+const Hjelpetekst = styled(HelpText)``;
+
+const LukkKnapp = styled(Button)`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    grid-column: 3;
+    grid-row: 1;
+`;
+
+const InnholdGrid = styled.div`
+    display: grid;
+    grid-template-columns: 1.5rem auto 3rem;
+    grid-template-rows: 3rem 2rem 2rem 2rem;
+`;
+
+const SaksbehandlerNavn = styled.div`
+    display: flex;
+    align-items: center;
+    grid-column: 2;
+    grid-row: 3;
+`;
+
+const FetTekst = styled(Label)`
+    grid-column: 2;
+    grid-row: 2;
+`;
+
+export const OppgaveAlleredePlukket: React.FC<{
+    visible: boolean;
+    settVisible: (oppgaveAlleredePlukket: boolean) => void;
+    åpenHøyreMeny?: boolean;
+}> = ({ visible, settVisible, åpenHøyreMeny }) => {
+    if (!visible) {
+        return null;
+    }
+
+    return (
+        <AdvarselEtikett åpenHøyreMeny={åpenHøyreMeny}>
+            <InnholdGrid>
+                <LukkKnapp
+                    variant={'tertiary'}
+                    size={'small'}
+                    onClick={() => settVisible(!visible)}
+                >
+                    <Close width={32} height={32} />
+                </LukkKnapp>
+                <FetTekst>Allerede plukket av:</FetTekst>
+                <SaksbehandlerNavn>
+                    <NavnTekst>Viktor Grøndalen Solberg</NavnTekst>
+                    <Hjelpetekst placement={'bottom'}>
+                        <BodyShort>
+                            Dersom en annen saksbehandler har plukket en oppgave fra oppgavebenken
+                            før deg
+                        </BodyShort>
+                        <BodyShort>
+                            og du i senere tid har plukket den samme oppgaven, så kan det hende at
+                            dere skriver
+                        </BodyShort>
+                        <BodyShort>over hverandres vurderinger.</BodyShort>
+                    </Hjelpetekst>
+                </SaksbehandlerNavn>
+            </InnholdGrid>
+        </AdvarselEtikett>
+    );
+};

--- a/src/frontend/Felles/PersonHeader/OppgaveTilordnetAnnenSaksbehandlerAdvarsel.tsx
+++ b/src/frontend/Felles/PersonHeader/OppgaveTilordnetAnnenSaksbehandlerAdvarsel.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { useState } from 'react';
 import styled from 'styled-components';
 import { BodyShort, Button, HelpText, Label } from '@navikt/ds-react';
 import { EtikettInfo } from 'nav-frontend-etiketter';
@@ -6,7 +7,12 @@ import { Close } from '@navikt/ds-icons';
 import { Behandling } from '../../App/typer/fagsak';
 import { ISaksbehandler } from '../../App/typer/saksbehandler';
 import { erBehandlingRedigerbar } from '../../App/typer/behandlingstatus';
-import { useState } from 'react';
+import {
+    hentFraLocalStorage,
+    lagreTilLocalStorage,
+    LocalStorageKey,
+    oppgaveRequestKey,
+} from '../../App/utils/localStorage';
 
 const AdvarselEtikett = styled(EtikettInfo)<{ åpenHøyreMeny?: boolean }>`
     position: absolute;
@@ -56,7 +62,12 @@ export const OppgaveTilordnetAnnenSaksbehandlerAdvarsel: React.FC<{
     tilordnetRessurs: string | null;
     innloggetaksbehandler: ISaksbehandler;
 }> = ({ behandling, åpenHøyreMeny, tilordnetRessurs, innloggetaksbehandler }) => {
-    const [advarselAlleredeLukket, settAdvarselAlleredeLukket] = useState<boolean>(false);
+    const [advarselAlleredeLukket, settAdvarselAlleredeLukket] = useState<boolean>(
+        hentFraLocalStorage(
+            oppgaveRequestKey(innloggetaksbehandler.navIdent, LocalStorageKey.OPPGAVE_TILORDNET),
+            false
+        )
+    );
 
     const skalViseAdvarsel = () => {
         const behandlingErRedigerbar = erBehandlingRedigerbar(behandling);
@@ -80,7 +91,16 @@ export const OppgaveTilordnetAnnenSaksbehandlerAdvarsel: React.FC<{
                 <LukkKnapp
                     variant={'tertiary'}
                     size={'small'}
-                    onClick={() => settAdvarselAlleredeLukket(true)}
+                    onClick={() => {
+                        settAdvarselAlleredeLukket(true);
+                        lagreTilLocalStorage(
+                            oppgaveRequestKey(
+                                innloggetaksbehandler.navIdent,
+                                LocalStorageKey.OPPGAVE_TILORDNET
+                            ),
+                            true
+                        );
+                    }}
                 >
                     <Close width={32} height={32} />
                 </LukkKnapp>

--- a/src/frontend/Felles/PersonHeader/OppgaveTilordnetAnnenSaksbehandlerAdvarsel.tsx
+++ b/src/frontend/Felles/PersonHeader/OppgaveTilordnetAnnenSaksbehandlerAdvarsel.tsx
@@ -3,6 +3,10 @@ import styled from 'styled-components';
 import { BodyShort, Button, HelpText, Label } from '@navikt/ds-react';
 import { EtikettInfo } from 'nav-frontend-etiketter';
 import { Close } from '@navikt/ds-icons';
+import { Behandling } from '../../App/typer/fagsak';
+import { ISaksbehandler } from '../../App/typer/saksbehandler';
+import { erBehandlingRedigerbar } from '../../App/typer/behandlingstatus';
+import { useState } from 'react';
 
 const AdvarselEtikett = styled(EtikettInfo)<{ åpenHøyreMeny?: boolean }>`
     position: absolute;
@@ -46,13 +50,28 @@ const FetTekst = styled(Label)`
     grid-row: 2;
 `;
 
-export const OppgaveAlleredePlukket: React.FC<{
-    visible: boolean;
-    settVisible: (oppgaveAlleredePlukket: boolean) => void;
+export const OppgaveTilordnetAnnenSaksbehandlerAdvarsel: React.FC<{
+    behandling: Behandling;
     åpenHøyreMeny?: boolean;
-}> = ({ visible, settVisible, åpenHøyreMeny }) => {
-    if (!visible) {
-        return null;
+    tilordnetRessurs: string | null;
+    innloggetaksbehandler: ISaksbehandler;
+}> = ({ behandling, åpenHøyreMeny, tilordnetRessurs, innloggetaksbehandler }) => {
+    const [advarselAlleredeLukket, settAdvarselAlleredeLukket] = useState<boolean>(false);
+
+    const skalViseAdvarsel = () => {
+        const behandlingErRedigerbar = erBehandlingRedigerbar(behandling);
+        const innloggetSaksbehandlerErIkkeTilordnetDenneOppgaven =
+            tilordnetRessurs !== null && tilordnetRessurs !== innloggetaksbehandler.navIdent;
+
+        return (
+            behandlingErRedigerbar &&
+            innloggetSaksbehandlerErIkkeTilordnetDenneOppgaven &&
+            !advarselAlleredeLukket
+        );
+    };
+
+    if (!skalViseAdvarsel()) {
+        return <></>;
     }
 
     return (
@@ -61,21 +80,23 @@ export const OppgaveAlleredePlukket: React.FC<{
                 <LukkKnapp
                     variant={'tertiary'}
                     size={'small'}
-                    onClick={() => settVisible(!visible)}
+                    onClick={() => settAdvarselAlleredeLukket(true)}
                 >
                     <Close width={32} height={32} />
                 </LukkKnapp>
-                <FetTekst>Allerede plukket av:</FetTekst>
+                <FetTekst>Advarsel</FetTekst>
                 <SaksbehandlerNavn>
-                    <NavnTekst>Viktor Grøndalen Solberg</NavnTekst>
+                    <NavnTekst>
+                        Oppgaven er tilordnet saksbehandler med ident: {tilordnetRessurs}
+                    </NavnTekst>
                     <Hjelpetekst placement={'bottom'}>
                         <BodyShort>
-                            Dersom en annen saksbehandler har plukket en oppgave fra oppgavebenken
-                            før deg
+                            Saksbehandler med ident {tilordnetRessurs} har plukket denne oppgaven
+                            fra oppgavebenken før deg.
                         </BodyShort>
                         <BodyShort>
-                            og du i senere tid har plukket den samme oppgaven, så kan det hende at
-                            dere skriver
+                            Dersom du foretar endringer i behandlingen, så kan det hende at dere
+                            skriver
                         </BodyShort>
                         <BodyShort>over hverandres vurderinger.</BodyShort>
                     </Hjelpetekst>

--- a/src/frontend/Felles/PersonHeader/PersonHeader.tsx
+++ b/src/frontend/Felles/PersonHeader/PersonHeader.tsx
@@ -94,7 +94,8 @@ const PersonHeaderComponent: FC<{
     data: IPersonopplysninger;
     behandling?: Behandling;
     åpenHøyreMeny?: boolean;
-}> = ({ data, behandling, åpenHøyreMeny }) => {
+    behandlingErRedigerbar?: boolean;
+}> = ({ data, behandling, åpenHøyreMeny, behandlingErRedigerbar }) => {
     const {
         personIdent,
         kjønn,
@@ -111,7 +112,7 @@ const PersonHeaderComponent: FC<{
     const [fagsakPersonId, settFagsakPersonId] = useState<string>('');
     const [erMigrert, settErMigrert] = useState(false);
     const [feilFagsakHenting, settFeilFagsakHenting] = useState<string>();
-    const [visOppgavePlukket, settVisOppgavePlukket] = useState<boolean>(true);
+    const [oppgaveTidligerePlukket, settOppgaveTidligerePlukket] = useState<boolean>(true);
 
     const utledVisningsnavn = (): string => {
         const alder = nullableDatoTilAlder(fødselsdato);
@@ -154,6 +155,8 @@ const PersonHeaderComponent: FC<{
 
         // eslint-disable-next-line
     }, []);
+
+    const visOppgavePlukket: boolean = behandlingErRedigerbar ? oppgaveTidligerePlukket : false;
 
     return (
         <>
@@ -267,7 +270,7 @@ const PersonHeaderComponent: FC<{
             </PersonHeaderWrapper>
             <OppgaveAlleredePlukket
                 visible={visOppgavePlukket}
-                settVisible={settVisOppgavePlukket}
+                settVisible={settOppgaveTidligerePlukket}
                 åpenHøyreMeny={åpenHøyreMeny}
             />
         </>

--- a/src/frontend/Felles/PersonHeader/PersonHeader.tsx
+++ b/src/frontend/Felles/PersonHeader/PersonHeader.tsx
@@ -29,6 +29,7 @@ import {
     stønadstypeTilTekstKort,
 } from '../../App/typer/behandlingstema';
 import { Behandlingsårsak, behandlingsårsakTilTekst } from '../../App/typer/Behandlingsårsak';
+import { OppgaveAlleredePlukket } from './OppgaveAlleredePlukket';
 
 const Visningsnavn = styled(Element)`
     text-overflow: ellipsis;
@@ -89,10 +90,11 @@ const ElementWrapper = styled.div`
     margin-left: 1rem;
 `;
 
-const PersonHeaderComponent: FC<{ data: IPersonopplysninger; behandling?: Behandling }> = ({
-    data,
-    behandling,
-}) => {
+const PersonHeaderComponent: FC<{
+    data: IPersonopplysninger;
+    behandling?: Behandling;
+    åpenHøyreMeny?: boolean;
+}> = ({ data, behandling, åpenHøyreMeny }) => {
     const {
         personIdent,
         kjønn,
@@ -109,6 +111,7 @@ const PersonHeaderComponent: FC<{ data: IPersonopplysninger; behandling?: Behand
     const [fagsakPersonId, settFagsakPersonId] = useState<string>('');
     const [erMigrert, settErMigrert] = useState(false);
     const [feilFagsakHenting, settFeilFagsakHenting] = useState<string>();
+    const [visOppgavePlukket, settVisOppgavePlukket] = useState<boolean>(true);
 
     const utledVisningsnavn = (): string => {
         const alder = nullableDatoTilAlder(fødselsdato);
@@ -153,109 +156,121 @@ const PersonHeaderComponent: FC<{ data: IPersonopplysninger; behandling?: Behand
     }, []);
 
     return (
-        <PersonHeaderWrapper>
-            {feilFagsakHenting && <Alertstripe type="feil">Kunne ikke hente fagsak</Alertstripe>}
-            <VisittKort
-                alder={20}
-                ident={personIdent}
-                kjønn={kjønn}
-                navn={
-                    <ResponsivLenke
-                        role={'link'}
-                        href={`/person/${fagsakPersonId}`}
-                        onClick={(e) => {
-                            e.preventDefault();
-                            gåTilUrl(`/person/${fagsakPersonId}`);
-                        }}
-                    >
-                        <Visningsnavn>{utledVisningsnavn()}</Visningsnavn>
-                    </ResponsivLenke>
-                }
-            >
-                {folkeregisterpersonstatus && (
-                    <ElementWrapper>
-                        <PersonStatusVarsel folkeregisterpersonstatus={folkeregisterpersonstatus} />
-                    </ElementWrapper>
+        <>
+            <PersonHeaderWrapper>
+                {feilFagsakHenting && (
+                    <Alertstripe type="feil">Kunne ikke hente fagsak</Alertstripe>
                 )}
-                {adressebeskyttelse && (
-                    <ElementWrapper>
-                        <AdressebeskyttelseVarsel adressebeskyttelse={adressebeskyttelse} />
-                    </ElementWrapper>
-                )}
-                {egenAnsatt && (
-                    <ElementWrapper>
-                        <EtikettFokus mini>Egen ansatt</EtikettFokus>
-                    </ElementWrapper>
-                )}
-                {fullmakt.some((f) => erEtterDagensDato(f.gyldigTilOgMed)) && (
-                    <ElementWrapper>
-                        <EtikettFokus mini>Fullmakt</EtikettFokus>
-                    </ElementWrapper>
-                )}
-
-                {vergemål.length > 0 && (
-                    <ElementWrapper>
-                        <EtikettFokus mini>Verge</EtikettFokus>
-                    </ElementWrapper>
-                )}
-
-                {erMigrert && (
-                    <ElementWrapper>
-                        <EtikettFokus mini>Migrert</EtikettFokus>
-                    </ElementWrapper>
-                )}
-
-                <TagsKnyttetTilBehandling>
-                    {behandling && (
+                <VisittKort
+                    alder={20}
+                    ident={personIdent}
+                    kjønn={kjønn}
+                    navn={
+                        <ResponsivLenke
+                            role={'link'}
+                            href={`/person/${fagsakPersonId}`}
+                            onClick={(e) => {
+                                e.preventDefault();
+                                gåTilUrl(`/person/${fagsakPersonId}`);
+                            }}
+                        >
+                            <Visningsnavn>{utledVisningsnavn()}</Visningsnavn>
+                        </ResponsivLenke>
+                    }
+                >
+                    {folkeregisterpersonstatus && (
                         <ElementWrapper>
-                            <TagsLitenSkjerm>
-                                <EtikettSuksess mini>
-                                    {stønadstypeTilTekstKort[behandling.stønadstype]}
-                                </EtikettSuksess>
-                            </TagsLitenSkjerm>
-                            <TagsStorSkjerm>
-                                <EtikettSuksess mini>
-                                    {stønadstypeTilTekst[behandling.stønadstype]}
-                                </EtikettSuksess>
-                            </TagsStorSkjerm>
+                            <PersonStatusVarsel
+                                folkeregisterpersonstatus={folkeregisterpersonstatus}
+                            />
                         </ElementWrapper>
                     )}
-                    {behandling && (
+                    {adressebeskyttelse && (
                         <ElementWrapper>
-                            <TagsLitenSkjerm>
-                                <EtikettInfo mini>
-                                    {behandlingstypeTilTekstKort[behandling.type]}
-                                </EtikettInfo>
-                            </TagsLitenSkjerm>
-                            <TagsStorSkjerm>
-                                <EtikettInfo mini>
-                                    {behandlingstypeTilTekst[behandling.type]}
-                                </EtikettInfo>
-                            </TagsStorSkjerm>
+                            <AdressebeskyttelseVarsel adressebeskyttelse={adressebeskyttelse} />
                         </ElementWrapper>
                     )}
-                    {behandling && behandling.behandlingsårsak === Behandlingsårsak.PAPIRSØKNAD && (
+                    {egenAnsatt && (
                         <ElementWrapper>
-                            <EtikettFokus mini>
-                                {behandlingsårsakTilTekst[behandling.behandlingsårsak]}
-                            </EtikettFokus>
+                            <EtikettFokus mini>Egen ansatt</EtikettFokus>
                         </ElementWrapper>
                     )}
-                </TagsKnyttetTilBehandling>
-            </VisittKort>
+                    {fullmakt.some((f) => erEtterDagensDato(f.gyldigTilOgMed)) && (
+                        <ElementWrapper>
+                            <EtikettFokus mini>Fullmakt</EtikettFokus>
+                        </ElementWrapper>
+                    )}
 
-            {behandling && (
-                <>
-                    <AlleStatuser behandling={behandling} />
-                    <StatuserLitenSkjerm>
-                        <StatusMeny behandling={behandling} />
-                    </StatuserLitenSkjerm>
-                </>
-            )}
-            {erSaksbehandler && behandling && erBehandlingRedigerbar(behandling) && (
-                <StyledHamburgermeny />
-            )}
-        </PersonHeaderWrapper>
+                    {vergemål.length > 0 && (
+                        <ElementWrapper>
+                            <EtikettFokus mini>Verge</EtikettFokus>
+                        </ElementWrapper>
+                    )}
+
+                    {erMigrert && (
+                        <ElementWrapper>
+                            <EtikettFokus mini>Migrert</EtikettFokus>
+                        </ElementWrapper>
+                    )}
+
+                    <TagsKnyttetTilBehandling>
+                        {behandling && (
+                            <ElementWrapper>
+                                <TagsLitenSkjerm>
+                                    <EtikettSuksess mini>
+                                        {stønadstypeTilTekstKort[behandling.stønadstype]}
+                                    </EtikettSuksess>
+                                </TagsLitenSkjerm>
+                                <TagsStorSkjerm>
+                                    <EtikettSuksess mini>
+                                        {stønadstypeTilTekst[behandling.stønadstype]}
+                                    </EtikettSuksess>
+                                </TagsStorSkjerm>
+                            </ElementWrapper>
+                        )}
+                        {behandling && (
+                            <ElementWrapper>
+                                <TagsLitenSkjerm>
+                                    <EtikettInfo mini>
+                                        {behandlingstypeTilTekstKort[behandling.type]}
+                                    </EtikettInfo>
+                                </TagsLitenSkjerm>
+                                <TagsStorSkjerm>
+                                    <EtikettInfo mini>
+                                        {behandlingstypeTilTekst[behandling.type]}
+                                    </EtikettInfo>
+                                </TagsStorSkjerm>
+                            </ElementWrapper>
+                        )}
+                        {behandling &&
+                            behandling.behandlingsårsak === Behandlingsårsak.PAPIRSØKNAD && (
+                                <ElementWrapper>
+                                    <EtikettFokus mini>
+                                        {behandlingsårsakTilTekst[behandling.behandlingsårsak]}
+                                    </EtikettFokus>
+                                </ElementWrapper>
+                            )}
+                    </TagsKnyttetTilBehandling>
+                </VisittKort>
+
+                {behandling && (
+                    <>
+                        <AlleStatuser behandling={behandling} />
+                        <StatuserLitenSkjerm>
+                            <StatusMeny behandling={behandling} />
+                        </StatuserLitenSkjerm>
+                    </>
+                )}
+                {erSaksbehandler && behandling && erBehandlingRedigerbar(behandling) && (
+                    <StyledHamburgermeny />
+                )}
+            </PersonHeaderWrapper>
+            <OppgaveAlleredePlukket
+                visible={visOppgavePlukket}
+                settVisible={settVisOppgavePlukket}
+                åpenHøyreMeny={åpenHøyreMeny}
+            />
+        </>
     );
 };
 

--- a/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
@@ -76,7 +76,11 @@ const BehandlingContent: FC<{
 
     return (
         <>
-            <PersonHeaderComponent data={personopplysninger} behandling={behandling} />
+            <PersonHeaderComponent
+                data={personopplysninger}
+                behandling={behandling}
+                åpenHøyreMeny={åpenHøyremeny}
+            />
             <Container>
                 <InnholdWrapper åpenHøyremeny={åpenHøyremeny}>
                     <Fanemeny behandlingId={behandling.id} />

--- a/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
@@ -72,7 +72,7 @@ const BehandlingContent: FC<{
     personopplysninger: IPersonopplysninger;
 }> = ({ behandling, personopplysninger }) => {
     useSetValgtFagsakId(behandling.fagsakId);
-    const { åpenHøyremeny } = useBehandling();
+    const { åpenHøyremeny, behandlingErRedigerbar } = useBehandling();
 
     return (
         <>
@@ -80,6 +80,7 @@ const BehandlingContent: FC<{
                 data={personopplysninger}
                 behandling={behandling}
                 åpenHøyreMeny={åpenHøyremeny}
+                behandlingErRedigerbar={behandlingErRedigerbar}
             />
             <Container>
                 <InnholdWrapper åpenHøyremeny={åpenHøyremeny}>

--- a/src/frontend/Komponenter/Behandling/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/Høyremeny.tsx
@@ -35,6 +35,8 @@ const StyledButton = styled.button`
 
     background-color: ${navFarger.navBlaLighten20};
 
+    z-index: 99;
+
     margin-left: -12px;
 
     top: 200px;

--- a/src/frontend/Komponenter/Journalforing/JournalforingAdmin.tsx
+++ b/src/frontend/Komponenter/Journalforing/JournalforingAdmin.tsx
@@ -16,8 +16,9 @@ import { utledRiktigBehandlingstype } from './journalførBehandlingUtil';
 import {
     hentFraLocalStorage,
     lagreTilLocalStorage,
+    LocalStorageKey,
     oppgaveRequestKey,
-} from '../Oppgavebenk/oppgavefilterStorage';
+} from '../../App/utils/localStorage';
 import { IJojurnalpostResponse, journalstatusTilTekst } from '../../App/typer/journalforing';
 import { formaterIsoDatoTid } from '../../App/utils/formatter';
 import { UtledEllerVelgFagsak } from './UtledEllerVelgFagsak';
@@ -62,14 +63,17 @@ export const JournalforingAdmin: React.FC = () => {
 
     const gåTilOppgavebenkMedPersonSøk = (personIdent: string) => {
         const lagredeOppgaveFiltreringer = hentFraLocalStorage(
-            oppgaveRequestKey(innloggetSaksbehandler.navIdent),
+            oppgaveRequestKey(innloggetSaksbehandler.navIdent, LocalStorageKey.OPPGAVE_FILTRERING),
             {}
         );
 
-        lagreTilLocalStorage(oppgaveRequestKey(innloggetSaksbehandler.navIdent), {
-            ...lagredeOppgaveFiltreringer,
-            ident: personIdent,
-        });
+        lagreTilLocalStorage(
+            oppgaveRequestKey(innloggetSaksbehandler.navIdent, LocalStorageKey.OPPGAVE_FILTRERING),
+            {
+                ...lagredeOppgaveFiltreringer,
+                ident: personIdent,
+            }
+        );
         navigate('/oppgavebenk');
     };
 

--- a/src/frontend/Komponenter/Journalforing/JournalforingApp.tsx
+++ b/src/frontend/Komponenter/Journalforing/JournalforingApp.tsx
@@ -25,8 +25,9 @@ import { useApp } from '../../App/context/AppContext';
 import {
     hentFraLocalStorage,
     lagreTilLocalStorage,
+    LocalStorageKey,
     oppgaveRequestKey,
-} from '../Oppgavebenk/oppgavefilterStorage';
+} from '../../App/utils/localStorage';
 import BehandlingInnold from './Behandling';
 import UIModalWrapper from '../../Felles/Modal/UIModalWrapper';
 import { UtledEllerVelgFagsak } from './UtledEllerVelgFagsak';
@@ -155,17 +156,26 @@ export const JournalforingApp: React.FC = () => {
     useEffect(() => {
         if (journalpostState.innsending.status === RessursStatus.SUKSESS) {
             const lagredeOppgaveFiltreringer = hentFraLocalStorage(
-                oppgaveRequestKey(innloggetSaksbehandler.navIdent),
+                oppgaveRequestKey(
+                    innloggetSaksbehandler.navIdent,
+                    LocalStorageKey.OPPGAVE_FILTRERING
+                ),
                 {}
             );
 
-            lagreTilLocalStorage(oppgaveRequestKey(innloggetSaksbehandler.navIdent), {
-                ...lagredeOppgaveFiltreringer,
-                ident:
-                    journalResponse.status === RessursStatus.SUKSESS
-                        ? journalResponse.data.personIdent
-                        : undefined,
-            });
+            lagreTilLocalStorage(
+                oppgaveRequestKey(
+                    innloggetSaksbehandler.navIdent,
+                    LocalStorageKey.OPPGAVE_FILTRERING
+                ),
+                {
+                    ...lagredeOppgaveFiltreringer,
+                    ident:
+                        journalResponse.status === RessursStatus.SUKSESS
+                            ? journalResponse.data.personIdent
+                            : undefined,
+                }
+            );
             navigate('/oppgavebenk');
         }
         // eslint-disable-next-line

--- a/src/frontend/Komponenter/Oppgavebenk/OppgaveFiltrering.tsx
+++ b/src/frontend/Komponenter/Oppgavebenk/OppgaveFiltrering.tsx
@@ -15,12 +15,13 @@ import {
     hentFraLocalStorage,
     lagreTilLocalStorage,
     oppgaveRequestKey,
-} from './oppgavefilterStorage';
+} from '../../App/utils/localStorage';
 import MappeVelger from './MappeVelger';
 import { IMappe } from './typer/mappe';
 import { harStrengtFortroligRolle } from '../../App/utils/roller';
 import Alertstripe from 'nav-frontend-alertstriper';
 import UIModalWrapper from '../../Felles/Modal/UIModalWrapper';
+import { LocalStorageKey } from '../../App/utils/localStorage';
 
 export const FlexDiv = styled.div<{ flexDirection?: 'row' | 'column' }>`
     display: flex;
@@ -117,7 +118,7 @@ const OppgaveFiltrering: React.FC<IOppgaveFiltrering> = ({
 
     useEffect(() => {
         const fraLocalStorage = hentFraLocalStorage<IOppgaveRequest>(
-            oppgaveRequestKey(innloggetSaksbehandler.navIdent),
+            oppgaveRequestKey(innloggetSaksbehandler.navIdent, LocalStorageKey.OPPGAVE_FILTRERING),
             {}
         );
 
@@ -142,7 +143,10 @@ const OppgaveFiltrering: React.FC<IOppgaveFiltrering> = ({
         if (Object.values(periodeFeil).some((val?: string) => val)) {
             return;
         }
-        lagreTilLocalStorage(oppgaveRequestKey(innloggetSaksbehandler.navIdent), oppgaveRequest);
+        lagreTilLocalStorage(
+            oppgaveRequestKey(innloggetSaksbehandler.navIdent, LocalStorageKey.OPPGAVE_FILTRERING),
+            oppgaveRequest
+        );
         hentOppgaver(oppgaveRequest);
     };
 
@@ -261,7 +265,10 @@ const OppgaveFiltrering: React.FC<IOppgaveFiltrering> = ({
                     className="flex-item"
                     onClick={() => {
                         lagreTilLocalStorage(
-                            oppgaveRequestKey(innloggetSaksbehandler.navIdent),
+                            oppgaveRequestKey(
+                                innloggetSaksbehandler.navIdent,
+                                LocalStorageKey.OPPGAVE_FILTRERING
+                            ),
                             tomOppgaveRequest
                         );
                         settOppgaveRequest(tomOppgaveRequest);


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-9156)
Skal vise en advarsel dersom en saksbehandler befinner seg på en redigerbar behandling som tidligere er plukket av en annen saksbehandler.

- PRen mangler en faktisk sjekk fra backend sin side som sjekker om nåværende behandling/oppgave allerede er plukket av en annen saksbehandler
 
![Skjermbilde 2022-07-28 kl  14 51 42](https://user-images.githubusercontent.com/32769446/181510403-049e3327-cb16-4f8a-8204-78fca26d095b.png)
