### PR TITLE
Revert "Det skal være mulig å journalføre ettersending på en ny behandling fo…"

### DIFF
--- a/src/frontend/Komponenter/Journalforing/JournalforingApp.tsx
+++ b/src/frontend/Komponenter/Journalforing/JournalforingApp.tsx
@@ -204,7 +204,7 @@ export const JournalforingApp: React.FC = () => {
         } else if (erPapirSøknad) {
             return !erNyBehandling;
         } else {
-            return false;
+            return erNyBehandling;
         }
     };
 
@@ -310,7 +310,7 @@ export const JournalforingApp: React.FC = () => {
                                             ) {
                                                 if (journalResponse.harStrukturertSøknad) {
                                                     journalpostState.settVisBekreftelsesModal(true);
-                                                } else {
+                                                } else if (!journalResponse.harStrukturertSøknad) {
                                                     journalpostState.settJournalføringIkkeMuligModal(
                                                         true
                                                     );
@@ -362,6 +362,7 @@ export const JournalforingApp: React.FC = () => {
                         <JournalføringIkkeMuligModal
                             visModal={journalpostState.visJournalføringIkkeMuligModal}
                             settVisModal={journalpostState.settJournalføringIkkeMuligModal}
+                            erPapirSøknad={erPapirSøknad}
                         />
                     </SideLayout>
                 );
@@ -373,7 +374,8 @@ export const JournalforingApp: React.FC = () => {
 const JournalføringIkkeMuligModal: React.FC<{
     visModal: boolean;
     settVisModal: Dispatch<SetStateAction<boolean>>;
-}> = ({ visModal, settVisModal }) => {
+    erPapirSøknad: boolean;
+}> = ({ visModal, settVisModal, erPapirSøknad }) => {
     return (
         <UIModalWrapper
             modal={{
@@ -384,11 +386,21 @@ const JournalføringIkkeMuligModal: React.FC<{
             }}
         >
             <div>
-                <Normaltekst>
-                    Foreløpig er det dessverre ikke mulig å journalføre på en eksisterende
-                    behandling via journalføringsbildet når det ikke er tilknyttet en digital søknad
-                    til journalposten.
-                </Normaltekst>
+                {erPapirSøknad ? (
+                    <Normaltekst>
+                        Foreløpig er det dessverre ikke mulig å journalføre på en eksisterende
+                        behandling via journalføringsbildet når det ikke er tilknyttet en digital
+                        søknad til journalposten.
+                    </Normaltekst>
+                ) : (
+                    <Normaltekst>
+                        Foreløpig er det dessverre ikke mulig å opprette en ny behandling via
+                        journalføringsbildet når det ikke er tilknyttet en digital søknad til
+                        journalposten. Gå inntil videre inn i behandlingsoversikten til bruker og
+                        opprett ny behandling derifra. Deretter kan du journalføre mot den nye
+                        behandlingen.
+                    </Normaltekst>
+                )}
             </div>
             <KnappWrapper>
                 <Button


### PR DESCRIPTION
Reverts navikt/familie-ef-sak-frontend#1455

Ruller tilbake då den då behandlingsårsak settes til SØKNAD, som jeg fikset i https://github.com/navikt/familie-ef-sak-frontend/pull/1477#issuecomment-1216671144 men så kan vi risikere at det ikke finnes noen barn på behandlingen likevel, og då blir det krøll. 