### PR TITLE
Skal hente klager på nytt ved opprettelse av ny klage

### DIFF
--- a/src/frontend/App/typer/toast.ts
+++ b/src/frontend/App/typer/toast.ts
@@ -13,8 +13,7 @@ export const toastTilTekst: Record<EToast, string> = {
     BEHANDLING_HENLAGT: 'Behandlingen er henlagt',
     TILBAKEKREVING_OPPRETTET:
         'Tilbakekreving blir opprettet. NB! Det kan ta litt tid før du kan se den i behandlingsoversikten.',
-    KLAGE_OPPRETTET:
-        'Klage blir opprettet. NB! Det kan ta litt tid før du kan se den i behandlingsoversikten.',
+    KLAGE_OPPRETTET: 'Klagen er opprettet og vises nå i behandlingsoversikten',
     BREVMOTTAKERE_SATT: 'Brevmottakere er satt',
     INNGANGSVILKÅR_GJENBRUKT: 'Vilkårsvurdering gjenbrukt',
     VEDTAK_NULLSTILT: 'Lagret vedtak nullstilt',

--- a/src/frontend/Komponenter/Personoversikt/Behandlingsoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Behandlingsoversikt.tsx
@@ -20,6 +20,9 @@ const Behandlingsoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPerso
         hentKlagebehandlinger(fagsakPersonId);
     }, [hentFagsakPerson, fagsakPersonId, hentKlagebehandlinger]);
 
+    const reHentKlagebehandlinger = () => {
+        hentKlagebehandlinger(fagsakPersonId);
+    };
     return (
         <DataViewer response={{ fagsakPerson, klagebehandlinger }}>
             {({ fagsakPerson, klagebehandlinger }) => (
@@ -29,18 +32,21 @@ const Behandlingsoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPerso
                         <FagsakOversikt
                             fagsak={fagsakPerson.overgangsstønad}
                             klageBehandlinger={klagebehandlinger.overgangsstønad}
+                            hentKlageBehandlinger={reHentKlagebehandlinger}
                         />
                     )}
                     {fagsakPerson.barnetilsyn && (
                         <FagsakOversikt
                             fagsak={fagsakPerson.barnetilsyn}
                             klageBehandlinger={klagebehandlinger.barnetilsyn}
+                            hentKlageBehandlinger={reHentKlagebehandlinger}
                         />
                     )}
                     {fagsakPerson.skolepenger && (
                         <FagsakOversikt
                             fagsak={fagsakPerson.skolepenger}
                             klageBehandlinger={klagebehandlinger.skolepenger}
+                            hentKlageBehandlinger={reHentKlagebehandlinger}
                         />
                     )}
                 </>

--- a/src/frontend/Komponenter/Personoversikt/FagsakOversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/FagsakOversikt.tsx
@@ -1,5 +1,5 @@
 import LagBehandlingModal from './LagBehandlingModal';
-import React, { useEffect, useState } from 'react';
+import React, { Dispatch, useEffect, useState } from 'react';
 import { byggTomRessurs, Ressurs } from '../../App/typer/ressurs';
 import { Fagsak } from '../../App/typer/fagsak';
 import { TilbakekrevingBehandling } from '../../App/typer/tilbakekreving';
@@ -23,9 +23,14 @@ const KnappMedMargin = styled(Knapp)`
 interface Props {
     fagsak: Fagsak;
     klageBehandlinger: KlageBehandling[];
+    hentKlageBehandlinger: Dispatch<void>;
 }
 
-export const FagsakOversikt: React.FC<Props> = ({ fagsak, klageBehandlinger }) => {
+export const FagsakOversikt: React.FC<Props> = ({
+    fagsak,
+    klageBehandlinger,
+    hentKlageBehandlinger,
+}) => {
     const { axiosRequest, erSaksbehandler } = useApp();
     const { toggles } = useToggles();
 
@@ -69,6 +74,7 @@ export const FagsakOversikt: React.FC<Props> = ({ fagsak, klageBehandlinger }) =
                                 settVisModal={settVisLagBehandlingModal}
                                 fagsak={fagsak}
                                 hentTilbakekrevinger={hentTilbakekrevingBehandlinger}
+                                hentKlageBehandlinger={hentKlageBehandlinger}
                                 kanStarteRevurdering={kanStarteRevurdering}
                             />
 

--- a/src/frontend/Komponenter/Personoversikt/LagBehandlingModal.tsx
+++ b/src/frontend/Komponenter/Personoversikt/LagBehandlingModal.tsx
@@ -34,6 +34,7 @@ interface IProps {
     settVisModal: (bool: boolean) => void;
     fagsak: Fagsak;
     hentTilbakekrevinger: Dispatch<void>;
+    hentKlageBehandlinger: Dispatch<void>;
     kanStarteRevurdering: boolean;
 }
 
@@ -42,6 +43,7 @@ const LagBehandlingModal: React.FunctionComponent<IProps> = ({
     settVisModal,
     fagsak,
     hentTilbakekrevinger,
+    hentKlageBehandlinger,
     kanStarteRevurdering,
 }) => {
     const { toggles } = useToggles();
@@ -109,7 +111,7 @@ const LagBehandlingModal: React.FunctionComponent<IProps> = ({
             })
                 .then((response) => {
                     if (response.status === RessursStatus.SUKSESS) {
-                        //TODO hentKlager();
+                        hentKlageBehandlinger();
                         settVisModal(false);
                         settToast(EToast.KLAGE_OPPRETTET);
                     } else {


### PR DESCRIPTION
Henter klager på nytt når man oppretter en klage. Dette gjør at behandlingsoversikten "refresher". Beholder toasten da det _KAN_ være litt vanskelig å skjønne/se at man faktisk har fått opp en ny rad i behandlingsoversikten.

[favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-9780)

![ezgif com-gif-maker](https://user-images.githubusercontent.com/402915/193832901-15f02100-9af0-47dd-8e0d-d0e6df637ed7.gif)
