### PR TITLE
Viser kun se beboer-knappen hvis personen har en bostedsadresse

### DIFF
--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Samliv/Bostedsadresse.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Samliv/Bostedsadresse.tsx
@@ -73,15 +73,21 @@ export const Bostedsadresse = ({ behandlingId }: BostedsadresseProps) => {
                             <Registergrunnlag />
                             <Normaltekst>Brukers bostedsadresse</Normaltekst>
                             <div>
-                                <Normaltekst>{bostedsadresse?.visningsadresse}</Normaltekst>
-                                <LenkeKnapp
-                                    onClick={() => {
-                                        settVisBeboere(!visBeboere);
-                                    }}
-                                >
-                                    Se beboere
-                                    <LenkeIkon>{visBeboere ? <Collapse /> : <Expand />}</LenkeIkon>
-                                </LenkeKnapp>
+                                <Normaltekst>
+                                    {bostedsadresse?.visningsadresse || 'Mangler bostedsadresse'}
+                                </Normaltekst>
+                                {bostedsadresse && (
+                                    <LenkeKnapp
+                                        onClick={() => {
+                                            settVisBeboere(!visBeboere);
+                                        }}
+                                    >
+                                        Se beboere
+                                        <LenkeIkon>
+                                            {visBeboere ? <Collapse /> : <Expand />}
+                                        </LenkeIkon>
+                                    </LenkeKnapp>
+                                )}
                             </div>
                         </>
                     );


### PR DESCRIPTION
For å unngå at backend kaster feil om at personen ikke har noen bostedsadresse

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-9248