### PR TITLE
Scroll til topp ved bytte av fane

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -21,6 +21,7 @@ import { Toast } from './Felles/Toast/Toast';
 import FagsakTilFagsakPersonRedirect from './Komponenter/Redirect/FagsakTilFagsakPersonRedirect';
 import OppgaveMigreringApp from './Komponenter/Migrering/OppgaveMigrering';
 import { AdminApp } from './Komponenter/Admin/AdminApp';
+import ScrollToTop from './Felles/ScrollToTop/ScrollToTop';
 
 Modal.setAppElement(document.getElementById('modal-a11y-wrapper'));
 
@@ -89,6 +90,7 @@ const AppInnhold: React.FC<{ innloggetSaksbehandler: ISaksbehandler }> = ({
     return (
         <>
             <HeaderMedSøk innloggetSaksbehandler={innloggetSaksbehandler} />
+            <ScrollToTop />
             <Routes>
                 <Route
                     path="/ekstern/fagsak/:eksternFagsakId/:behandlingIdEllerSaksoversikt"

--- a/src/frontend/Felles/ScrollToTop/ScrollToTop.tsx
+++ b/src/frontend/Felles/ScrollToTop/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+    const { pathname } = useLocation();
+
+    useEffect(() => {
+        window.scrollTo(0, 0);
+    }, [pathname]);
+
+    return null;
+}


### PR DESCRIPTION
Om man f.eks. scroller ned på Inngangsvilkår-fanen for så å bytte til Aktivitet, så scrolles det ikke automatisk opp dersom høyremenyen har så mye innhold at det også er scrollbar der. Denne fikser det problemet.