### PR TITLE
Skal ikke vise Se Beboer-knappen hvis adressen ikke er gyldig, sånn s…

### DIFF
--- a/src/frontend/Felles/Personopplysninger/Adressehistorikk.tsx
+++ b/src/frontend/Felles/Personopplysninger/Adressehistorikk.tsx
@@ -8,9 +8,9 @@ import { IngenData, TabellWrapper, Td } from './TabellWrapper';
 import styled from 'styled-components';
 import { Knapp } from 'nav-frontend-knapper';
 import Lesmerpanel from 'nav-frontend-lesmerpanel';
-import { datoErEtterDagensDato } from '../../App/utils/utils';
 import Beboere from './Beboere';
 import { formaterNullableIsoDato } from '../../App/utils/formatter';
+import { gyldigTilOgMedErNullEllerFremITid } from './adresseUtil';
 
 const StyledKnapp = styled(Knapp)`
     margin-left: 1rem;
@@ -117,9 +117,6 @@ const Adresser: React.FC<{ adresser: IAdresse[]; fagsakPersonId: string; type?: 
         </TabellWrapper>
     );
 };
-
-const gyldigTilOgMedErNullEllerFremITid = (adresse: IAdresse) =>
-    !adresse.gyldigTilOgMed || datoErEtterDagensDato(adresse.gyldigTilOgMed);
 
 const Innhold: React.FC<{ adresser: IAdresse[]; fagsakPersonId: string }> = ({
     adresser,

--- a/src/frontend/Felles/Personopplysninger/adresseUtil.ts
+++ b/src/frontend/Felles/Personopplysninger/adresseUtil.ts
@@ -1,0 +1,5 @@
+import { IAdresse } from '../../App/typer/personopplysninger';
+import { datoErEtterDagensDato } from '../../App/utils/utils';
+
+export const gyldigTilOgMedErNullEllerFremITid = (adresse: IAdresse) =>
+    !adresse.gyldigTilOgMed || datoErEtterDagensDato(adresse.gyldigTilOgMed);

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Samliv/Bostedsadresse.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Samliv/Bostedsadresse.tsx
@@ -2,7 +2,12 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { Registergrunnlag } from '../../../../Felles/Ikoner/DataGrunnlagIkoner';
 import { Normaltekst } from 'nav-frontend-typografi';
 import { Td } from '../../../../Felles/Personopplysninger/TabellWrapper';
-import { AdresseType, ISøkeresultatPerson } from '../../../../App/typer/personopplysninger';
+import {
+    AdresseType,
+    IAdresse,
+    IPersonopplysninger,
+    ISøkeresultatPerson,
+} from '../../../../App/typer/personopplysninger';
 import { useApp } from '../../../../App/context/AppContext';
 import { byggTomRessurs, Ressurs, RessursStatus } from '../../../../App/typer/ressurs';
 import DataViewer from '../../../../Felles/DataViewer/DataViewer';
@@ -11,6 +16,7 @@ import LenkeKnapp from '../../../../Felles/Knapper/LenkeKnapp';
 import { Collapse, Expand } from '@navikt/ds-icons';
 import { useBehandling } from '../../../../App/context/BehandlingContext';
 import { AlertStripeVariant } from '../../../../Felles/Visningskomponenter/AlertStripeFeilPreWrap';
+import { gyldigTilOgMedErNullEllerFremITid } from '../../../../Felles/Personopplysninger/adresseUtil';
 
 interface BeboereTabellProps {
     vis: boolean;
@@ -35,6 +41,17 @@ const LenkeIkon = styled.div`
     display: inline-block;
     position: relative;
 `;
+
+const nåværendeBostedsadresse = (
+    personopplysningerResponse: IPersonopplysninger
+): IAdresse | undefined => {
+    const bostedsadresse = personopplysningerResponse.adresse.find(
+        (adresse) => adresse.type === AdresseType.BOSTEDADRESSE
+    );
+    return bostedsadresse && gyldigTilOgMedErNullEllerFremITid(bostedsadresse)
+        ? bostedsadresse
+        : undefined;
+};
 
 export const Bostedsadresse = ({ behandlingId }: BostedsadresseProps) => {
     const { personopplysningerResponse } = useBehandling();
@@ -64,9 +81,7 @@ export const Bostedsadresse = ({ behandlingId }: BostedsadresseProps) => {
         <>
             <DataViewer response={{ personopplysningerResponse }}>
                 {({ personopplysningerResponse }) => {
-                    const bostedsadresse = personopplysningerResponse.adresse.find(
-                        (adresse) => adresse.type === AdresseType.BOSTEDADRESSE
-                    );
+                    const bostedsadresse = nåværendeBostedsadresse(personopplysningerResponse);
 
                     return (
                         <>


### PR DESCRIPTION
…om det gjøres i adressehistorikk i personopplysningene

Hadde en situasjon der en person hadde bostedsadresse men som ikke var gyldig (tom-datoet var utgått)