### PR TITLE
Fjerner toggle for nullstilling av vedtaksside

### DIFF
--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -14,5 +14,4 @@ export enum ToggleName {
     skalPrefylleVedtaksperider = 'familie.ef.sak.frontend-prefyll-vedtaksperioder',
     skolepengerOpphør = 'familie.ef.sak.skolepenger-opphor',
     visGjenbrukAvVilkår = 'familie.ef.sak.frontend-skal-vise-alertboks-gjenbruk-vilkar',
-    visNullstillVedtakKnapp = 'familie.ef.sak.frontend-skal-vise-nullstill-vedtak-knapp',
 }

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/SelectVedtaksresultat.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/SelectVedtaksresultat.tsx
@@ -119,7 +119,7 @@ const SelectVedtaksresultat = (props: Props): JSX.Element => {
                         </TekstLinje>
                     </HjelpeTekst>
                 )}
-                {props.skalViseNullstillVedtakKnapp && toggles[ToggleName.visNullstillVedtakKnapp] && (
+                {props.skalViseNullstillVedtakKnapp && (
                     <Button
                         variant="tertiary"
                         size={'small'}


### PR DESCRIPTION
Funksjonalitet er påskrudd i både dev og prod, så trenger ikke toggle lengre.