### PR TITLE
Skal vise hjelptetekst for bostedsadresse i personopplysningene for å…

### DIFF
--- a/src/frontend/Felles/Personopplysninger/Adressehistorikk.tsx
+++ b/src/frontend/Felles/Personopplysninger/Adressehistorikk.tsx
@@ -12,11 +12,6 @@ import { ModalWrapper } from '../Modal/ModalWrapper';
 import UtvidPanel from '../UtvidPanel/UtvidPanel';
 import { Button, HelpText } from '@navikt/ds-react';
 
-const BostedsadresseTittelMedHjelpetekst = styled.div`
-    display: flex;
-    gap: 1rem;
-`;
-
 const StyledFlexDiv = styled.div`
     display: flex;
     justify-content: space-between;
@@ -85,15 +80,12 @@ const Kolonnetittel: React.FC<{ text: string; width: number }> = ({ text, width 
     </Td>
 );
 
-const TittelBostedsadresser: React.ReactElement = (
-    <BostedsadresseTittelMedHjelpetekst>
-        <span>Bostedsadresser</span>
-        <HelpText title="Gjeldende" placement={'right'}>
-            En person skal til enhver tid ha kun en folkeregistrert bostedsadresse. I EF Sak er
-            denne adressen markert med "(gjeldende)". Vær oppmerksom på at det i noen tilfeller ikke
-            vil være adressen med den nyeste fra-datoen som er gjeldende.
-        </HelpText>
-    </BostedsadresseTittelMedHjelpetekst>
+const TittelbeskrivelseBostedsadresser: React.ReactElement = (
+    <HelpText title="Gjeldende" placement={'right'}>
+        En person skal til enhver tid ha kun en folkeregistrert bostedsadresse. I EF Sak er denne
+        adressen markert med "(gjeldende)". Vær oppmerksom på at det i noen tilfeller ikke vil være
+        adressen med den nyeste fra-datoen som er gjeldende.
+    </HelpText>
 );
 
 const Adresser: React.FC<{ adresser: IAdresse[]; fagsakPersonId: string; type?: AdresseType }> = ({
@@ -105,8 +97,11 @@ const Adresser: React.FC<{ adresser: IAdresse[]; fagsakPersonId: string; type?: 
         <TabellWrapper>
             <TabellOverskrift
                 Ikon={Bygning}
-                tittel={
-                    type === AdresseType.BOSTEDADRESSE ? TittelBostedsadresser : 'Andre adresser'
+                tittel={type === AdresseType.BOSTEDADRESSE ? 'Bostedsadresser' : 'Andre adresser'}
+                tittelbeskrivelse={
+                    type === AdresseType.BOSTEDADRESSE
+                        ? TittelbeskrivelseBostedsadresser
+                        : undefined
                 }
             />
             {(adresser.length !== 0 && (

--- a/src/frontend/Felles/Personopplysninger/Adressehistorikk.tsx
+++ b/src/frontend/Felles/Personopplysninger/Adressehistorikk.tsx
@@ -87,13 +87,11 @@ const Kolonnetittel: React.FC<{ text: string; width: number }> = ({ text, width 
 
 const TittelBostedsadresser: React.ReactElement = (
     <BostedsadresseTittelMedHjelpetekst>
-        <span>Bostedsadresses</span>
+        <span>Bostedsadresser</span>
         <HelpText title="Gjeldende" placement={'right'}>
-            Folkeregisteret skal til enhver tid kun ha en gyldig bostedsadresse per person. Denne
-            vil i EF Sak markeres med (gjeldende). Hver gang en ny bostedsadresse blir registrert så
-            vil den bli gjeldene og den forrige bli historisk/ikke gjeldene. Merk at det i enkelte
-            tilfeller ikke vil være adressen med den nyeste fra-datoen som er gjeldene, feks ved en
-            korreksjon i Folkeregisteret.
+            En person skal til enhver tid ha kun en folkeregistrert bostedsadresse. I EF Sak er
+            denne adressen markert med "(gjeldende)". Vær oppmerksom på at det i noen tilfeller ikke
+            vil være adressen med den nyeste fra-datoen som er gjeldende.
         </HelpText>
     </BostedsadresseTittelMedHjelpetekst>
 );

--- a/src/frontend/Felles/Personopplysninger/Adressehistorikk.tsx
+++ b/src/frontend/Felles/Personopplysninger/Adressehistorikk.tsx
@@ -10,7 +10,12 @@ import { formaterNullableIsoDato } from '../../App/utils/formatter';
 import { gyldigTilOgMedErNullEllerFremITid } from './adresseUtil';
 import { ModalWrapper } from '../Modal/ModalWrapper';
 import UtvidPanel from '../UtvidPanel/UtvidPanel';
-import { Button } from '@navikt/ds-react';
+import { Button, HelpText } from '@navikt/ds-react';
+
+const BostedsadresseTittelMedHjelpetekst = styled.div`
+    display: flex;
+    gap: 1rem;
+`;
 
 const StyledFlexDiv = styled.div`
     display: flex;
@@ -80,6 +85,19 @@ const Kolonnetittel: React.FC<{ text: string; width: number }> = ({ text, width 
     </Td>
 );
 
+const TittelBostedsadresser: React.ReactElement = (
+    <BostedsadresseTittelMedHjelpetekst>
+        <span>Bostedsadresses</span>
+        <HelpText title="Gjeldende" placement={'right'}>
+            Folkeregisteret skal til enhver tid kun ha en gyldig bostedsadresse per person. Denne
+            vil i EF Sak markeres med (gjeldende). Hver gang en ny bostedsadresse blir registrert så
+            vil den bli gjeldene og den forrige bli historisk/ikke gjeldene. Merk at det i enkelte
+            tilfeller ikke vil være adressen med den nyeste fra-datoen som er gjeldene, feks ved en
+            korreksjon i Folkeregisteret.
+        </HelpText>
+    </BostedsadresseTittelMedHjelpetekst>
+);
+
 const Adresser: React.FC<{ adresser: IAdresse[]; fagsakPersonId: string; type?: AdresseType }> = ({
     adresser,
     fagsakPersonId,
@@ -89,7 +107,9 @@ const Adresser: React.FC<{ adresser: IAdresse[]; fagsakPersonId: string; type?: 
         <TabellWrapper>
             <TabellOverskrift
                 Ikon={Bygning}
-                tittel={type === AdresseType.BOSTEDADRESSE ? 'Bostedsadresser' : 'Andre adresser'}
+                tittel={
+                    type === AdresseType.BOSTEDADRESSE ? TittelBostedsadresser : 'Andre adresser'
+                }
             />
             {(adresser.length !== 0 && (
                 <table className="tabell">

--- a/src/frontend/Felles/Personopplysninger/TabellOverskrift.tsx
+++ b/src/frontend/Felles/Personopplysninger/TabellOverskrift.tsx
@@ -4,11 +4,14 @@ import { Undertittel } from 'nav-frontend-typografi';
 
 interface Props {
     Ikon: React.FC;
-    tittel: React.ReactElement | string;
+    tittel: string;
+    tittelbeskrivelse?: React.ReactElement;
 }
 
-const StyledTittel = styled(Undertittel)`
+const StyledTittel = styled.div`
     grid-area: tittel;
+    display: flex;
+    gap: 1rem;
 `;
 
 const StyledIkon = styled.div`
@@ -16,13 +19,16 @@ const StyledIkon = styled.div`
     justify-self: left;
 `;
 
-const TabellOverskrift: React.FC<Props> = ({ Ikon, tittel }) => {
+const TabellOverskrift: React.FC<Props> = ({ Ikon, tittel, tittelbeskrivelse }) => {
     return (
         <>
             <StyledIkon>
                 <Ikon />
             </StyledIkon>
-            <StyledTittel>{tittel}</StyledTittel>
+            <StyledTittel>
+                <Undertittel>{tittel}</Undertittel>
+                <div>{tittelbeskrivelse}</div>
+            </StyledTittel>
         </>
     );
 };

--- a/src/frontend/Felles/Personopplysninger/TabellOverskrift.tsx
+++ b/src/frontend/Felles/Personopplysninger/TabellOverskrift.tsx
@@ -4,7 +4,7 @@ import { Undertittel } from 'nav-frontend-typografi';
 
 interface Props {
     Ikon: React.FC;
-    tittel: string;
+    tittel: React.ReactElement | string;
 }
 
 const StyledTittel = styled(Undertittel)`


### PR DESCRIPTION
… forklere hvorfor "(gjeldende)" vises

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10403

Endringen burde egentligen vært med i forrige PR
* https://github.com/navikt/familie-ef-sak-frontend/pull/1766

![image](https://user-images.githubusercontent.com/937168/202461651-575567e6-d19c-4f34-80e2-0669f4589c28.png)
