### PR TITLE
Revurder fra, som skjer før tidligere perioder skal legge inn en tom …

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
@@ -47,8 +47,8 @@ const StyledInput = styled(InputMedTusenSkille)`
     text-align: left;
 `;
 
-export const tomInntektsperiodeRad = (): IInntektsperiode => ({
-    årMånedFra: '',
+export const tomInntektsperiodeRad = (årMånedFra?: string): IInntektsperiode => ({
+    årMånedFra: årMånedFra || '',
     endretKey: uuidv4(),
 });
 

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
@@ -114,7 +114,11 @@ export const InnvilgeVedtak: React.FC<{
     const låsVedtaksperiodeRad = revurderesFra && toggles[ToggleName.skalPrefylleVedtaksperider];
 
     useEffect(() => {
-        if (!vedtakshistorikk || !toggles[ToggleName.skalPrefylleVedtaksperider]) {
+        if (
+            !revurderesFra ||
+            !vedtakshistorikk ||
+            !toggles[ToggleName.skalPrefylleVedtaksperider]
+        ) {
             return;
         }
 
@@ -125,7 +129,7 @@ export const InnvilgeVedtak: React.FC<{
             .reduce(fyllHullMedOpphør, [] as IVedtaksperiode[]);
 
         vedtaksperiodeState.setValue([
-            ...revurderFraInitPeriode(vedtakshistorikk, revurderesFra),
+            ...revurderFraInitPeriode(vedtakshistorikk, revurderesFra, tomVedtaksperiodeRad),
             ...perioderMedEndretKey,
         ]);
 
@@ -133,9 +137,10 @@ export const InnvilgeVedtak: React.FC<{
             return { ...inntekt, endretKey: uuidv4() };
         });
 
-        inntektsperiodeState.setValue(
-            inntekterMedEndretKey.length > 0 ? inntekterMedEndretKey : [tomInntektsperiodeRad()]
-        );
+        inntektsperiodeState.setValue([
+            ...revurderFraInitPeriode(vedtakshistorikk, revurderesFra, tomInntektsperiodeRad),
+            ...inntekterMedEndretKey,
+        ]);
 
         formState.setErrors((prevState) => ({ ...prevState, perioder: [], inntekter: [] }));
 

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
@@ -297,6 +297,7 @@ export const InnvilgeVedtak: React.FC<{
                         settRevurderesFra={settRevurderesFra}
                         revurderesFra={revurderesFra}
                         feilmelding={revurderesFraOgMedFeilmelding}
+                        vedtakshistorikk={vedtakshistorikk}
                     />
                 ) : null}
                 {skalViseVedtaksperiodeOgInntekt && (

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/RevurderesFraOgMed.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/RevurderesFraOgMed.tsx
@@ -2,16 +2,28 @@ import React, { Dispatch, SetStateAction } from 'react';
 import MånedÅrVelger from '../../../../../Felles/Input/MånedÅr/MånedÅrVelger';
 import styled from 'styled-components';
 import { SkjemaelementFeilmelding } from 'nav-frontend-skjema';
+import { IVedtakshistorikk } from '../../../../../App/typer/vedtak';
+import { revurdererFørFørstePeriode } from './revurderFraUtils';
+import { AlertStripeAdvarsel } from 'nav-frontend-alertstriper';
 
 const WrapperMarginBottom = styled.div`
     margin-bottom: 2rem;
+`;
+
+const Advarsel = styled(AlertStripeAdvarsel)`
+    margin-top: 0.5rem;
+    max-width: 60rem;
+    .alertstripe__tekst {
+        max-width: 60rem;
+    }
 `;
 
 export const RevurderesFraOgMed: React.FC<{
     settRevurderesFra: Dispatch<SetStateAction<string | undefined>>;
     revurderesFra: string;
     feilmelding: string | null;
-}> = ({ settRevurderesFra, revurderesFra, feilmelding }) => {
+    vedtakshistorikk: IVedtakshistorikk | undefined;
+}> = ({ settRevurderesFra, revurderesFra, feilmelding, vedtakshistorikk }) => {
     return (
         <WrapperMarginBottom>
             <MånedÅrVelger
@@ -26,6 +38,12 @@ export const RevurderesFraOgMed: React.FC<{
                 årMånedInitiell={revurderesFra}
             />
             {feilmelding && <SkjemaelementFeilmelding>{feilmelding}</SkjemaelementFeilmelding>}
+            {revurdererFørFørstePeriode(vedtakshistorikk, revurderesFra) && (
+                <Advarsel>
+                    Fom-datoen for denne revurderingen er før fom-datoen for tidligere vedtak. Husk
+                    å fylle ut vedtaksperiode og inntekt for den nye perioden.
+                </Advarsel>
+            )}
         </WrapperMarginBottom>
     );
 };

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/revurderFraUtils.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/revurderFraUtils.ts
@@ -51,9 +51,6 @@ export const revurdererFørFørstePeriode = (
     vedtakshistorikk: IVedtakshistorikk | undefined,
     revurderesFra: string
 ): boolean => {
-    if (!vedtakshistorikk) {
-        return false;
-    }
-    const fraOgMedDato = vedtakshistorikk.perioder[0]?.årMånedFra;
+    const fraOgMedDato = vedtakshistorikk?.perioder[0]?.årMånedFra;
     return !!fraOgMedDato && revurderesFra < fraOgMedDato;
 };

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/revurderFraUtils.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/revurderFraUtils.ts
@@ -43,8 +43,17 @@ export const revurderFraInitPeriode = <T>(
     periode: (revurderesFra: string) => T
 ): T[] => {
     const manglerPerioder = vedtakshistorikk.perioder.length === 0;
-    const fraOgMedDato = vedtakshistorikk.perioder[0]?.årMånedFra;
-    const erFørFørstePeriode = fraOgMedDato && revurderesFra < fraOgMedDato;
-
+    const erFørFørstePeriode = revurdererFørFørstePeriode(vedtakshistorikk, revurderesFra);
     return erFørFørstePeriode || manglerPerioder ? [periode(revurderesFra)] : [];
+};
+
+export const revurdererFørFørstePeriode = (
+    vedtakshistorikk: IVedtakshistorikk | undefined,
+    revurderesFra: string
+): boolean => {
+    if (!vedtakshistorikk) {
+        return false;
+    }
+    const fraOgMedDato = vedtakshistorikk.perioder[0]?.årMånedFra;
+    return !!fraOgMedDato && revurderesFra < fraOgMedDato;
 };

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/revurderFraUtils.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/revurderFraUtils.ts
@@ -4,7 +4,6 @@ import {
     IVedtakshistorikk,
     IVedtaksperiode,
 } from '../../../../../App/typer/vedtak';
-import { tomVedtaksperiodeRad } from './VedtaksperiodeValg';
 import { v4 as uuidv4 } from 'uuid';
 import { månedÅrTilDate, plusMåneder, tilÅrMåned } from '../../../../../App/utils/dato';
 
@@ -36,15 +35,16 @@ export const fyllHullMedOpphør = (
 };
 
 /**
- * Lager en periode som legges før tidligere vedtaksperioder hvis revurderes fra er før tidligere dato
+ * Lager en periode som legges før tidligere perioder hvis revurderes fra er før tidligere dato
  */
-export const revurderFraInitPeriode = (
+export const revurderFraInitPeriode = <T>(
     vedtakshistorikk: IVedtakshistorikk,
-    revurderesFra: string | undefined
-): IVedtaksperiode[] => {
+    revurderesFra: string,
+    periode: (revurderesFra: string) => T
+): T[] => {
     const manglerPerioder = vedtakshistorikk.perioder.length === 0;
     const fraOgMedDato = vedtakshistorikk.perioder[0]?.årMånedFra;
-    const erFørFørstePeriode = revurderesFra && fraOgMedDato && revurderesFra < fraOgMedDato;
+    const erFørFørstePeriode = fraOgMedDato && revurderesFra < fraOgMedDato;
 
-    return erFørFørstePeriode || manglerPerioder ? [tomVedtaksperiodeRad(revurderesFra)] : [];
+    return erFørFørstePeriode || manglerPerioder ? [periode(revurderesFra)] : [];
 };


### PR DESCRIPTION
…rad for inntekt som er før tidligere inntektsrader

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-7719

Bild: Personen har perioder fra august, en tom vedtaksrad ble lagt inn fra før. Denne endringen legger også inn en tom inntektsrad før tidligere inntekter. 
Testet både med revurdering og førstegangsbehandling lokalt. 
![image](https://user-images.githubusercontent.com/937168/185927359-d75900a0-117f-46a2-be97-e62017b7d2e0.png)
