### PR TITLE
Det skal være mulig å lagre vedtak 7mnd frem i tiden for å kunne støt…

### DIFF
--- a/src/frontend/App/hooks/felles/useFormState.ts
+++ b/src/frontend/App/hooks/felles/useFormState.ts
@@ -7,13 +7,13 @@ export type FormState<T> = {
     [P in keyof T]: any;
 };
 export type InternalFormState<T> = { [P in keyof T]: FieldState | ListState<unknown> };
-export type FormHook<T extends Record<string, any>, U> = {
+export type FormHook<T extends Record<string, any>> = {
     getProps(key: keyof T): FieldState | ListState<unknown>;
     errors: FormErrors<T>;
     setErrors: Dispatch<SetStateAction<FormErrors<T>>>;
     validateForm: () => boolean;
     onSubmit(fn: (state: FormState<T>) => void): FormEventHandler<HTMLFormElement>;
-    customValidate: (fn: Valideringsfunksjon<T, U>) => boolean;
+    customValidate: (fn: Valideringsfunksjon<T>) => boolean;
 };
 
 export type FormErrors<T extends Record<string, any | undefined>> = {
@@ -22,13 +22,12 @@ export type FormErrors<T extends Record<string, any | undefined>> = {
         : FormErrors<T[P]>;
 };
 
-type Valideringsfunksjon<T, U> = (state: FormState<T>, valideringsbetingelse?: U) => FormErrors<T>;
+type Valideringsfunksjon<T> = (state: FormState<T>) => FormErrors<T>;
 
-export default function useFormState<T extends Record<string, unknown>, U = void>(
+export default function useFormState<T extends Record<string, unknown>>(
     initialState: FormState<T>,
-    valideringsfunksjon: Valideringsfunksjon<T, U>,
-    valideringsbetingelse?: U
-): FormHook<T, U> {
+    valideringsfunksjon: Valideringsfunksjon<T>
+): FormHook<T> {
     const [errors, setErrors] = useState<FormErrors<T>>(
         Object.keys(initialState).reduce(
             (acc, key) => ({
@@ -60,7 +59,7 @@ export default function useFormState<T extends Record<string, unknown>, U = void
     return {
         getProps: (key: keyof T) => formState[key],
         validateForm: () => {
-            const errors = valideringsfunksjon(tilFormstate, valideringsbetingelse);
+            const errors = valideringsfunksjon(tilFormstate);
             setErrors(errors);
             return isValid(errors);
         },
@@ -69,13 +68,13 @@ export default function useFormState<T extends Record<string, unknown>, U = void
         onSubmit(fn: (state: FormState<T>) => void): FormEventHandler<HTMLFormElement> {
             return (event) => {
                 event.preventDefault();
-                const errors = valideringsfunksjon(tilFormstate, valideringsbetingelse);
+                const errors = valideringsfunksjon(tilFormstate);
                 setErrors(errors);
                 if (isValid(errors)) fn(tilFormstate);
             };
         },
         customValidate(validate) {
-            const errors = validate(tilFormstate, valideringsbetingelse);
+            const errors = validate(tilFormstate);
             setErrors(errors);
             return isValid(errors);
         },

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
@@ -84,9 +84,7 @@ export const InnvilgeVedtak: React.FC<{
 
     const [feilmelding, settFeilmelding] = useState<string>();
 
-    const erFørstegangsInnvilgelse = behandling.forrigeBehandlingId === null;
-
-    const formState = useFormState<InnvilgeVedtakForm, boolean>(
+    const formState = useFormState<InnvilgeVedtakForm>(
         {
             periodeBegrunnelse: lagretInnvilgetVedtak?.periodeBegrunnelse || '',
             inntektBegrunnelse: lagretInnvilgetVedtak?.inntektBegrunnelse || '',
@@ -98,8 +96,7 @@ export const InnvilgeVedtak: React.FC<{
                 : [tomInntektsperiodeRad()],
             samordningsfradragType: lagretInnvilgetVedtak?.samordningsfradragType || '',
         },
-        validerInnvilgetVedtakForm,
-        erFørstegangsInnvilgelse
+        validerInnvilgetVedtakForm
     );
 
     const inntektsperiodeState = formState.getProps('inntekter') as ListState<IInntektsperiode>;

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
@@ -15,16 +15,13 @@ import { InnvilgeVedtakForm } from './InnvilgeVedtak/InnvilgeVedtak';
 import { FormErrors } from '../../../../App/hooks/felles/useFormState';
 import { SanksjonereVedtakForm } from '../../Sanksjon/Sanksjonsfastsettelse';
 
-export const validerInnvilgetVedtakForm = (
-    {
-        perioder,
-        inntekter,
-        periodeBegrunnelse,
-        inntektBegrunnelse,
-        samordningsfradragType,
-    }: InnvilgeVedtakForm,
-    erFørstegangsInnvilgelse?: boolean
-): FormErrors<InnvilgeVedtakForm> => {
+export const validerInnvilgetVedtakForm = ({
+    perioder,
+    inntekter,
+    periodeBegrunnelse,
+    inntektBegrunnelse,
+    samordningsfradragType,
+}: InnvilgeVedtakForm): FormErrors<InnvilgeVedtakForm> => {
     const periodeBegrunnelseFeil =
         periodeBegrunnelse === '' || periodeBegrunnelse === undefined
             ? 'Mangelfull utfylling av periodebegrunnelse'
@@ -41,28 +38,25 @@ export const validerInnvilgetVedtakForm = (
         samordningsfradagEksisterer && !samordningsfradragType
             ? 'Mangelfull utfylling av type samordningsfradag'
             : undefined;
+
     return {
-        ...validerVedtaksperioder({ perioder, inntekter }, erFørstegangsInnvilgelse),
+        ...validerVedtaksperioder({ perioder, inntekter }),
         inntektBegrunnelse: inntektBegrunnelseFeil,
         periodeBegrunnelse: periodeBegrunnelseFeil,
         samordningsfradragType: typeSamordningFeil,
     };
 };
 
-export const validerVedtaksperioder = (
-    {
-        perioder,
-        inntekter,
-    }: {
-        perioder: IVedtaksperiode[];
-        inntekter: IInntektsperiode[];
-    },
-    erFørstegangsinnvilgelse?: boolean
-): FormErrors<{
+export const validerVedtaksperioder = ({
+    perioder,
+    inntekter,
+}: {
+    perioder: IVedtaksperiode[];
+    inntekter: IInntektsperiode[];
+}): FormErrors<{
     perioder: IVedtaksperiode[];
     inntekter: IInntektsperiode[];
 }> => {
-    const toMånederFremITiden = tilÅrMåned(plusMåneder(new Date(), 2));
     const syvMånederFremITiden = tilÅrMåned(plusMåneder(new Date(), 7));
     const tolvMånederFremITiden = tilÅrMåned(plusMåneder(new Date(), 12));
     let harPeriodeFør7mndFremITiden = false;
@@ -107,18 +101,6 @@ export const validerVedtaksperioder = (
                     årMånedFra: `Ugyldig etterfølgende periode - fra (${årMånedFra}) må være etter til (${forrige.årMånedTil})`,
                 };
             }
-        }
-
-        // Den første fom-perioden kan ikke være mer enn to måneder frem i tid for førstegangsinnvilgelser
-        if (
-            index === 0 &&
-            erFørstegangsinnvilgelse &&
-            erMånedÅrEtter(toMånederFremITiden, årMånedFra)
-        ) {
-            return {
-                ...vedtaksperiodeFeil,
-                årMånedFra: `Startdato (${årMånedFra}) mer enn 2mnd frem i tid`,
-            };
         }
 
         // Det er gyldig med periode etter 7mnd frem i tiden, hvis det finnes en periode før 7mnd frem i tiden


### PR DESCRIPTION
…te terminbarn lang frem i tiden

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-9415

Det blir fortsatt validert at man ikke får legge inn perioder 7mnd frem i tiden

* Det ligger visstnok saker de ikke får behandlet nå pga sperren.

Reverterer 
* https://github.com/navikt/familie-ef-sak-frontend/pull/1416