### PR TITLE
Oppdaterer brevmottakere til nytt designsystem

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brevmottakere/BrevmottakereListe.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/BrevmottakereListe.tsx
@@ -1,10 +1,10 @@
 import React, { Dispatch, FC, SetStateAction } from 'react';
-import { Ingress, Normaltekst } from 'nav-frontend-typografi';
 import styled from 'styled-components';
 import SlettSøppelkasse from '../../../Felles/Ikoner/SlettSøppelkasse';
 import LenkeKnapp from '../../../Felles/Knapper/LenkeKnapp';
 import { IBrevmottaker, IOrganisasjonMottaker } from './typer';
 import { KopierbartNullableFødselsnummer } from '../../../Felles/Fødselsnummer/KopierbartNullableFødselsnummer';
+import { BodyShort, Ingress } from '@navikt/ds-react';
 
 interface Props {
     valgtePersonMottakere: IBrevmottaker[];
@@ -52,10 +52,10 @@ export const BrevmottakereListe: FC<Props> = ({
             {valgtePersonMottakere.map((mottaker, index) => (
                 <StyledMottakerBoks key={mottaker.navn + index}>
                     <Flexboks>
-                        <Normaltekst>
+                        <BodyShort>
                             {`${mottaker.navn} (${mottaker.mottakerRolle.toLowerCase()})`}
                             <KopierbartNullableFødselsnummer fødselsnummer={mottaker.personIdent} />
-                        </Normaltekst>
+                        </BodyShort>
                     </Flexboks>
                     <LenkeKnapp onClick={fjernPersonMottaker(mottaker.personIdent)}>
                         <SlettSøppelkasse withDefaultStroke={false} />
@@ -65,10 +65,10 @@ export const BrevmottakereListe: FC<Props> = ({
             {valgteOrganisasjonMottakere.map((mottaker, index) => (
                 <StyledMottakerBoks key={mottaker.navnHosOrganisasjon + index}>
                     <div>
-                        <Normaltekst>{`${mottaker.navnHosOrganisasjon}`}</Normaltekst>
-                        <Normaltekst>
+                        <BodyShort>{`${mottaker.navnHosOrganisasjon}`}</BodyShort>
+                        <BodyShort>
                             {`Organisasjonsnummer: ${mottaker.organisasjonsnummer}`}
-                        </Normaltekst>
+                        </BodyShort>
                     </div>
                     <LenkeKnapp onClick={fjernOrganisasjonMottaker(mottaker.organisasjonsnummer)}>
                         <SlettSøppelkasse withDefaultStroke={false} />

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/BrevmottakereListe.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/BrevmottakereListe.tsx
@@ -13,7 +13,7 @@ interface Props {
     settValgteOrganisasjonMottakere: Dispatch<SetStateAction<IOrganisasjonMottaker[]>>;
 }
 
-const StyledIngress = styled(Ingress)`
+const Undertittel = styled(Ingress)`
     margin-bottom: 1rem;
 `;
 
@@ -48,7 +48,7 @@ export const BrevmottakereListe: FC<Props> = ({
     };
     return (
         <>
-            <StyledIngress>Brevmottakere</StyledIngress>
+            <Undertittel>Brevmottakere</Undertittel>
             {valgtePersonMottakere.map((mottaker, index) => (
                 <StyledMottakerBoks key={mottaker.navn + index}>
                     <Flexboks>

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/SkalBrukerHaBrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/SkalBrukerHaBrev.tsx
@@ -1,11 +1,10 @@
 import React, { Dispatch, FC, SetStateAction } from 'react';
-import { Ingress } from 'nav-frontend-typografi';
-import { Radio, RadioGruppe } from 'nav-frontend-skjema';
 import { IPersonopplysninger } from '../../../App/typer/personopplysninger';
 import { EBrevmottakerRolle, IBrevmottaker } from './typer';
 import styled from 'styled-components';
+import { Ingress, Radio, RadioGroup } from '@navikt/ds-react';
 
-const StyledRadioGruppe = styled(RadioGruppe)`
+const StyledRadioGruppe = styled(RadioGroup)`
     display: flex;
 
     > div {
@@ -60,19 +59,23 @@ export const SkalBrukerHaBrev: FC<Props> = ({
     return (
         <>
             <StyledIngress>Skal bruker motta brevet?</StyledIngress>
-            <StyledRadioGruppe>
+            <StyledRadioGruppe legend={'Skal bruker motta brevet?'} hideLegend>
                 <Radio
-                    label={'Ja'}
+                    value={'Ja'}
                     name={'brukerHaBrevRadio'}
                     checked={brukerSkalHaBrev}
                     onChange={toggleBrukerSkalHaBrev}
-                />
+                >
+                    Ja
+                </Radio>
                 <Radio
-                    label={'Nei'}
+                    value={'Nei'}
                     name={'brukerHaBrevRadio'}
                     checked={!brukerSkalHaBrev}
                     onChange={toggleBrukerSkalHaBrev}
-                />
+                >
+                    Nei
+                </Radio>
             </StyledRadioGruppe>
         </>
     );

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/SkalBrukerHaBrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/SkalBrukerHaBrev.tsx
@@ -4,7 +4,7 @@ import { EBrevmottakerRolle, IBrevmottaker } from './typer';
 import styled from 'styled-components';
 import { Ingress, Radio, RadioGroup } from '@navikt/ds-react';
 
-const StyledRadioGruppe = styled(RadioGroup)`
+const RadioGruppe = styled(RadioGroup)`
     display: flex;
 
     > div {
@@ -12,7 +12,7 @@ const StyledRadioGruppe = styled(RadioGroup)`
     }
 `;
 
-const StyledIngress = styled(Ingress)`
+const Underoverskrift = styled(Ingress)`
     margin-bottom: 1rem;
 `;
 
@@ -58,8 +58,8 @@ export const SkalBrukerHaBrev: FC<Props> = ({
 
     return (
         <>
-            <StyledIngress>Skal bruker motta brevet?</StyledIngress>
-            <StyledRadioGruppe legend={'Skal bruker motta brevet?'} hideLegend>
+            <Underoverskrift>Skal bruker motta brevet?</Underoverskrift>
+            <RadioGruppe legend={'Skal bruker motta brevet?'} hideLegend>
                 <Radio
                     value={'Ja'}
                     name={'brukerHaBrevRadio'}
@@ -76,7 +76,7 @@ export const SkalBrukerHaBrev: FC<Props> = ({
                 >
                     Nei
                 </Radio>
-            </StyledRadioGruppe>
+            </RadioGruppe>
         </>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/SøkOrganisasjon.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/SøkOrganisasjon.tsx
@@ -1,12 +1,10 @@
 import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
-import { Input } from 'nav-frontend-skjema';
 import { useApp } from '../../../App/context/AppContext';
 import { byggTomRessurs, Ressurs } from '../../../App/typer/ressurs';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
-import { Element } from 'nav-frontend-typografi';
-import { Knapp } from 'nav-frontend-knapper';
 import { IOrganisasjonMottaker } from './typer';
 import { StyledSøkInput, StyledSøkResultat } from './brevmottakereStyling';
+import { BodyShort, Button, TextField } from '@navikt/ds-react';
 
 interface Props {
     valgteMottakere: IOrganisasjonMottaker[];
@@ -53,6 +51,7 @@ export const SøkOrganisasjon: React.FC<Props> = ({ settValgteMottakere }) => {
         <>
             <StyledSøkInput
                 label={'Organisasjonsnummer'}
+                htmlSize={26}
                 placeholder={'Søk'}
                 value={organisasjonsnummer}
                 onChange={(e) => settOrganisasjonsnummer(e.target.value)}
@@ -63,24 +62,25 @@ export const SøkOrganisasjon: React.FC<Props> = ({ settValgteMottakere }) => {
                         <>
                             <StyledSøkResultat>
                                 <div>
-                                    <Element>{organisasjonRessurs.navn}</Element>
+                                    <BodyShort>{organisasjonRessurs.navn}</BodyShort>
                                     {organisasjonRessurs.organisasjonsnummer}
                                 </div>
-                                <Knapp
+                                <Button
+                                    variant={'secondary'}
                                     onClick={leggTilOrganisasjon(
                                         organisasjonRessurs.organisasjonsnummer,
                                         organisasjonRessurs.navn
                                     )}
                                 >
                                     Legg til
-                                </Knapp>
-                                <Input
-                                    bredde={'M'}
+                                </Button>
+                                <TextField
+                                    htmlSize={25}
                                     label={'Ved'}
                                     placeholder={'Personen brevet skal til'}
                                     value={navnHosOrganisasjon}
                                     onChange={(e) => settNavnHosOrganisasjon(e.target.value)}
-                                    feil={feil}
+                                    error={feil}
                                 />
                             </StyledSøkResultat>
                         </>

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/SøkOrganisasjon.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/SøkOrganisasjon.tsx
@@ -3,7 +3,7 @@ import { useApp } from '../../../App/context/AppContext';
 import { byggTomRessurs, Ressurs } from '../../../App/typer/ressurs';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { IOrganisasjonMottaker } from './typer';
-import { StyledSøkInput, StyledSøkResultat } from './brevmottakereStyling';
+import { Søkefelt, Søkeresultat } from './brevmottakereStyling';
 import { BodyShort, Button, TextField } from '@navikt/ds-react';
 
 interface Props {
@@ -49,7 +49,7 @@ export const SøkOrganisasjon: React.FC<Props> = ({ settValgteMottakere }) => {
 
     return (
         <>
-            <StyledSøkInput
+            <Søkefelt
                 label={'Organisasjonsnummer'}
                 htmlSize={26}
                 placeholder={'Søk'}
@@ -60,7 +60,7 @@ export const SøkOrganisasjon: React.FC<Props> = ({ settValgteMottakere }) => {
                 {({ organisasjonRessurs }) => {
                     return (
                         <>
-                            <StyledSøkResultat>
+                            <Søkeresultat>
                                 <div>
                                     <BodyShort>{organisasjonRessurs.navn}</BodyShort>
                                     {organisasjonRessurs.organisasjonsnummer}
@@ -82,7 +82,7 @@ export const SøkOrganisasjon: React.FC<Props> = ({ settValgteMottakere }) => {
                                     onChange={(e) => settNavnHosOrganisasjon(e.target.value)}
                                     error={feil}
                                 />
-                            </StyledSøkResultat>
+                            </Søkeresultat>
                         </>
                     );
                 }}

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/SøkPerson.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/SøkPerson.tsx
@@ -3,8 +3,7 @@ import { useApp } from '../../../App/context/AppContext';
 import { byggTomRessurs, Ressurs } from '../../../App/typer/ressurs';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { EBrevmottakerRolle, IBrevmottaker } from './typer';
-import { Normaltekst } from 'nav-frontend-typografi';
-import { Button } from '@navikt/ds-react';
+import { BodyShort, Button } from '@navikt/ds-react';
 import { StyledSøkInput, StyledSøkResultat } from './brevmottakereStyling';
 import { VertikalSentrering } from '../../../App/utils/styling';
 
@@ -47,6 +46,7 @@ export const SøkPerson: React.FC<Props> = ({ settValgteMottakere }) => {
         <>
             <StyledSøkInput
                 label={'Personident'}
+                htmlSize={26}
                 placeholder={'Personen som skal ha brevet'}
                 value={søkIdent}
                 onChange={(e) => settSøkIdent(e.target.value)}
@@ -56,7 +56,7 @@ export const SøkPerson: React.FC<Props> = ({ settValgteMottakere }) => {
                     return (
                         <StyledSøkResultat>
                             <div>
-                                <Normaltekst>{søkRessurs.navn}</Normaltekst>
+                                <BodyShort>{søkRessurs.navn}</BodyShort>
                                 {søkRessurs.personIdent}
                             </div>
                             <VertikalSentrering>

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/SøkPerson.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/SøkPerson.tsx
@@ -4,7 +4,7 @@ import { byggTomRessurs, Ressurs } from '../../../App/typer/ressurs';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { EBrevmottakerRolle, IBrevmottaker } from './typer';
 import { BodyShort, Button } from '@navikt/ds-react';
-import { StyledSøkInput, StyledSøkResultat } from './brevmottakereStyling';
+import { Søkefelt, Søkeresultat } from './brevmottakereStyling';
 import { VertikalSentrering } from '../../../App/utils/styling';
 
 interface Props {
@@ -44,7 +44,7 @@ export const SøkPerson: React.FC<Props> = ({ settValgteMottakere }) => {
 
     return (
         <>
-            <StyledSøkInput
+            <Søkefelt
                 label={'Personident'}
                 htmlSize={26}
                 placeholder={'Personen som skal ha brevet'}
@@ -54,7 +54,7 @@ export const SøkPerson: React.FC<Props> = ({ settValgteMottakere }) => {
             <DataViewer response={{ søkRessurs }}>
                 {({ søkRessurs }) => {
                     return (
-                        <StyledSøkResultat>
+                        <Søkeresultat>
                             <div>
                                 <BodyShort>{søkRessurs.navn}</BodyShort>
                                 {søkRessurs.personIdent}
@@ -73,7 +73,7 @@ export const SøkPerson: React.FC<Props> = ({ settValgteMottakere }) => {
                                     </Button>
                                 </div>
                             </VertikalSentrering>
-                        </StyledSøkResultat>
+                        </Søkeresultat>
                     );
                 }}
             </DataViewer>

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/SøkWrapper.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/SøkWrapper.tsx
@@ -3,7 +3,7 @@ import { SøkPerson } from './SøkPerson';
 import { SøkOrganisasjon } from './SøkOrganisasjon';
 import { IBrevmottaker, IOrganisasjonMottaker } from './typer';
 import styled from 'styled-components';
-import { Select } from '@navikt/ds-react';
+import { Ingress, Select } from '@navikt/ds-react';
 
 interface Props {
     settValgtePersonMottakere: Dispatch<SetStateAction<IBrevmottaker[]>>;
@@ -15,6 +15,10 @@ enum ESøktype {
     ORGANISASJON = 'ORGANISASJON',
     PERSON = 'PERSON',
 }
+
+const Underoverskrift = styled(Ingress)`
+    margin-bottom: 1rem;
+`;
 
 const SøkTypeSelect = styled(Select)`
     width: 200px;
@@ -30,8 +34,10 @@ export const SøkWrapper: FC<Props> = ({
 
     return (
         <>
+            <Underoverskrift>Manuelt søk</Underoverskrift>
             <SøkTypeSelect
                 label={'Manuelt søk'}
+                hideLabel
                 value={søktype}
                 onChange={(e) => settSøktype(e.target.value as ESøktype)}
             >

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/SøkWrapper.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/SøkWrapper.tsx
@@ -1,10 +1,9 @@
 import React, { Dispatch, FC, SetStateAction, useState } from 'react';
-import { Ingress } from 'nav-frontend-typografi';
-import { Select } from 'nav-frontend-skjema';
 import { SøkPerson } from './SøkPerson';
 import { SøkOrganisasjon } from './SøkOrganisasjon';
 import { IBrevmottaker, IOrganisasjonMottaker } from './typer';
 import styled from 'styled-components';
+import { Select } from '@navikt/ds-react';
 
 interface Props {
     settValgtePersonMottakere: Dispatch<SetStateAction<IBrevmottaker[]>>;
@@ -16,10 +15,6 @@ enum ESøktype {
     ORGANISASJON = 'ORGANISASJON',
     PERSON = 'PERSON',
 }
-
-const StyledIngress = styled(Ingress)`
-    margin-bottom: 1rem;
-`;
 
 const SøkTypeSelect = styled(Select)`
     width: 200px;
@@ -35,8 +30,8 @@ export const SøkWrapper: FC<Props> = ({
 
     return (
         <>
-            <StyledIngress>Manuelt søk</StyledIngress>
             <SøkTypeSelect
+                label={'Manuelt søk'}
                 value={søktype}
                 onChange={(e) => settSøktype(e.target.value as ESøktype)}
             >

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/VergerOgFullmektigeFraRegister.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/VergerOgFullmektigeFraRegister.tsx
@@ -14,7 +14,7 @@ interface Props {
     fullmakter: IFullmakt[];
 }
 
-const StyledIngress = styled(Ingress)`
+const Undertittel = styled(Ingress)`
     margin-bottom: 1rem;
 `;
 
@@ -50,7 +50,7 @@ export const VergerOgFullmektigeFraRegister: FC<Props> = ({
 
     return (
         <>
-            <StyledIngress>Verge/Fullmektig fra register</StyledIngress>
+            <Undertittel>Verge/Fullmektig fra register</Undertittel>
             {muligeMottakere.length ? (
                 muligeMottakere.map((mottaker, index) => {
                     const mottakerValgt = !!valgteMottakere.find(

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/VergerOgFullmektigeFraRegister.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/VergerOgFullmektigeFraRegister.tsx
@@ -1,11 +1,10 @@
 import React, { Dispatch, FC, SetStateAction } from 'react';
-import { Ingress, Normaltekst } from 'nav-frontend-typografi';
 import { IFullmakt, IVergemål } from '../../../App/typer/personopplysninger';
 import { IBrevmottaker } from './typer';
 import { fullmaktTilBrevMottaker, vergemålTilBrevmottaker } from './brevmottakerUtils';
 import styled from 'styled-components';
 import { KopierbartNullableFødselsnummer } from '../../../Felles/Fødselsnummer/KopierbartNullableFødselsnummer';
-import { Button } from '@navikt/ds-react';
+import { Ingress, Button, BodyShort } from '@navikt/ds-react';
 import { VertikalSentrering } from '../../../App/utils/styling';
 
 interface Props {
@@ -82,7 +81,7 @@ export const VergerOgFullmektigeFraRegister: FC<Props> = ({
                     );
                 })
             ) : (
-                <Normaltekst>Ingen verge/fullmektig i register</Normaltekst>
+                <BodyShort>Ingen verge/fullmektig i register</BodyShort>
             )}
         </>
     );

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/brevmottakereStyling.ts
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/brevmottakereStyling.ts
@@ -1,12 +1,12 @@
 import { TextField } from '@navikt/ds-react';
 import styled from 'styled-components';
 
-export const StyledSøkInput = styled(TextField)`
+export const Søkefelt = styled(TextField)`
     width: 50%;
     padding-right: 1rem;
 `;
 
-export const StyledSøkResultat = styled.div`
+export const Søkeresultat = styled.div`
     margin-top: 2rem;
     margin-bottom: 10rem;
     display: grid;

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/brevmottakereStyling.ts
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/brevmottakereStyling.ts
@@ -1,7 +1,7 @@
+import { TextField } from '@navikt/ds-react';
 import styled from 'styled-components';
-import { Input } from 'nav-frontend-skjema';
 
-export const StyledSøkInput = styled(Input)`
+export const StyledSøkInput = styled(TextField)`
     width: 50%;
     padding-right: 1rem;
 `;
@@ -10,7 +10,7 @@ export const StyledSøkResultat = styled.div`
     margin-top: 2rem;
     margin-bottom: 10rem;
     display: grid;
-    grid-template-columns: 5fr 1fr;
+    grid-template-columns: 5fr 2fr;
     padding: 10px;
     margin-bottom: 4px;
     background: rgba(196, 196, 196, 0.2);


### PR DESCRIPTION
Tar å oppdaterer denne før vi kopierer over den til klage

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-9972

Den største forskjellen er at ingress fra "Manuellt søk" er slettet, då input nå har labels, skal sjekke med Lars om det før jeg merger denne, då ingressen er for selve avsnittet og kanskje ikke direkt den boksen

Før:

Etter:
![image](https://user-images.githubusercontent.com/937168/198216462-e24e2af7-78e0-4794-acc8-62d1559fe912.png)

