### PR TITLE
Skolepenger opphørsforbedringer

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/VedtaksformSkolepenger.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/VedtaksformSkolepenger.tsx
@@ -91,10 +91,6 @@ export const VedtaksformSkolepenger: React.FC<{
         ? forrigeVedtak.skoleårsperioder.flatMap((p) => p.utgiftsperioder.map((u) => u.id))
         : [];
 
-    const oppdaterHarUtførtBeregning = (harUtførtBeregning: boolean) => {
-        settHarUtførtBeregning(harUtførtBeregning);
-    };
-
     const lagreVedtak = (vedtaksRequest: IVedtakForSkolepenger) => {
         settLaster(true);
 
@@ -128,7 +124,7 @@ export const VedtaksformSkolepenger: React.FC<{
 
     const handleSubmit = (form: FormState<InnvilgeVedtakForm>) => {
         settVisFeilmelding(false);
-        if (harUtførtBeregning) {
+        if (harUtførtBeregning || erOpphør) {
             const vedtaksRequest: IVedtakForSkolepenger = {
                 skoleårsperioder: form.skoleårsperioder,
                 begrunnelse: form.begrunnelse,
@@ -192,7 +188,7 @@ export const VedtaksformSkolepenger: React.FC<{
                     låsteUtgiftIder={utgiftsIderForrigeBehandling}
                     valideringsfeil={formState.errors.skoleårsperioder}
                     settValideringsFeil={formState.setErrors}
-                    oppdaterHarUtførtBeregning={oppdaterHarUtførtBeregning}
+                    oppdaterHarUtførtBeregning={settHarUtførtBeregning}
                 />
             ) : (
                 <OpphørSkolepenger
@@ -200,7 +196,6 @@ export const VedtaksformSkolepenger: React.FC<{
                     forrigeSkoleårsperioder={forrigeVedtak?.skoleårsperioder || []}
                     valideringsfeil={formState.errors.skoleårsperioder}
                     settValideringsFeil={formState.setErrors}
-                    oppdaterHarUtførtBeregning={oppdaterHarUtførtBeregning}
                 />
             )}
             {feilmelding && (
@@ -208,7 +203,7 @@ export const VedtaksformSkolepenger: React.FC<{
                     {feilmelding}
                 </AlertStripeFeilPreWrap>
             )}
-            {behandlingErRedigerbar && (
+            {behandlingErRedigerbar && !erOpphør && (
                 <WrapperDobbelMarginTop>
                     <Button variant={'secondary'} onClick={beregnSkolepenger} type={'button'}>
                         Beregn

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/OpphørSkolepenger/OpphørSkolepenger.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/OpphørSkolepenger/OpphørSkolepenger.tsx
@@ -26,7 +26,6 @@ const Skoleårsperiode = styled.div`
 interface Props {
     skoleårsperioder: ListState<ISkoleårsperiodeSkolepenger>;
     forrigeSkoleårsperioder: ISkoleårsperiodeSkolepenger[];
-    oppdaterHarUtførtBeregning: (beregningUtført: boolean) => void;
     valideringsfeil?: FormErrors<InnvilgeVedtakForm>['skoleårsperioder'];
     settValideringsFeil: Dispatch<SetStateAction<FormErrors<InnvilgeVedtakForm>>>;
 }
@@ -43,7 +42,6 @@ const beregnSkoleårForSkoleårsperiode = (periode: ISkoleårsperiodeSkolepenger
 const OpphørSkolepenger: React.FC<Props> = ({
     skoleårsperioder,
     forrigeSkoleårsperioder,
-    oppdaterHarUtførtBeregning,
     valideringsfeil,
     settValideringsFeil,
 }) => {
@@ -54,7 +52,6 @@ const OpphørSkolepenger: React.FC<Props> = ({
         const index = skoleårsperioder.value.indexOf(skoleårsperiode);
         skoleårsperioder.remove(index);
         settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
-        oppdaterHarUtførtBeregning(false);
     };
 
     const tilbakestillSkoleårsperiode = (forrigeIndex: number) => {
@@ -72,7 +69,6 @@ const OpphørSkolepenger: React.FC<Props> = ({
             ];
         });
         settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
-        oppdaterHarUtførtBeregning(false);
     };
 
     /**
@@ -88,7 +84,6 @@ const OpphørSkolepenger: React.FC<Props> = ({
         const skoleårsperiode = skoleårsperioder.value[index];
         skoleårsperioder.update({ ...skoleårsperiode, [property]: value }, index);
         settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
-        oppdaterHarUtførtBeregning(false);
     };
 
     /**

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/OpphørSkolepenger/OpphørUtgiftsperiodeSkolepenger.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/OpphørSkolepenger/OpphørUtgiftsperiodeSkolepenger.tsx
@@ -88,6 +88,13 @@ const OpphørUtgiftsperiodeSkolepenger: React.FC<SkolepengerOpphørProps<Skolepe
                     {forrigeData.map((utgift, index) => {
                         const erFjernet = !nyePerioder[utgift.id];
 
+                        const harFlereUtgifter = data.length > 1;
+                        const skalViseFjernKnapp =
+                            behandlingErRedigerbar &&
+                            !skoleårErFjernet &&
+                            !erFjernet &&
+                            harFlereUtgifter;
+
                         return (
                             <Utgiftsrad
                                 erHeader={false}
@@ -102,7 +109,7 @@ const OpphørUtgiftsperiodeSkolepenger: React.FC<SkolepengerOpphørProps<Skolepe
                                 <Element>
                                     {formaterTallMedTusenSkilleEllerStrek(utgift.stønad)}
                                 </Element>
-                                {behandlingErRedigerbar && !skoleårErFjernet && !erFjernet && (
+                                {skalViseFjernKnapp && (
                                     <FjernKnapp
                                         onClick={() => fjernUtgift(utgift.id)}
                                         knappetekst="Fjern vedtaksperiode"


### PR DESCRIPTION
2 første punktene i https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-9349
* Skal ikke vise utregning/beregn-knappen for opphør
* Skal ikke vise fjernknappen på utgiftsperiode hvis det kun finnes en igjen å fjerne

Til info: opphør er featuretogglet

Beregn-knappen er fjernet
![image](https://user-images.githubusercontent.com/937168/187426782-266b2670-bd09-465a-8bb2-b0774f851dcc.png)

Opphør, skal ikke vise fjerne utgift når det bare finnes en rad -> man må då opphøre hele skoleåret
![image](https://user-images.githubusercontent.com/937168/187425813-5fa7307a-d8cb-497a-9afa-0cf9b1cf5453.png)
