### PR TITLE
Setter revurdersFra kun hvis det er en revurdering, sånn at låsing av…

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
@@ -72,7 +72,7 @@ export const InnvilgeVedtak: React.FC<{
     );
     const [vedtakshistorikk, settVedtakshistorikk] = useState<IVedtakshistorikk>();
     const [revurderesFra, settRevurderesFra] = useState(
-        lagretInnvilgetVedtak?.perioder.length
+        behandling.forrigeBehandlingId && lagretInnvilgetVedtak?.perioder.length
             ? lagretInnvilgetVedtak.perioder[0].årMånedFra
             : undefined
     );
@@ -111,10 +111,7 @@ export const InnvilgeVedtak: React.FC<{
     const inntektsperioder = inntektsperiodeState.value;
     const vedtaksperioder = vedtaksperiodeState.value;
 
-    const låsVedtaksperiodeRad =
-        revurderesFra &&
-        lagretInnvilgetVedtak?.perioder.length &&
-        toggles[ToggleName.skalPrefylleVedtaksperider];
+    const låsVedtaksperiodeRad = revurderesFra && toggles[ToggleName.skalPrefylleVedtaksperider];
 
     useEffect(() => {
         if (!vedtakshistorikk || !toggles[ToggleName.skalPrefylleVedtaksperider]) {


### PR DESCRIPTION
… første rad kun skjer for revurderinger

Fiks då første rad ikke låses når man prefyller perioder, dette pga `låsVedtaksperiodeRad` kun sattes hvis lagret vedtak hadde perioder.
For å då også unngå låsing av første rad på førstegangsvedtak med lagret vedtak, så gir det mer mening å kun sette revurderFra hvis det er en revurdering 

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-7719