### PR TITLE
Verge frittståendebrev utbedringer

### DIFF
--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -10,6 +10,5 @@ export enum ToggleName {
     opprettBehandlingForFerdigstiltJournalpost = 'familie.ef.sak.opprett-behandling-for-ferdigstilt-journalpost',
     visOpprettKlage = 'familie.ef.sak.frontend-vis-opprett-klage',
     visAutomatiskUtfylleVilkår = 'familie.ef.sak.frontend-automatisk-utfylle-vilkar',
-    visKnappVergeFrittståendeBrev = 'familie.ef.sak.frontend-verge-frittstaende-brev',
     visUtestengelse = 'familie.ef.sak.frontend-utestengelse',
 }

--- a/src/frontend/Komponenter/Behandling/Brev/FrittståendeBrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/FrittståendeBrev.tsx
@@ -35,7 +35,7 @@ import { ModalWrapper } from '../../../Felles/Modal/ModalWrapper';
 
 const StyledBrev = styled.div`
     margin-bottom: 10rem;
-    width: inherit;
+    width: 48rem;
 `;
 
 const StyledHovedKnapp = styled(Hovedknapp)`
@@ -48,12 +48,12 @@ const AlertStripe = styled(Alert)`
 
 const Grid = styled.div`
     display: grid;
-    grid-template-columns: 9rem 30rem 16rem;
+    grid-template-columns: 9rem 23rem 16rem;
 `;
 
 const InfoHeader = styled.div`
     display: grid;
-    grid-template-columns: 34rem 14rem;
+    grid-template-columns: 29rem 14rem;
 `;
 
 const SideTittel = styled(Heading)`

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/BrevmottakereModal.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/BrevmottakereModal.tsx
@@ -115,6 +115,9 @@ export const BrevmottakereModal: FC<{
         }
     }, [kallHentBrevmottakere, visBrevmottakereModal, initielleBrevmottakere]);
 
+    const harValgtMottakere =
+        valgtePersonMottakere.length > 0 || valgteOrganisasjonMottakere.length > 0;
+
     return (
         <ModalWrapper
             tittel={'Hvem skal motta brevet?'}
@@ -160,7 +163,7 @@ export const BrevmottakereModal: FC<{
                 <Button variant="tertiary" onClick={() => settVisBrevmottakereModal(false)}>
                     Avbryt
                 </Button>
-                <Button variant="primary" onClick={settBrevmottakere}>
+                <Button variant="primary" onClick={settBrevmottakere} disabled={!harValgtMottakere}>
                     Sett mottakere
                 </Button>
             </SentrerKnapper>


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-9950)

Utbedret modal for brevmottakere:
- Må velge minst en mottaker i modalen
- Litt endring på visning av mottakere og knapp for åpning av modal

en mottaker, smal skjerm:
![Skjermbilde 2022-10-13 kl  14 41 29](https://user-images.githubusercontent.com/32769446/195599371-806af610-fd77-4d2d-b124-baf626a9ed90.png)

en mottaker, bred skjerm:
![Skjermbilde 2022-10-13 kl  14 41 38](https://user-images.githubusercontent.com/32769446/195599483-421ad514-f45d-4cb5-af93-41a4ba274db0.png)

flere mottakere, small skjerm:
![Skjermbilde 2022-10-13 kl  14 41 58](https://user-images.githubusercontent.com/32769446/195599570-4de543ab-4a31-4498-af5c-efcea871edd7.png)

flere mottakere, bred skjerm:
![Skjermbilde 2022-10-13 kl  14 41 51](https://user-images.githubusercontent.com/32769446/195599691-982a6e5d-d84d-44b6-8939-336d9407975d.png)

