### PR TITLE
Fikset tekst for modal ved godkjent totrinnskontroll

### DIFF
--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/FatterVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/FatterVedtak.tsx
@@ -44,8 +44,8 @@ interface TotrinnskontrollForm {
 
 const FatterVedtak: React.FC<{
     behandlingId: string;
-    settVisModal: (vis: boolean) => void;
-}> = ({ behandlingId, settVisModal }) => {
+    settVisGodkjentModal: (vis: boolean) => void;
+}> = ({ behandlingId, settVisGodkjentModal }) => {
     const [godkjent, settGodkjent] = useState<boolean>();
     const [begrunnelse, settBegrunnelse] = useState<string>();
     const [feil, settFeil] = useState<string>();
@@ -74,7 +74,7 @@ const FatterVedtak: React.FC<{
                     if (godkjent) {
                         hentBehandlingshistorikk.rerun();
                         hentTotrinnskontroll.rerun();
-                        settVisModal(true);
+                        settVisGodkjentModal(true);
                     } else {
                         settToast(EToast.VEDTAK_UNDERKJENT);
                         gåTilUrl('/oppgavebenk');

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
@@ -36,21 +36,21 @@ export const BorderBox = styled.div`
 
 const Totrinnskontroll: FC = () => {
     const { gåTilUrl } = useApp();
-    const [visModal, settVisModal] = useState(false);
+    const [visGodkjentModal, settVisGodkjentModal] = useState(false);
 
     return (
         <>
-            <TotrinnskontrollSwitch settVisModal={settVisModal} />
+            <TotrinnskontrollSwitch settVisGodkjentModal={settVisGodkjentModal} />
             <ModalWrapper
-                tittel={'Vedtaket er sendt til beslutter'}
-                visModal={visModal}
-                onClose={() => settVisModal(false)}
+                tittel={'Vedtaket er godkjent'}
+                visModal={visGodkjentModal}
+                onClose={() => settVisGodkjentModal(false)}
                 aksjonsknapper={{
                     hovedKnapp: {
                         onClick: () => gåTilUrl('/oppgavebenk'),
                         tekst: 'Til oppgavebenk',
                     },
-                    lukkKnapp: { onClick: () => settVisModal(false), tekst: 'Lukk' },
+                    lukkKnapp: { onClick: () => settVisGodkjentModal(false), tekst: 'Lukk' },
                     marginTop: 4,
                 }}
             />
@@ -58,7 +58,9 @@ const Totrinnskontroll: FC = () => {
     );
 };
 
-const TotrinnskontrollSwitch: FC<{ settVisModal: (vis: boolean) => void }> = ({ settVisModal }) => {
+const TotrinnskontrollSwitch: FC<{ settVisGodkjentModal: (vis: boolean) => void }> = ({
+    settVisGodkjentModal,
+}) => {
     const { behandling, totrinnskontroll } = useBehandling();
 
     if (
@@ -70,7 +72,12 @@ const TotrinnskontrollSwitch: FC<{ settVisModal: (vis: boolean) => void }> = ({ 
 
     switch (totrinnskontroll.data.status) {
         case TotrinnskontrollStatus.KAN_FATTE_VEDTAK:
-            return <FatterVedtak behandlingId={behandling.data.id} settVisModal={settVisModal} />;
+            return (
+                <FatterVedtak
+                    behandlingId={behandling.data.id}
+                    settVisGodkjentModal={settVisGodkjentModal}
+                />
+            );
         case TotrinnskontrollStatus.IKKE_AUTORISERT:
             return <SendtTilBeslutter totrinnskontroll={totrinnskontroll.data.totrinnskontroll} />;
         case TotrinnskontrollStatus.TOTRINNSKONTROLL_UNDERKJENT:


### PR DESCRIPTION
Hadde blitt en liten typo-feil i omskrivning til nye modaler
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10058

endrede navn på `settVisModal` for å tydeliggjøre hvilken modal det gjelder :) 