### PR TITLE
Hvis en person har en fagsak i personoversikten, så genereres url mot…

### DIFF
--- a/src/frontend/App/hooks/useSetValgtFagsakId.ts
+++ b/src/frontend/App/hooks/useSetValgtFagsakId.ts
@@ -2,11 +2,13 @@ import { useApp } from '../context/AppContext';
 import { useEffect } from 'react';
 
 // eslint-disable-next-line
-export const useSetValgtFagsakId = (fagsakId: string) => {
+export const useSetValgtFagsakId = (fagsakId: string | undefined) => {
     const { settValgtFagsakId } = useApp();
 
     useEffect(() => {
-        settValgtFagsakId(fagsakId);
+        if (fagsakId) {
+            settValgtFagsakId(fagsakId);
+        }
         return () => settValgtFagsakId(undefined);
     }, [settValgtFagsakId, fagsakId]);
 

--- a/src/frontend/Komponenter/Personoversikt/Personoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Personoversikt.tsx
@@ -15,6 +15,7 @@ import Dokumenter from './Dokumenter';
 import { Infotrygdperioderoversikt } from './Infotrygdperioderoversikt';
 import { IFagsakPerson } from '../../App/typer/fagsak';
 import { useApp } from '../../App/context/AppContext';
+import { useSetValgtFagsakId } from '../../App/hooks/useSetValgtFagsakId';
 
 type TabWithRouter = {
     label: string;
@@ -84,6 +85,10 @@ const PersonoversiktContent: React.FC<{
 }> = ({ fagsakPerson, personopplysninger }) => {
     const navigate = useNavigate();
     const { erSaksbehandler } = useApp();
+
+    useSetValgtFagsakId(
+        fagsakPerson.overgangsstønad || fagsakPerson.barnetilsyn || fagsakPerson.skolepenger
+    );
 
     const paths = useLocation().pathname.split('/').slice(-1);
     const path = paths.length ? paths[paths.length - 1] : '';


### PR DESCRIPTION
… a-inntekt koblet til personidenten

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-9247

Jeg tenkte at jeg kunde endre bruket av fagsakId til fagsakPersonId for å generere url mot a-inntekt, men pga at vi ikke har fagsakPersonId inne på en så måtte vi ha både fagsakPersonId og fagsakId i appcontext:
* personoversikt: fagsakPersonId
* behandling: fagsakId
Her: https://github.com/navikt/familie-ef-sak/pull/1695/files og https://github.com/navikt/familie-ef-sak-frontend/compare/a-inntekt-url-personoversikt?expand=1

I tillegg til gosys som skal ha personIdent

Hvis vi gjør det sånn her, så settes fagsakId hvis det finnes en.