### PR TITLE
Revurderinger skal vise informasjon om terminbarn

### DIFF
--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/AleneomsorgInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/AleneomsorgInfo.tsx
@@ -56,7 +56,7 @@ const AleneomsorgInfo: FC<{
                             )}
                         </Element>
                     </>
-                ) : skalViseSøknadsdata ? (
+                ) : (
                     <>
                         <Søknadsgrunnlag />
                         <Element>Barnets navn</Element>
@@ -66,7 +66,7 @@ const AleneomsorgInfo: FC<{
                                 : 'Ikke født'}
                         </Element>
                     </>
-                ) : null}
+                )}
                 {registergrunnlag.fødselsnummer ? (
                     <>
                         <Registergrunnlag />
@@ -75,17 +75,15 @@ const AleneomsorgInfo: FC<{
                             fødselsnummer={registergrunnlag.fødselsnummer}
                         />
                     </>
-                ) : skalViseSøknadsdata ? (
-                    søknadsgrunnlag.fødselTermindato && (
-                        <>
-                            <Søknadsgrunnlag />
-                            <Normaltekst>Termindato</Normaltekst>
-                            <Normaltekst>
-                                {formaterNullableIsoDato(søknadsgrunnlag.fødselTermindato)}
-                            </Normaltekst>
-                        </>
-                    )
-                ) : null}
+                ) : (
+                    <>
+                        <Søknadsgrunnlag />
+                        <Normaltekst>Termindato</Normaltekst>
+                        <Normaltekst>
+                            {formaterNullableIsoDato(søknadsgrunnlag.fødselTermindato)}
+                        </Normaltekst>
+                    </>
+                )}
 
                 <Bosted
                     harSammeAdresseRegister={registergrunnlag.harSammeAdresse}

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/MorEllerFar/MorEllerFarInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/MorEllerFar/MorEllerFarInfo.tsx
@@ -25,27 +25,15 @@ const MorEllerFarInfo: FC<Props> = ({ barnMedSamvær, skalViseSøknadsdata, doku
                 return (
                     <React.Fragment key={barn.barnId}>
                         <GridTabell>
-                            {registergrunnlag.navn ? (
-                                <>
-                                    <LiteBarn />
-                                    <Element>
-                                        {registergrunnlag.navn}
-                                        {registergrunnlag.dødsdato && (
-                                            <EtikettDød dødsdato={registergrunnlag.dødsdato} />
-                                        )}
-                                    </Element>
-                                </>
-                            ) : skalViseSøknadsdata ? (
-                                <>
-                                    <LiteBarn />
-                                    <Element>
-                                        {søknadsgrunnlag.navn ? søknadsgrunnlag.navn : 'Ikke født'}
-                                        {registergrunnlag.dødsdato && (
-                                            <EtikettDød dødsdato={registergrunnlag.dødsdato} />
-                                        )}
-                                    </Element>
-                                </>
-                            ) : null}
+                            <>
+                                <LiteBarn />
+                                <Element>
+                                    {registergrunnlag.navn ?? søknadsgrunnlag.navn ?? 'Ikke født'}
+                                    {registergrunnlag.dødsdato && (
+                                        <EtikettDød dødsdato={registergrunnlag.dødsdato} />
+                                    )}
+                                </Element>
+                            </>
                             {registergrunnlag.fødselsnummer ? (
                                 <>
                                     <Registergrunnlag />
@@ -54,7 +42,7 @@ const MorEllerFarInfo: FC<Props> = ({ barnMedSamvær, skalViseSøknadsdata, doku
                                         fødselsnummer={registergrunnlag.fødselsnummer}
                                     />
                                 </>
-                            ) : skalViseSøknadsdata ? (
+                            ) : (
                                 <>
                                     <Søknadsgrunnlag />
                                     <Normaltekst>Termindato</Normaltekst>
@@ -62,7 +50,7 @@ const MorEllerFarInfo: FC<Props> = ({ barnMedSamvær, skalViseSøknadsdata, doku
                                         {formaterNullableIsoDato(søknadsgrunnlag.fødselTermindato)}
                                     </Normaltekst>
                                 </>
-                            ) : null}
+                            )}
                         </GridTabell>
                     </React.Fragment>
                 );

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/NyttBarnSammePartner/NyttBarnSammePartner.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/NyttBarnSammePartner/NyttBarnSammePartner.tsx
@@ -13,7 +13,6 @@ export const NyttBarnSammePartner: React.FC<VilkårProps> = ({
     nullstillVurdering,
     feilmeldinger,
     ikkeVurderVilkår,
-    skalViseSøknadsdata,
 }) => {
     const vurdering = vurderinger.find(
         (v) => v.vilkårType === InngangsvilkårType.NYTT_BARN_SAMME_PARTNER
@@ -35,7 +34,6 @@ export const NyttBarnSammePartner: React.FC<VilkårProps> = ({
                         <NyttBarnSammePartnerInfo
                             barnMedSamvær={barnMedSamvær}
                             tidligereVedtaksperioder={grunnlag.tidligereVedtaksperioder}
-                            skalViseSøknadsdata={skalViseSøknadsdata}
                         />
                     </>
                 ),

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/NyttBarnSammePartner/NyttBarnSammePartnerInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/NyttBarnSammePartner/NyttBarnSammePartnerInfo.tsx
@@ -14,11 +14,7 @@ interface Props {
     skalViseSøknadsdata: boolean;
 }
 
-const NyttBarnSammePartnerInfo: FC<Props> = ({
-    barnMedSamvær,
-    tidligereVedtaksperioder,
-    skalViseSøknadsdata,
-}) => {
+const NyttBarnSammePartnerInfo: FC<Props> = ({ barnMedSamvær, tidligereVedtaksperioder }) => {
     const registergrunnlagNyttBarn = mapTilRegistergrunnlagNyttBarn(barnMedSamvær);
     const søknadsgrunnlagNyttBarn = mapTilSøknadsgrunnlagNyttBarn(barnMedSamvær);
     return (
@@ -43,24 +39,20 @@ const NyttBarnSammePartnerInfo: FC<Props> = ({
                     </Normaltekst>
                 )}
             </div>
-            {skalViseSøknadsdata && (
-                <div>
-                    <FlexDiv>
-                        <Overskrift className="tittel" tag="h3">
-                            Brukers fremtidige barn lagt til i søknad
-                        </Overskrift>
-                    </FlexDiv>
-                    {søknadsgrunnlagNyttBarn.length ? (
-                        søknadsgrunnlagNyttBarn.map((barn) => (
-                            <SøknadgrunnlagNyttBarn barn={barn} />
-                        ))
-                    ) : (
-                        <Normaltekst>
-                            <i>Bruker har ingen barn lagt til i søknad</i>
-                        </Normaltekst>
-                    )}
-                </div>
-            )}
+            <div>
+                <FlexDiv>
+                    <Overskrift className="tittel" tag="h3">
+                        Brukers fremtidige barn lagt til i søknad
+                    </Overskrift>
+                </FlexDiv>
+                {søknadsgrunnlagNyttBarn.length ? (
+                    søknadsgrunnlagNyttBarn.map((barn) => <SøknadgrunnlagNyttBarn barn={barn} />)
+                ) : (
+                    <Normaltekst>
+                        <i>Bruker har ingen barn lagt til i søknad</i>
+                    </Normaltekst>
+                )}
+            </div>
         </>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/NyttBarnSammePartner/NyttBarnSammePartnerInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/NyttBarnSammePartner/NyttBarnSammePartnerInfo.tsx
@@ -11,7 +11,6 @@ import { ITidligereVedtaksperioder } from '../../TidligereVedtaksperioder/typer'
 interface Props {
     barnMedSamvær: IBarnMedSamvær[];
     tidligereVedtaksperioder: ITidligereVedtaksperioder;
-    skalViseSøknadsdata: boolean;
 }
 
 const NyttBarnSammePartnerInfo: FC<Props> = ({ barnMedSamvær, tidligereVedtaksperioder }) => {


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8145

Vi viser generellt ikke søknadsinformasjon i revurderinger uten søknad. Då viser vi heller ikke terminbarn. For aleneomsorg så viser vi bare en tom boks

Diskusjon: 
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-8145

Tidligere: 
<img src="https://user-images.githubusercontent.com/937168/188813686-97d88fe6-111e-4522-b677-976b9b99cef1.png" alt="drawing" width="300"/>

Etter:
![image](https://user-images.githubusercontent.com/937168/188813770-45bb92c9-0c0c-4d95-836d-2bf21c9bdbdc.png)
