### PR TITLE
Vedtaksperioder legg til rad under

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
@@ -111,8 +111,8 @@ const InntektsperiodeValg: React.FC<Props> = ({
             {inntektsperiodeListe.value.map((rad, index) => {
                 const skalViseFjernKnapp =
                     behandlingErRedigerbar &&
-                    (skalViseLeggTilKnapp ||
-                        (index === inntektsperiodeListe.value.length - 1 && index !== 0));
+                    index !== 0 &&
+                    (skalViseLeggTilKnapp || index === inntektsperiodeListe.value.length - 1);
                 return (
                     <InntektContainer key={rad.endretKey} lesevisning={!behandlingErRedigerbar}>
                         <MånedÅrVelger
@@ -193,7 +193,7 @@ const InntektsperiodeValg: React.FC<Props> = ({
                                 {samordningValideringsfeil}
                             </SkjemaelementFeilmelding>
                         </div>
-                        {skalViseFjernKnapp && (
+                        {skalViseFjernKnapp ? (
                             <FjernKnapp
                                 onClick={() => {
                                     inntektsperiodeListe.remove(index);
@@ -208,6 +208,8 @@ const InntektsperiodeValg: React.FC<Props> = ({
                                 }}
                                 knappetekst="Fjern inntektsperiode"
                             />
+                        ) : (
+                            <div />
                         )}
                         {skalViseLeggTilKnapp && (
                             <Tooltip content="Legg til rad under" placement="right">

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
@@ -52,6 +52,12 @@ export const tomInntektsperiodeRad = (): IInntektsperiode => ({
     endretKey: uuidv4(),
 });
 
+const KnappWrapper = styled.div`
+    button {
+        width: 3rem;
+    }
+`;
+
 interface Props {
     inntektsperiodeListe: ListState<IInntektsperiode>;
     valideringsfeil?: FormErrors<InnvilgeVedtakForm>['inntekter'];
@@ -86,11 +92,11 @@ const InntektsperiodeValg: React.FC<Props> = ({
         );
     };
 
-    const leggTilTomRadOver = (index: number) => {
+    const leggTilTomRadUnder = (index: number) => {
         inntektsperiodeListe.setValue((prevState) => [
-            ...prevState.slice(0, index),
+            ...prevState.slice(0, index + 1),
             tomInntektsperiodeRad(),
-            ...prevState.slice(index, prevState.length),
+            ...prevState.slice(index + 1, prevState.length),
         ]);
     };
 
@@ -204,12 +210,14 @@ const InntektsperiodeValg: React.FC<Props> = ({
                             />
                         )}
                         {skalViseLeggTilKnapp && (
-                            <Tooltip content="Legg til rad over" placement="right">
-                                <LeggTilKnapp
-                                    onClick={() => {
-                                        leggTilTomRadOver(index);
-                                    }}
-                                />
+                            <Tooltip content="Legg til rad under" placement="right">
+                                <KnappWrapper>
+                                    <LeggTilKnapp
+                                        onClick={() => {
+                                            leggTilTomRadUnder(index);
+                                        }}
+                                    />
+                                </KnappWrapper>
                             </Tooltip>
                         )}
                     </InntektContainer>

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/VedtaksperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/VedtaksperiodeValg.tsx
@@ -129,8 +129,8 @@ const VedtaksperiodeValg: React.FC<Props> = ({
                 // når featuretoggle for skalViseLeggTilKnapp fjernes, så kan skalViseFjernKnapp inlineas då den alltid skal vises
                 const skalViseFjernKnapp =
                     behandlingErRedigerbar &&
-                    (skalViseLeggTilKnapp ||
-                        (index === vedtaksperiodeListe.value.length - 1 && index !== 0));
+                    index !== 0 &&
+                    (skalViseLeggTilKnapp || index === vedtaksperiodeListe.value.length - 1);
 
                 return (
                     <VedtakPeriodeContainer
@@ -172,7 +172,7 @@ const VedtaksperiodeValg: React.FC<Props> = ({
                         <Element style={{ marginTop: behandlingErRedigerbar ? '0.65rem' : 0 }}>
                             {antallMåneder && `${antallMåneder} mnd`}
                         </Element>
-                        {skalViseFjernKnapp && (
+                        {skalViseFjernKnapp ? (
                             <FjernKnapp
                                 onClick={() => {
                                     vedtaksperiodeListe.remove(index);
@@ -187,6 +187,8 @@ const VedtaksperiodeValg: React.FC<Props> = ({
                                 }}
                                 knappetekst="Fjern vedtaksperiode"
                             />
+                        ) : (
+                            <div />
                         )}
                         {skalViseLeggTilKnapp && (
                             <Tooltip content="Legg til rad under" placement="right">

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/VedtaksperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/VedtaksperiodeValg.tsx
@@ -43,6 +43,12 @@ const KolonneHeaderWrapper = styled.div<{ lesevisning?: boolean }>`
     margin-bottom: 0.5rem;
 `;
 
+const KnappWrapper = styled.div`
+    button {
+        width: 3rem;
+    }
+`;
+
 interface Props {
     vedtaksperiodeListe: ListState<IVedtaksperiode>;
     valideringsfeil?: FormErrors<InnvilgeVedtakForm>['perioder'];
@@ -90,11 +96,11 @@ const VedtaksperiodeValg: React.FC<Props> = ({
         settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
     };
 
-    const leggTilTomRadOver = (index: number) => {
+    const leggTilTomRadUnder = (index: number) => {
         vedtaksperiodeListe.setValue((prevState) => [
-            ...prevState.slice(0, index),
+            ...prevState.slice(0, index + 1),
             tomVedtaksperiodeRad(),
-            ...prevState.slice(index, prevState.length),
+            ...prevState.slice(index + 1, prevState.length),
         ]);
     };
 
@@ -183,12 +189,14 @@ const VedtaksperiodeValg: React.FC<Props> = ({
                             />
                         )}
                         {skalViseLeggTilKnapp && (
-                            <Tooltip content="Legg til rad over" placement="right">
-                                <LeggTilKnapp
-                                    onClick={() => {
-                                        leggTilTomRadOver(index);
-                                    }}
-                                />
+                            <Tooltip content="Legg til rad under" placement="right">
+                                <KnappWrapper>
+                                    <LeggTilKnapp
+                                        onClick={() => {
+                                            leggTilTomRadUnder(index);
+                                        }}
+                                    />
+                                </KnappWrapper>
                             </Tooltip>
                         )}
                     </VedtakPeriodeContainer>


### PR DESCRIPTION
Feedback på "legg til rad over" var at vi endrer til å legge til den under i stedet
Samt fjerner "fjern-knappen" fra første raden

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8697

* Måtte legge til knappwrapper for å få tooltip til å virke
* Endringen på `{skalViseFjernKnapp ? <...> : <div/>` med en tom div er for å alltid ha en div for den kolonnen sånn att legg-til-knappen alltid er i samme kolonne uavhengig om det finnes en sletteknapp eller ikke