### PR TITLE
tilÅrMåned skal fortsatt kun sette yyyy-mm

### DIFF
--- a/src/frontend/App/utils/dato.ts
+++ b/src/frontend/App/utils/dato.ts
@@ -14,7 +14,7 @@ import {
 export const plusMåneder = (date: Date, antall: number): Date => addMonths(date, antall);
 
 export const tilÅrMåned = (date: Date): string => {
-    return formatISO(date, { representation: 'date' });
+    return formatISO(date).substring(0, 7);
 };
 
 export const månedÅrTilDate = (årMåned: string): Date => {


### PR DESCRIPTION
Det ble feil i https://github.com/navikt/familie-ef-sak-frontend/pull/1483
Må fortsatt bruke substring for å få år-måned