### PR TITLE
toISOString konverterer til UTC, som då kan endre datoet som ikke er …

### DIFF
--- a/src/frontend/App/utils/dato.ts
+++ b/src/frontend/App/utils/dato.ts
@@ -14,7 +14,7 @@ import {
 export const plusMåneder = (date: Date, antall: number): Date => addMonths(date, antall);
 
 export const tilÅrMåned = (date: Date): string => {
-    return formatISO(date).substring(0, 7);
+    return formatISO(date, { representation: 'date' });
 };
 
 export const månedÅrTilDate = (årMåned: string): Date => {

--- a/src/frontend/App/utils/dato.ts
+++ b/src/frontend/App/utils/dato.ts
@@ -3,6 +3,7 @@ import {
     areIntervalsOverlapping,
     differenceInMonths,
     differenceInYears,
+    formatISO,
     isAfter,
     isBefore,
     isEqual,
@@ -13,7 +14,7 @@ import {
 export const plusMåneder = (date: Date, antall: number): Date => addMonths(date, antall);
 
 export const tilÅrMåned = (date: Date): string => {
-    return date.toISOString().substr(0, 7);
+    return formatISO(date).substring(0, 7);
 };
 
 export const månedÅrTilDate = (årMåned: string): Date => {


### PR DESCRIPTION
…ønskelig for denne metoden

Når vi først bruker `månedÅrTilDate` så får vi en dato med `00:00:00 GMT+0200`
`toISOString` gjør om datoet til UTC, dvs dagen før med tidspunkt `22:00:00 Z`

Når vi då tar substring av denne så blir det dagen før. 

Denne er mest brukt i validering, samt skoleår. Jeg har sjekket at skoleår fortsatt blir riktig