### PR TITLE
Splitter opp journalføring for å få enklere komponenter som går å gje…

### DIFF
--- a/src/frontend/App/hooks/useHentDokument.ts
+++ b/src/frontend/App/hooks/useHentDokument.ts
@@ -1,17 +1,17 @@
 import { useApp } from '../context/AppContext';
 import { useCallback, useState } from 'react';
 import { byggHenterRessurs, byggTomRessurs, Ressurs } from '../typer/ressurs';
-import { OrNothing } from './felles/useSorteringState';
 import { IJournalpost } from '../typer/journalføring';
 
-interface HentDokumentResponse {
+export interface HentDokumentResponse {
     hentDokument: (dokumentinfoId: string) => void;
     valgtDokument: Ressurs<string>;
-    hentFørsteDokument: (journalpost: IJournalpost) => void;
-    hentNesteDokument: (journalpost: IJournalpost) => void;
-    hentForrigeDokument: (journalpost: IJournalpost) => void;
+    hentFørsteDokument: () => void;
+    hentNesteDokument: () => void;
+    hentForrigeDokument: () => void;
 }
-export const useHentDokument = (journalpostIdParam: OrNothing<string>): HentDokumentResponse => {
+
+export const useHentDokument = (journalpost: IJournalpost): HentDokumentResponse => {
     const { axiosRequest } = useApp();
     const [valgtDokument, settValgtDokument] = useState<Ressurs<string>>(byggTomRessurs());
     const [valgtDokumentInfoId, settDokumentInfoId] = useState<string | undefined>();
@@ -21,61 +21,43 @@ export const useHentDokument = (journalpostIdParam: OrNothing<string>): HentDoku
             settValgtDokument(byggHenterRessurs());
             axiosRequest<string, null>({
                 method: 'GET',
-                url: `/familie-ef-sak/api/journalpost/${journalpostIdParam}/dokument/${dokumentInfoId}`,
+                url: `/familie-ef-sak/api/journalpost/${journalpost.journalpostId}/dokument/${dokumentInfoId}`,
             }).then((res: Ressurs<string>) => settValgtDokument(res));
         },
-        // eslint-disable-next-line
-        [journalpostIdParam]
-    );
-
-    const hentFørsteDokument = useCallback(
-        (journalpost: IJournalpost) => {
-            hentDokumentForIndex(journalpost, 0);
-        },
-        // eslint-disable-next-line
-        [journalpostIdParam]
+        [axiosRequest, journalpost.journalpostId]
     );
 
     const hentDokumentForIndex = useCallback(
-        (journalpost: IJournalpost, index: number) => {
+        (index: number) => {
             if (journalpost.dokumenter && journalpost.dokumenter.length > index) {
                 hentDokument(journalpost.dokumenter[index].dokumentInfoId);
             }
         },
-        // eslint-disable-next-line
-        [journalpostIdParam]
+        [hentDokument, journalpost]
     );
 
-    const indeksForValgtDokument = useCallback(
-        (journalpost: IJournalpost) => {
-            return journalpost.dokumenter.findIndex(
-                (dok) => dok.dokumentInfoId === valgtDokumentInfoId
-            );
-        },
-        // eslint-disable-next-line
-        [valgtDokumentInfoId]
-    );
+    const hentFørsteDokument = useCallback(() => {
+        hentDokumentForIndex(0);
+    }, [hentDokumentForIndex]);
 
-    const hentNesteDokument = useCallback(
-        (journalpost: IJournalpost) => {
-            const nesteEllerFørsteIndeks =
-                (indeksForValgtDokument(journalpost) + 1) % journalpost.dokumenter.length;
-            hentDokumentForIndex(journalpost, nesteEllerFørsteIndeks);
-        },
-        // eslint-disable-next-line
-        [journalpostIdParam, valgtDokumentInfoId]
-    );
+    const indeksForValgtDokument = useCallback(() => {
+        return journalpost.dokumenter.findIndex(
+            (dok) => dok.dokumentInfoId === valgtDokumentInfoId
+        );
+    }, [journalpost, valgtDokumentInfoId]);
 
-    const hentForrigeDokument = useCallback(
-        (journalpost: IJournalpost) => {
-            const forrigeEllerSisteIndeks =
-                (indeksForValgtDokument(journalpost) - 1 + journalpost.dokumenter.length) %
-                journalpost.dokumenter.length;
-            hentDokumentForIndex(journalpost, forrigeEllerSisteIndeks);
-        },
-        // eslint-disable-next-line
-        [journalpostIdParam, valgtDokumentInfoId]
-    );
+    const hentNesteDokument = useCallback(() => {
+        const nesteEllerFørsteIndeks =
+            (indeksForValgtDokument() + 1) % journalpost.dokumenter.length;
+        hentDokumentForIndex(nesteEllerFørsteIndeks);
+    }, [hentDokumentForIndex, indeksForValgtDokument, journalpost]);
+
+    const hentForrigeDokument = useCallback(() => {
+        const forrigeEllerSisteIndeks =
+            (indeksForValgtDokument() - 1 + journalpost.dokumenter.length) %
+            journalpost.dokumenter.length;
+        hentDokumentForIndex(forrigeEllerSisteIndeks);
+    }, [hentDokumentForIndex, indeksForValgtDokument, journalpost]);
 
     return {
         hentDokument,

--- a/src/frontend/App/hooks/useJournalføringState.ts
+++ b/src/frontend/App/hooks/useJournalføringState.ts
@@ -36,11 +36,7 @@ export interface JournalføringStateRequest {
     settDokumentTitler: Dispatch<SetStateAction<Record<string, string> | undefined>>;
     innsending: Ressurs<string>;
     settInnsending: Dispatch<SetStateAction<Ressurs<string>>>;
-    fullførJournalføring: (
-        journalpostId: string,
-        journalførendeEnhet: string,
-        navIdent?: string
-    ) => void;
+    fullførJournalføring: (journalførendeEnhet: string, navIdent?: string) => void;
     visBekreftelsesModal: boolean;
     settVisBekreftelsesModal: Dispatch<SetStateAction<boolean>>;
     visJournalføringIkkeMuligModal: boolean;

--- a/src/frontend/App/hooks/useJournalføringState.ts
+++ b/src/frontend/App/hooks/useJournalføringState.ts
@@ -28,16 +28,12 @@ export interface BarnSomSkalFødes {
 }
 
 export interface JournalføringStateRequest {
-    oppgaveId: string;
-    settOppgaveId: Dispatch<SetStateAction<string>>;
     fagsakId: string;
     settFagsakId: Dispatch<SetStateAction<string>>;
     behandling?: BehandlingRequest;
     settBehandling: Dispatch<SetStateAction<BehandlingRequest | undefined>>;
     dokumentTitler?: Record<string, string>;
     settDokumentTitler: Dispatch<SetStateAction<Record<string, string> | undefined>>;
-    forsøktJournalført: boolean;
-    settForsøktJournalført: Dispatch<SetStateAction<boolean>>;
     innsending: Ressurs<string>;
     settInnsending: Dispatch<SetStateAction<Ressurs<string>>>;
     fullførJournalføring: (
@@ -57,13 +53,14 @@ export interface JournalføringStateRequest {
     settVilkårsbehandleNyeBarn: Dispatch<SetStateAction<EVilkårsbehandleBarnValg>>;
 }
 
-export const useJournalføringState = (): JournalføringStateRequest => {
+export const useJournalføringState = (
+    oppgaveId: string,
+    journalpostId: string
+): JournalføringStateRequest => {
     const { axiosRequest } = useApp();
-    const [oppgaveId, settOppgaveId] = useState<string>('');
     const [fagsakId, settFagsakId] = useState<string>('');
     const [behandling, settBehandling] = useState<BehandlingRequest>();
     const [dokumentTitler, settDokumentTitler] = useState<Record<string, string>>();
-    const [forsøktJournalført, settForsøktJournalført] = useState<boolean>(false);
     const [innsending, settInnsending] = useState<Ressurs<string>>(byggTomRessurs());
     const [visBekreftelsesModal, settVisBekreftelsesModal] = useState<boolean>(false);
     const [visJournalføringIkkeMuligModal, settJournalføringIkkeMuligModal] =
@@ -79,12 +76,7 @@ export const useJournalføringState = (): JournalføringStateRequest => {
         settBehandling(undefined);
     }, [fagsakId]);
 
-    const fullførJournalføring = (
-        journalpostId: string,
-        journalførendeEnhet: string,
-        navIdent?: string
-    ) => {
-        settForsøktJournalført(true);
+    const fullførJournalføring = (journalførendeEnhet: string, navIdent?: string) => {
         if (!behandling || innsending.status === RessursStatus.HENTER) {
             return;
         }
@@ -113,16 +105,12 @@ export const useJournalføringState = (): JournalføringStateRequest => {
     };
 
     return {
-        oppgaveId,
-        settOppgaveId,
         fagsakId,
         settFagsakId,
         behandling,
         settBehandling,
         dokumentTitler,
         settDokumentTitler,
-        forsøktJournalført,
-        settForsøktJournalført,
         innsending,
         settInnsending,
         fullførJournalføring,

--- a/src/frontend/Komponenter/Journalføring/JournalføringApp.tsx
+++ b/src/frontend/Komponenter/Journalføring/JournalføringApp.tsx
@@ -316,7 +316,6 @@ const JournalføringAppContent: React.FC<JournalføringAppProps> = ({
             </Kolonner>
             <BekreftJournalføringModal
                 journalpostState={journalpostState}
-                journalpostId={journalpostId}
                 innloggetSaksbehandler={innloggetSaksbehandler}
             />
             <JournalføringIkkeMuligModal
@@ -363,9 +362,8 @@ const JournalføringIkkeMuligModal: React.FC<{
 
 const BekreftJournalføringModal: React.FC<{
     journalpostState: JournalføringStateRequest;
-    journalpostId: string;
     innloggetSaksbehandler: ISaksbehandler;
-}> = ({ journalpostState, journalpostId, innloggetSaksbehandler }) => {
+}> = ({ journalpostState, innloggetSaksbehandler }) => {
     return (
         <ModalWrapper
             tittel={''}
@@ -376,7 +374,6 @@ const BekreftJournalføringModal: React.FC<{
                     onClick: () => {
                         journalpostState.settVisBekreftelsesModal(false);
                         journalpostState.fullførJournalføring(
-                            journalpostId,
                             innloggetSaksbehandler?.enhet || '9999',
                             innloggetSaksbehandler?.navIdent
                         );

--- a/src/frontend/Komponenter/Journalføring/JournalføringApp.tsx
+++ b/src/frontend/Komponenter/Journalføring/JournalføringApp.tsx
@@ -1,21 +1,17 @@
 import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
-import { Link, Navigate, useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { RessursStatus } from '../../App/typer/ressurs';
 import styled from 'styled-components';
-import PdfVisning from '../../Felles/Pdf/PdfVisning';
 import Brukerinfo from './Brukerinfo';
 import { Sidetittel } from 'nav-frontend-typografi';
 import DokumentVisning from './Dokumentvisning';
 import { behandlingstemaTilTekst } from '../../App/typer/behandlingstema';
-import { Hovedknapp, Knapp } from 'nav-frontend-knapper';
-import { useQueryParams } from '../../App/hooks/felles/useQueryParams';
-import DataViewer from '../../Felles/DataViewer/DataViewer';
+import { Hovedknapp } from 'nav-frontend-knapper';
 import { SkjemaGruppe } from 'nav-frontend-skjema';
 import {
     JournalføringStateRequest,
     useJournalføringState,
 } from '../../App/hooks/useJournalføringState';
-import { useHentJournalpost } from '../../App/hooks/useHentJournalpost';
 import { useHentDokument } from '../../App/hooks/useHentDokument';
 import { useHentFagsak } from '../../App/hooks/useHentFagsak';
 import { useApp } from '../../App/context/AppContext';
@@ -41,20 +37,16 @@ import { Behandlingstype } from '../../App/typer/behandlingstype';
 import { erGyldigDato } from '../../App/utils/dato';
 import { ModalWrapper } from '../../Felles/Modal/ModalWrapper';
 import { AlertError } from '../../Felles/Visningskomponenter/Alerts';
-
-const SideLayout = styled.div`
-    max-width: 1600px;
-    margin: 0 auto;
-    padding: 2rem;
-`;
-
-const Kolonner = styled.div`
-    margin-top: 2rem;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    flex-wrap: wrap;
-`;
+import { harTittelForAlleDokumenter } from './journalføringUtil';
+import JournalføringWrapper, {
+    FlexKnapper,
+    Høyrekolonne,
+    JournalføringAppProps,
+    Kolonner,
+    SideLayout,
+    Venstrekolonne,
+} from './JournalføringWrapper';
+import JournalføringPdfVisning from './JournalføringPdfVisning';
 
 const ModalKnapp = styled(Button)`
     margin-bottom: 1rem;
@@ -64,31 +56,6 @@ const ModalKnapp = styled(Button)`
 const ModalTekst = styled(BodyLong)`
     margin-top: 2rem;
 `;
-
-const Venstrekolonne = styled.div`
-    max-width: 900px;
-`;
-const Høyrekolonne = styled.div``;
-const FlexKnapper = styled.div`
-    display: flex;
-    justify-content: space-between;
-`;
-
-const JOURNALPOST_QUERY_STRING = 'journalpostId';
-const OPPGAVEID_QUERY_STRING = 'oppgaveId';
-
-const harTittelForAlleDokumenter = (
-    journalResponse: IJojurnalpostResponse,
-    journalpostState: JournalføringStateRequest
-) =>
-    journalResponse.journalpost.dokumenter
-        .map(
-            (d) =>
-                d.tittel ||
-                (journalpostState.dokumentTitler &&
-                    journalpostState.dokumentTitler[d.dokumentInfoId])
-        )
-        .every((tittel) => tittel && tittel.trim());
 
 const erUstrukturertSøknadOgManglerDokumentasjonsType = (
     journalResponse: IJojurnalpostResponse,
@@ -125,7 +92,12 @@ const validerJournalføringState = (
     journalpostState: JournalføringStateRequest,
     erAlleBehandlingerFerdigstilte: boolean
 ): string | undefined => {
-    if (!erAlleBehandlingerFerdigstilte && harValgtNyBehandling(journalpostState.behandling)) {
+    if (!journalpostState.behandling) {
+        return 'Du må velge en behandling for å journalføre';
+    } else if (
+        !erAlleBehandlingerFerdigstilte &&
+        harValgtNyBehandling(journalpostState.behandling)
+    ) {
         return 'Kan ikke journalføre på ny behandling når det finnes en behandling som ikke er ferdigstilt';
     } else if (
         erUstrukturertSøknadOgManglerDokumentasjonsType(
@@ -150,37 +122,26 @@ const validerJournalføringState = (
 };
 
 export const JournalføringApp: React.FC = () => {
+    return <JournalføringWrapper komponent={JournalføringAppContent} />;
+};
+
+const JournalføringAppContent: React.FC<JournalføringAppProps> = ({
+    oppgaveId,
+    journalResponse,
+}) => {
     const { innloggetSaksbehandler } = useApp();
     const navigate = useNavigate();
-    const query: URLSearchParams = useQueryParams();
-    const oppgaveIdParam = query.get(OPPGAVEID_QUERY_STRING);
-    const journalpostIdParam = query.get(JOURNALPOST_QUERY_STRING);
 
-    const journalpostState: JournalføringStateRequest = useJournalføringState();
-    const { hentJournalPost, journalResponse } = useHentJournalpost(journalpostIdParam);
-    const {
-        hentDokument,
-        valgtDokument,
-        hentFørsteDokument,
-        hentNesteDokument,
-        hentForrigeDokument,
-    } = useHentDokument(journalpostIdParam);
+    const journalpostId = journalResponse.journalpost.journalpostId;
+
+    const journalpostState: JournalføringStateRequest = useJournalføringState(
+        oppgaveId,
+        journalpostId
+    );
+    const hentDokumentResponse = useHentDokument(journalResponse.journalpost);
+
     const { hentFagsak, fagsak } = useHentFagsak();
     const [feilmelding, settFeilMeldning] = useState('');
-
-    useEffect(() => {
-        if (journalpostState.forsøktJournalført && !journalpostState.behandling) {
-            settFeilMeldning('Du må velge en behandling for å journalføre');
-        }
-    }, [journalpostState]);
-
-    useEffect(() => {
-        if (oppgaveIdParam && journalpostIdParam) {
-            hentJournalPost();
-            journalpostState.settOppgaveId(oppgaveIdParam);
-        }
-        // eslint-disable-next-line
-    }, [oppgaveIdParam, journalpostIdParam]);
 
     useEffect(() => {
         if (journalpostState.innsending.status === RessursStatus.SUKSESS) {
@@ -191,22 +152,11 @@ export const JournalføringApp: React.FC = () => {
 
             lagreTilLocalStorage(oppgaveRequestKey(innloggetSaksbehandler.navIdent), {
                 ...lagredeOppgaveFiltreringer,
-                ident:
-                    journalResponse.status === RessursStatus.SUKSESS
-                        ? journalResponse.data.personIdent
-                        : undefined,
+                ident: journalResponse.personIdent,
             });
             navigate('/oppgavebenk');
         }
-        // eslint-disable-next-line
-    }, [journalpostState.innsending]);
-
-    useEffect(() => {
-        if (journalResponse.status === RessursStatus.SUKSESS) {
-            hentFørsteDokument(journalResponse.data.journalpost);
-        }
-        // eslint-disable-next-line
-    }, [journalResponse]);
+    }, [innloggetSaksbehandler, journalResponse, journalpostState, navigate]);
 
     useEffect(() => {
         if (fagsak.status === RessursStatus.SUKSESS) {
@@ -214,14 +164,6 @@ export const JournalføringApp: React.FC = () => {
         }
         // eslint-disable-next-line
     }, [fagsak]);
-
-    useEffect(() => {
-        document.title = 'Journalpost';
-    }, []);
-
-    if (!oppgaveIdParam || !journalpostIdParam) {
-        return <Navigate to="/oppgavebenk" />;
-    }
 
     const skalBeOmBekreftelse = (
         erNyBehandling: boolean,
@@ -245,9 +187,7 @@ export const JournalføringApp: React.FC = () => {
             journalpostState.behandling &&
             journalpostState.behandling.behandlingstype &&
             !journalpostState.behandling.behandlingsId;
-        const harIkkeStrukturertSøknad =
-            journalResponse.status === RessursStatus.SUKSESS &&
-            !journalResponse.data.harStrukturertSøknad;
+        const harIkkeStrukturertSøknad = !journalResponse.harStrukturertSøknad;
         return (
             erNyBehandling &&
             harIkkeStrukturertSøknad &&
@@ -261,173 +201,130 @@ export const JournalføringApp: React.FC = () => {
             UstrukturertDokumentasjonType.ETTERSENDING &&
         harValgtNyBehandling(journalpostState.behandling);
 
+    const erPapirsøknad =
+        journalpostState.ustrukturertDokumentasjonType ===
+        UstrukturertDokumentasjonType.PAPIRSØKNAD;
     return (
-        <DataViewer response={{ journalResponse }}>
-            {({ journalResponse }) => {
-                const erPapirsøknad =
-                    journalpostState.ustrukturertDokumentasjonType ===
-                    UstrukturertDokumentasjonType.PAPIRSØKNAD;
-                return (
-                    <SideLayout className={'container'}>
-                        <Sidetittel>{`Registrere journalpost${
-                            journalResponse.journalpost.behandlingstema
-                                ? ': ' +
-                                  behandlingstemaTilTekst[
-                                      journalResponse.journalpost.behandlingstema
-                                  ]
-                                : ''
-                        }`}</Sidetittel>
-                        <Kolonner>
-                            <Venstrekolonne>
-                                {!journalResponse.harStrukturertSøknad ? (
-                                    <>
-                                        <VelgFagsakForIkkeSøknad
-                                            journalResponse={journalResponse}
-                                            hentFagsak={hentFagsak}
-                                        />
-                                        <VelgUstrukturertDokumentasjonType
-                                            oppgaveId={oppgaveIdParam}
-                                            ustrukturertDokumentasjonType={
-                                                journalpostState.ustrukturertDokumentasjonType
-                                            }
-                                            settUstrukturertDokumentasjonType={
-                                                journalpostState.settUstrukturertDokumentasjonType
-                                            }
-                                        />
-                                    </>
-                                ) : (
-                                    <UtledEllerVelgFagsak
-                                        journalResponse={journalResponse}
-                                        hentFagsak={hentFagsak}
-                                    />
-                                )}
-                                <Brukerinfo
-                                    navn={journalResponse.navn}
-                                    personIdent={journalResponse.personIdent}
-                                />
-                                <DokumentVisning
-                                    journalPost={journalResponse.journalpost}
-                                    hentDokument={hentDokument}
-                                    dokumentTitler={journalpostState.dokumentTitler}
-                                    settDokumentTitler={journalpostState.settDokumentTitler}
-                                    erPapirsøknad={erPapirsøknad}
-                                />
-                                <SkjemaGruppe feil={feilmelding}>
-                                    <BehandlingInnold
-                                        settBehandling={journalpostState.settBehandling}
-                                        behandling={journalpostState.behandling}
-                                        fagsak={fagsak}
-                                        settFeilmelding={settFeilMeldning}
-                                    />
-                                    {kanLeggeTilBarnSomSkalFødes() && (
-                                        <LeggTilBarnSomSkalFødes
-                                            barnSomSkalFødes={journalpostState.barnSomSkalFødes}
-                                            oppdaterBarnSomSkalFødes={
-                                                journalpostState.settBarnSomSkalFødes
-                                            }
-                                        />
-                                    )}
-                                    {skalVelgeVilkårsbehandleNyeBarn &&
-                                        fagsak.status === RessursStatus.SUKSESS && (
-                                            <EttersendingMedNyeBarn
-                                                fagsak={fagsak.data}
-                                                vilkårsbehandleNyeBarn={
-                                                    journalpostState.vilkårsbehandleNyeBarn
-                                                }
-                                                settVilkårsbehandleNyeBarn={
-                                                    journalpostState.settVilkårsbehandleNyeBarn
-                                                }
-                                            />
-                                        )}
-                                </SkjemaGruppe>
-                                {(journalpostState.innsending.status === RessursStatus.FEILET ||
-                                    journalpostState.innsending.status ===
-                                        RessursStatus.FUNKSJONELL_FEIL) && (
-                                    <AlertError>
-                                        {journalpostState.innsending.frontendFeilmelding}
-                                    </AlertError>
-                                )}
-                                <FlexKnapper>
-                                    <Link to="/oppgavebenk">Tilbake til oppgavebenk</Link>
-                                    <Hovedknapp
-                                        onClick={() => {
-                                            const feilmeldingFraValidering =
-                                                validerJournalføringState(
-                                                    journalResponse,
-                                                    journalpostState,
-                                                    erAlleBehandlingerFerdigstilte(fagsak)
-                                                );
-                                            if (feilmeldingFraValidering) {
-                                                settFeilMeldning(feilmeldingFraValidering);
-                                            } else if (
-                                                skalBeOmBekreftelse(
-                                                    harValgtNyBehandling(
-                                                        journalpostState.behandling
-                                                    ),
-                                                    journalResponse.harStrukturertSøknad,
-                                                    journalpostState.ustrukturertDokumentasjonType
-                                                )
-                                            ) {
-                                                if (journalResponse.harStrukturertSøknad) {
-                                                    journalpostState.settVisBekreftelsesModal(true);
-                                                } else if (!journalResponse.harStrukturertSøknad) {
-                                                    journalpostState.settJournalføringIkkeMuligModal(
-                                                        true
-                                                    );
-                                                }
-                                            } else {
-                                                journalpostState.fullførJournalføring(
-                                                    journalpostIdParam,
-                                                    innloggetSaksbehandler?.enhet || '9999',
-                                                    innloggetSaksbehandler?.navIdent
-                                                );
-                                            }
-                                        }}
-                                        spinner={
-                                            journalpostState.innsending.status ===
-                                            RessursStatus.HENTER
-                                        }
-                                    >
-                                        Journalfør
-                                    </Hovedknapp>
-                                </FlexKnapper>
-                            </Venstrekolonne>
-                            <Høyrekolonne>
-                                <FlexKnapper>
-                                    <Knapp
-                                        onClick={() =>
-                                            hentForrigeDokument(journalResponse.journalpost)
-                                        }
-                                        mini
-                                    >
-                                        Forrige Dokument
-                                    </Knapp>
-                                    <Knapp
-                                        onClick={() =>
-                                            hentNesteDokument(journalResponse.journalpost)
-                                        }
-                                        mini
-                                    >
-                                        Neste Dokument
-                                    </Knapp>
-                                </FlexKnapper>
-                                <PdfVisning pdfFilInnhold={valgtDokument} />
-                            </Høyrekolonne>
-                        </Kolonner>
-                        <BekreftJournalføringModal
-                            journalpostState={journalpostState}
-                            journalpostId={journalpostIdParam}
-                            innloggetSaksbehandler={innloggetSaksbehandler}
+        <SideLayout className={'container'}>
+            <Sidetittel>{`Registrere journalpost${
+                journalResponse.journalpost.behandlingstema
+                    ? ': ' + behandlingstemaTilTekst[journalResponse.journalpost.behandlingstema]
+                    : ''
+            }`}</Sidetittel>
+            <Kolonner>
+                <Venstrekolonne>
+                    {!journalResponse.harStrukturertSøknad ? (
+                        <>
+                            <VelgFagsakForIkkeSøknad
+                                journalResponse={journalResponse}
+                                hentFagsak={hentFagsak}
+                            />
+                            <VelgUstrukturertDokumentasjonType
+                                oppgaveId={oppgaveId}
+                                ustrukturertDokumentasjonType={
+                                    journalpostState.ustrukturertDokumentasjonType
+                                }
+                                settUstrukturertDokumentasjonType={
+                                    journalpostState.settUstrukturertDokumentasjonType
+                                }
+                            />
+                        </>
+                    ) : (
+                        <UtledEllerVelgFagsak
+                            journalResponse={journalResponse}
+                            hentFagsak={hentFagsak}
                         />
-                        <JournalføringIkkeMuligModal
-                            visModal={journalpostState.visJournalføringIkkeMuligModal}
-                            settVisModal={journalpostState.settJournalføringIkkeMuligModal}
-                            erPapirSøknad={erPapirsøknad}
+                    )}
+                    <Brukerinfo
+                        navn={journalResponse.navn}
+                        personIdent={journalResponse.personIdent}
+                    />
+                    <DokumentVisning
+                        journalPost={journalResponse.journalpost}
+                        hentDokument={hentDokumentResponse.hentDokument}
+                        dokumentTitler={journalpostState.dokumentTitler}
+                        settDokumentTitler={journalpostState.settDokumentTitler}
+                        erPapirsøknad={erPapirsøknad}
+                    />
+                    <SkjemaGruppe feil={feilmelding}>
+                        <BehandlingInnold
+                            settBehandling={journalpostState.settBehandling}
+                            behandling={journalpostState.behandling}
+                            fagsak={fagsak}
+                            settFeilmelding={settFeilMeldning}
                         />
-                    </SideLayout>
-                );
-            }}
-        </DataViewer>
+                        {kanLeggeTilBarnSomSkalFødes() && (
+                            <LeggTilBarnSomSkalFødes
+                                barnSomSkalFødes={journalpostState.barnSomSkalFødes}
+                                oppdaterBarnSomSkalFødes={journalpostState.settBarnSomSkalFødes}
+                            />
+                        )}
+                        {skalVelgeVilkårsbehandleNyeBarn &&
+                            fagsak.status === RessursStatus.SUKSESS && (
+                                <EttersendingMedNyeBarn
+                                    fagsak={fagsak.data}
+                                    vilkårsbehandleNyeBarn={journalpostState.vilkårsbehandleNyeBarn}
+                                    settVilkårsbehandleNyeBarn={
+                                        journalpostState.settVilkårsbehandleNyeBarn
+                                    }
+                                />
+                            )}
+                    </SkjemaGruppe>
+                    {(journalpostState.innsending.status === RessursStatus.FEILET ||
+                        journalpostState.innsending.status === RessursStatus.FUNKSJONELL_FEIL) && (
+                        <AlertError>{journalpostState.innsending.frontendFeilmelding}</AlertError>
+                    )}
+                    <FlexKnapper>
+                        <Link to="/oppgavebenk">Tilbake til oppgavebenk</Link>
+                        <Hovedknapp
+                            onClick={() => {
+                                const feilmeldingFraValidering = validerJournalføringState(
+                                    journalResponse,
+                                    journalpostState,
+                                    erAlleBehandlingerFerdigstilte(fagsak)
+                                );
+                                if (feilmeldingFraValidering) {
+                                    settFeilMeldning(feilmeldingFraValidering);
+                                } else if (
+                                    skalBeOmBekreftelse(
+                                        harValgtNyBehandling(journalpostState.behandling),
+                                        journalResponse.harStrukturertSøknad,
+                                        journalpostState.ustrukturertDokumentasjonType
+                                    )
+                                ) {
+                                    if (journalResponse.harStrukturertSøknad) {
+                                        journalpostState.settVisBekreftelsesModal(true);
+                                    } else if (!journalResponse.harStrukturertSøknad) {
+                                        journalpostState.settJournalføringIkkeMuligModal(true);
+                                    }
+                                } else {
+                                    journalpostState.fullførJournalføring(
+                                        innloggetSaksbehandler?.enhet || '9999',
+                                        innloggetSaksbehandler?.navIdent
+                                    );
+                                }
+                            }}
+                            spinner={journalpostState.innsending.status === RessursStatus.HENTER}
+                        >
+                            Journalfør
+                        </Hovedknapp>
+                    </FlexKnapper>
+                </Venstrekolonne>
+                <Høyrekolonne>
+                    <JournalføringPdfVisning hentDokumentResponse={hentDokumentResponse} />
+                </Høyrekolonne>
+            </Kolonner>
+            <BekreftJournalføringModal
+                journalpostState={journalpostState}
+                journalpostId={journalpostId}
+                innloggetSaksbehandler={innloggetSaksbehandler}
+            />
+            <JournalføringIkkeMuligModal
+                visModal={journalpostState.visJournalføringIkkeMuligModal}
+                settVisModal={journalpostState.settJournalføringIkkeMuligModal}
+                erPapirSøknad={erPapirsøknad}
+            />
+        </SideLayout>
     );
 };
 

--- a/src/frontend/Komponenter/Journalføring/JournalføringPdfVisning.tsx
+++ b/src/frontend/Komponenter/Journalføring/JournalføringPdfVisning.tsx
@@ -1,0 +1,38 @@
+import { Knapp } from 'nav-frontend-knapper';
+import PdfVisning from '../../Felles/Pdf/PdfVisning';
+import React, { useEffect } from 'react';
+import { HentDokumentResponse } from '../../App/hooks/useHentDokument';
+import styled from 'styled-components';
+
+const FlexKnapper = styled.div`
+    display: flex;
+    justify-content: space-between;
+`;
+
+const JournalføringPdfVisning: React.FC<{ hentDokumentResponse: HentDokumentResponse }> = ({
+    hentDokumentResponse,
+}) => {
+    const { hentFørsteDokument, hentForrigeDokument, hentNesteDokument, valgtDokument } =
+        hentDokumentResponse;
+
+    useEffect(() => {
+        hentFørsteDokument();
+        // eslint-disable-next-line
+    }, []);
+
+    return (
+        <>
+            <FlexKnapper>
+                <Knapp onClick={() => hentForrigeDokument()} mini>
+                    Forrige Dokument
+                </Knapp>
+                <Knapp onClick={() => hentNesteDokument()} mini>
+                    Neste Dokument
+                </Knapp>
+            </FlexKnapper>
+            <PdfVisning pdfFilInnhold={valgtDokument} />
+        </>
+    );
+};
+
+export default JournalføringPdfVisning;

--- a/src/frontend/Komponenter/Journalføring/JournalføringWrapper.tsx
+++ b/src/frontend/Komponenter/Journalføring/JournalføringWrapper.tsx
@@ -1,0 +1,77 @@
+import React, { FunctionComponent, useEffect } from 'react';
+import { Navigate } from 'react-router-dom';
+import { useQueryParams } from '../../App/hooks/felles/useQueryParams';
+import { JOURNALPOST_QUERY_STRING, OPPGAVEID_QUERY_STRING } from './journalføringUtil';
+import { useHentJournalpost } from '../../App/hooks/useHentJournalpost';
+import DataViewer from '../../Felles/DataViewer/DataViewer';
+import { IJojurnalpostResponse } from '../../App/typer/journalføring';
+import styled from 'styled-components';
+
+export const SideLayout = styled.div`
+    max-width: 1600px;
+    margin: 0 auto;
+    padding: 2rem;
+`;
+
+export const Kolonner = styled.div`
+    margin-top: 2rem;
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    flex-wrap: wrap;
+`;
+
+export const Venstrekolonne = styled.div`
+    max-width: 900px;
+`;
+export const Høyrekolonne = styled.div``;
+export const FlexKnapper = styled.div`
+    display: flex;
+    justify-content: space-between;
+`;
+
+export interface JournalføringAppProps {
+    oppgaveId: string;
+    journalResponse: IJojurnalpostResponse;
+}
+
+interface JournalføringAppSide {
+    komponent: FunctionComponent<JournalføringAppProps>;
+}
+
+const JournalføringWrapper: React.FC<JournalføringAppSide> = ({ komponent }) => {
+    const query: URLSearchParams = useQueryParams();
+    const oppgaveId = query.get(OPPGAVEID_QUERY_STRING);
+    const journalpostId = query.get(JOURNALPOST_QUERY_STRING);
+
+    const { hentJournalPost, journalResponse } = useHentJournalpost(journalpostId);
+
+    useEffect(() => {
+        hentJournalPost();
+    }, [hentJournalPost]);
+
+    useEffect(() => {
+        document.title = 'Journalpost';
+    }, []);
+
+    if (!oppgaveId || !journalpostId) {
+        return <Navigate to="/oppgavebenk" />;
+    }
+
+    return (
+        <DataViewer response={{ journalResponse }}>
+            {({ journalResponse }) => {
+                return (
+                    <>
+                        {React.createElement(komponent, {
+                            oppgaveId,
+                            journalResponse,
+                        })}
+                    </>
+                );
+            }}
+        </DataViewer>
+    );
+};
+
+export default JournalføringWrapper;

--- a/src/frontend/Komponenter/Journalføring/journalføringUtil.ts
+++ b/src/frontend/Komponenter/Journalføring/journalføringUtil.ts
@@ -1,0 +1,18 @@
+import { IJojurnalpostResponse } from '../../App/typer/journalføring';
+import { JournalføringStateRequest } from '../../App/hooks/useJournalføringState';
+
+export const JOURNALPOST_QUERY_STRING = 'journalpostId';
+export const OPPGAVEID_QUERY_STRING = 'oppgaveId';
+
+export const harTittelForAlleDokumenter = (
+    journalResponse: IJojurnalpostResponse,
+    journalpostState: JournalføringStateRequest
+) =>
+    journalResponse.journalpost.dokumenter
+        .map(
+            (d) =>
+                d.tittel ||
+                (journalpostState.dokumentTitler &&
+                    journalpostState.dokumentTitler[d.dokumentInfoId])
+        )
+        .every((tittel) => tittel && tittel.trim());


### PR DESCRIPTION
…nbruke for klage

* fjerner `forsøktJournalført` og håndterer feilmeldingen hvis man ikke har satt behandling på annet sted
* JournalføringWrapper.tsx som håndterer henting av journalpost
  *  Dette gjør at vi ikke trenger dataviewer i JournalføringApp, og sjekk på SUKSESS, som gjør koden litt enklere
* useHentDokument blir avhengig av journalposten for å ikke kalle på de ulike metodene med journalpost
* useJournalføringState tar inn oppgaveId og journalpostId då de ellers settes inne i en useEffect 
* Trekker ut noen fellesdeler i egne filer