### PR TITLE
Samliv skal vise se-beboer-knappen selv om behandlingen ikke skal vis…

### DIFF
--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Samliv/SamlivInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Samliv/SamlivInfo.tsx
@@ -27,48 +27,38 @@ const SamlivInfo: FC<Props> = ({
     const { sivilstand, bosituasjon, sivilstandsplaner } = grunnlag;
 
     return (
-        <>
-            {sivilstand.søknadsgrunnlag && bosituasjon && sivilstandsplaner && (
-                <GridTabell>
-                    {skalViseSøknadsdata && (
+        <GridTabell>
+            {skalViseSøknadsdata && sivilstand.søknadsgrunnlag && bosituasjon && sivilstandsplaner && (
+                <>
+                    {sivilstand.registergrunnlag.type !== SivilstandType.GIFT && (
                         <>
-                            {sivilstand.registergrunnlag.type !== SivilstandType.GIFT && (
-                                <>
-                                    <Søknadsgrunnlag />
-                                    <Normaltekst>Alene med barn fordi</Normaltekst>
-                                    <Normaltekst>
-                                        {(sivilstand.søknadsgrunnlag.årsakEnslig &&
-                                            ÅrsakEnsligTilTekst[
-                                                sivilstand.søknadsgrunnlag?.årsakEnslig
-                                            ]) ||
-                                            ''}
-                                    </Normaltekst>
-                                    <ÅrsakEnslig søknadsgrunnlag={sivilstand.søknadsgrunnlag} />
-                                </>
-                            )}
-
                             <Søknadsgrunnlag />
-                            {bosituasjon && (
-                                <>
-                                    <Normaltekst>Bosituasjon</Normaltekst>
-                                    <Normaltekst>
-                                        {SøkerDelerBoligTilTekst[bosituasjon.delerDuBolig] || ''}
-                                    </Normaltekst>
-                                </>
-                            )}
-                            <Bosituasjon
-                                bosituasjon={bosituasjon}
-                                sivilstandsplaner={sivilstandsplaner}
-                            />
+                            <Normaltekst>Alene med barn fordi</Normaltekst>
+                            <Normaltekst>
+                                {(sivilstand.søknadsgrunnlag.årsakEnslig &&
+                                    ÅrsakEnsligTilTekst[sivilstand.søknadsgrunnlag?.årsakEnslig]) ||
+                                    ''}
+                            </Normaltekst>
+                            <ÅrsakEnslig søknadsgrunnlag={sivilstand.søknadsgrunnlag} />
                         </>
                     )}
 
-                    {behandlingsstatus !== BehandlingStatus.FERDIGSTILT && (
-                        <Bostedsadresse behandlingId={behandlingId} />
+                    <Søknadsgrunnlag />
+                    {bosituasjon && (
+                        <>
+                            <Normaltekst>Bosituasjon</Normaltekst>
+                            <Normaltekst>
+                                {SøkerDelerBoligTilTekst[bosituasjon.delerDuBolig] || ''}
+                            </Normaltekst>
+                        </>
                     )}
-                </GridTabell>
+                    <Bosituasjon bosituasjon={bosituasjon} sivilstandsplaner={sivilstandsplaner} />
+                </>
             )}
-        </>
+            {behandlingsstatus !== BehandlingStatus.FERDIGSTILT && (
+                <Bostedsadresse behandlingId={behandlingId} />
+            )}
+        </GridTabell>
     );
 };
 


### PR DESCRIPTION
…e søknadsdata

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8645

Diffen er kanskje litt rar, men det som er gjort er at `sivilstand.søknadsgrunnlag && bosituasjon && sivilstandsplaner` er flyttet ned til `skalViseSøknadsdata`, sånn at visningen av se-beboer-knappen vises selv om man ikke skal vise søknadsdata