### PR TITLE
Bryter ut hamburgaren

### DIFF
--- a/src/frontend/Felles/Hamburgermeny/Hamburgermeny.tsx
+++ b/src/frontend/Felles/Hamburgermeny/Hamburgermeny.tsx
@@ -1,9 +1,7 @@
-import React, { useEffect, useRef, useState } from 'react';
-import { Hamburger } from '@navikt/ds-icons';
+import React, { FC, useEffect, useRef, useState } from 'react';
+import { Hamburger, EllipsisV } from '@navikt/ds-icons';
 import styled from 'styled-components';
 import { Normaltekst } from 'nav-frontend-typografi';
-import { useApp } from '../../App/context/AppContext';
-import { useBehandling } from '../../App/context/BehandlingContext';
 
 interface HamburgerMenyInnholdProps {
     åpen: boolean;
@@ -15,6 +13,18 @@ const HamburgerMenyIkon = styled(Hamburger)`
     &:hover {
         cursor: pointer;
     }
+`;
+
+const HamburgerMenyEllipsisVIkon = styled(EllipsisV)`
+    margin: 0.5rem 0.5rem 0 0.5rem;
+
+    &:hover {
+        cursor: pointer;
+    }
+`;
+
+const HamburgerWrapper = styled.div`
+    position: relative;
 `;
 
 const HamburgerMenyInnhold = styled.div`
@@ -31,6 +41,8 @@ const HamburgerMenyInnhold = styled.div`
     box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.4);
     -webkit-box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.4);
     -moz-box-shadow: 5px 5px 5px rgba(0, 0, 0, 0.4);
+
+    white-space: nowrap;
 
     ul,
     li {
@@ -58,10 +70,18 @@ const Knapp = styled.button`
     text-align: left;
 `;
 
-export const Hamburgermeny = () => {
+export interface MenyItem {
+    tekst: string;
+    onClick: () => void;
+}
+
+export interface Props {
+    type?: 'hamburger' | 'ellipsisV';
+    items: MenyItem[];
+}
+
+export const Hamburgermeny: FC<Props> = ({ type = 'hamburger', items }) => {
     const ref = useRef(null);
-    const { settVisBrevmottakereModal } = useApp();
-    const { settVisHenleggModal } = useBehandling();
     const [åpenHamburgerMeny, settÅpenHamburgerMeny] = useState<boolean>(false);
 
     useEffect(() => {
@@ -82,34 +102,33 @@ export const Hamburgermeny = () => {
     }, [åpenHamburgerMeny]);
 
     return (
-        <div ref={ref}>
-            <HamburgerMenyIkon
-                onClick={() => {
-                    settÅpenHamburgerMeny(!åpenHamburgerMeny);
-                }}
-            />
+        <HamburgerWrapper ref={ref}>
+            {type === 'hamburger' ? (
+                <HamburgerMenyIkon
+                    onClick={() => {
+                        settÅpenHamburgerMeny(!åpenHamburgerMeny);
+                    }}
+                />
+            ) : (
+                <HamburgerMenyEllipsisVIkon
+                    width={'1.75em'}
+                    height={'1.75em'}
+                    onClick={() => {
+                        settÅpenHamburgerMeny(!åpenHamburgerMeny);
+                    }}
+                />
+            )}
             <HamburgerMenyInnhold åpen={åpenHamburgerMeny}>
                 <ul>
-                    <li>
-                        <Knapp
-                            onClick={() => {
-                                settVisBrevmottakereModal(true);
-                            }}
-                        >
-                            <Normaltekst>Sett Verge/Fullmakt mottakere</Normaltekst>
-                        </Knapp>
-                    </li>
-                    <li>
-                        <Knapp
-                            onClick={() => {
-                                settVisHenleggModal(true);
-                            }}
-                        >
-                            <Normaltekst>Henlegg</Normaltekst>
-                        </Knapp>
-                    </li>
+                    {items.map((p) => (
+                        <li key={p.tekst}>
+                            <Knapp onClick={p.onClick}>
+                                <Normaltekst>{p.tekst}</Normaltekst>
+                            </Knapp>
+                        </li>
+                    ))}
                 </ul>
             </HamburgerMenyInnhold>
-        </div>
+        </HamburgerWrapper>
     );
 };

--- a/src/frontend/Felles/PersonHeader/PersonHeader.tsx
+++ b/src/frontend/Felles/PersonHeader/PersonHeader.tsx
@@ -16,7 +16,7 @@ import { ISøkPerson } from '../../App/typer/personsøk';
 import Lenke from 'nav-frontend-lenker';
 import { IPersonIdent } from '../../App/typer/felles';
 import Alertstripe from 'nav-frontend-alertstriper';
-import { Hamburgermeny } from './Hamburgermeny';
+import { PersonHeaderHamburgermeny } from './PersonHeaderHamburgermeny';
 import { erBehandlingRedigerbar } from '../../App/typer/behandlingstatus';
 import {
     behandlingstypeTilTekst,
@@ -77,7 +77,7 @@ export const PersonHeaderWrapper = styled(Sticky)`
     }
 `;
 
-const StyledHamburgermeny = styled(Hamburgermeny)`
+const StyledHamburgermeny = styled(PersonHeaderHamburgermeny)`
     margin-left: auto;
     display: block;
     position: sticky;

--- a/src/frontend/Felles/PersonHeader/PersonHeaderHamburgermeny.tsx
+++ b/src/frontend/Felles/PersonHeader/PersonHeaderHamburgermeny.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { useApp } from '../../App/context/AppContext';
+import { useBehandling } from '../../App/context/BehandlingContext';
+import { Hamburgermeny } from '../Hamburgermeny/Hamburgermeny';
+
+export const PersonHeaderHamburgermeny = () => {
+    const { settVisBrevmottakereModal } = useApp();
+    const { settVisHenleggModal } = useBehandling();
+
+    return (
+        <Hamburgermeny
+            items={[
+                {
+                    tekst: 'Sett Verge/Fullmakt mottakere',
+                    onClick: () => settVisBrevmottakereModal(true),
+                },
+                {
+                    tekst: 'Henlegg',
+                    onClick: () => settVisHenleggModal(true),
+                },
+            ]}
+        />
+    );
+};


### PR DESCRIPTION
Blir brukt i https://github.com/navikt/familie-ef-sak-frontend/pull/1644

La til mulighet for å kunne gjenbruke funksjonaliteten for hamburgaren. 
* Dette krever wrap med `position: aboslute`, hvis ikke havner menyn helt feil sted for behandlingsoversikten
I det så la jeg også til en annan ikone
* Denne måtte jeg ha til å være litt større, og då annen margin sånn at de ble relativt like
Hamburgere: 
<img width="241" alt="image" src="https://user-images.githubusercontent.com/937168/195370950-b4c24ba3-e5c5-4668-89c6-d47e6d53c8c2.png">
Ellipse:
<img width="292" alt="image" src="https://user-images.githubusercontent.com/937168/195371115-73ddc565-4677-4459-beb0-8c19337b2569.png">

https://user-images.githubusercontent.com/937168/195371462-49e0a464-3392-40ec-9b3d-cd4802da2d50.mov



<img width="203" alt="image" src="https://user-images.githubusercontent.com/937168/195370498-676d4f95-127e-42b4-84c8-305bf74b5750.png">
