### PR TITLE
Fiks lag-rekkefølgen

### DIFF
--- a/src/frontend/Felles/PersonHeader/PersonHeader.tsx
+++ b/src/frontend/Felles/PersonHeader/PersonHeader.tsx
@@ -68,7 +68,7 @@ export const PersonHeaderWrapper = styled(Sticky)`
     display: flex;
 
     border-bottom: 1px solid ${navFarger.navGra80};
-    z-index: 22;
+    z-index: 23;
     top: 55px;
 
     .visittkort {

--- a/src/frontend/Felles/Visningskomponenter/Sticky.tsx
+++ b/src/frontend/Felles/Visningskomponenter/Sticky.tsx
@@ -4,6 +4,6 @@ export const Sticky = styled.div`
     position: sticky;
     position: -webkit-sticky;
     top: 0;
-    z-index: 23;
+    z-index: 24;
     background-color: white;
 `;

--- a/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
@@ -35,6 +35,8 @@ interface HøyreMenyWrapperProps {
 const HøyreMenyWrapper = styled.div<HøyreMenyWrapperProps>`
     border-left: 2px solid ${navFarger.navGra40};
 
+    background-color: white;
+
     flex-shrink: 1;
     flex-grow: 0;
 

--- a/src/frontend/Komponenter/Behandling/Fanemeny/Fanemeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Fanemeny/Fanemeny.tsx
@@ -13,6 +13,7 @@ import { useApp } from '../../../App/context/AppContext';
 const StickyMedBoxShadow = styled(Sticky)`
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.4);
     top: 6.5rem;
+    z-index: 22;
 `;
 
 const StyledFanemeny = styled.div`

--- a/src/frontend/Komponenter/Behandling/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/Høyremeny.tsx
@@ -37,6 +37,8 @@ const StyledButton = styled.button`
 
     margin-left: -12px;
 
+    z-index: 22;
+
     top: 200px;
 
     width: 24px;


### PR DESCRIPTION
Måtte noen ekstra justeringer i z-indeks til for å få "lagene" i riktig rekkefølge. Setter også bakgrunnsfarge på høyremenyen for å unngå at den ser gjennomsiktig ut på smal skjerm.

Før:

<img width="500" alt="Skjermbilde 2022-08-19 kl  15 53 43" src="https://user-images.githubusercontent.com/1413265/185635004-3b74a483-122e-4716-a116-6211826a56bb.png">

Etter:

<img width="472" alt="Skjermbilde 2022-08-19 kl  15 55 56" src="https://user-images.githubusercontent.com/1413265/185635049-7ad52079-9b6c-4722-ba5d-59d69bfd1bb6.png">
