### PR TITLE
Adressehistorikk skal vise gjeldende på gjeldende adresse då adresser…

### DIFF
--- a/src/frontend/App/typer/personopplysninger.ts
+++ b/src/frontend/App/typer/personopplysninger.ts
@@ -46,6 +46,7 @@ export interface IAdresse {
     gyldigFraOgMed?: string;
     gyldigTilOgMed?: string;
     angittFlyttedato?: string;
+    erGjeldende: boolean;
 }
 
 export interface ISøkeresultatPerson {

--- a/src/frontend/Felles/Personopplysninger/Adressehistorikk.tsx
+++ b/src/frontend/Felles/Personopplysninger/Adressehistorikk.tsx
@@ -121,7 +121,10 @@ const Innhold: React.FC<{ adresser: IAdresse[]; fagsakPersonId: string }> = ({
                 {adresser.map((adresse, indeks) => {
                     return (
                         <tr key={indeks}>
-                            <Td>{adresse.visningsadresse}</Td>
+                            <Td>
+                                {adresse.visningsadresse}
+                                {adresse.erGjeldende ? ' (gjeldende)' : ''}
+                            </Td>
                             <Td>{adresse.type !== AdresseType.BOSTEDADRESSE && adresse.type}</Td>
                             <Td>
                                 {formaterNullableIsoDato(


### PR DESCRIPTION
… då en adresse med senere fra-dato kan være historisk. Backend sorterer disse med gjelende først

* https://github.com/navikt/familie-ef-sak/pull/1892
* https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10403

<img width="1241" alt="image" src="https://user-images.githubusercontent.com/937168/202435108-2341007e-6375-4591-88e0-0e905cf1497c.png">
