### PR TITLE
settIkkePersistertKomponent trenger ikke å være med for å unngå at de…

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
@@ -233,7 +233,8 @@ export const InnvilgeVedtak: React.FC<{
                 }
             });
         },
-        [axiosRequest, behandling, settIkkePersistertKomponent]
+        // eslint-disable-next-line
+        [axiosRequest, behandling]
     );
 
     useEffectNotInitialRender(() => {


### PR DESCRIPTION
…n oppdaterer hentVedtakshistorikk når man går til en annen fane

I redigeringsmodus:
Nå mister man data når man går fra en fane tilbake til vedtak, der man har tidligere lagret vedtak, med historikk

I låsemodus:
Nå laster vi historikk når man går ut fra vedtak, og då trigger man `settIkkePersistertKomponent` så neste gang man går ut fra en fane så får man en popup