### PR TITLE
Viser henlagt årsak for klager

### DIFF
--- a/src/frontend/App/typer/Behandlingsårsak.ts
+++ b/src/frontend/App/typer/Behandlingsårsak.ts
@@ -1,5 +1,5 @@
 import { TilbakekrevingsbehandlingÅrsak } from './tilbakekreving';
-import { KlageÅrsak } from './klage';
+import { KlageHenlagtÅrsak, KlageÅrsak } from './klage';
 
 export enum Behandlingsårsak {
     KLAGE = 'KLAGE',
@@ -68,7 +68,7 @@ export enum EHenlagtårsak {
     FEILREGISTRERT = 'FEILREGISTRERT',
 }
 
-export const henlagtÅrsakTilTekst: Record<EHenlagtårsak, string> = {
+export const henlagtÅrsakTilTekst: Record<EHenlagtårsak | KlageHenlagtÅrsak, string> = {
     TRUKKET_TILBAKE: 'Trukket tilbake',
     FEILREGISTRERT: 'Feilregistrert',
 };

--- a/src/frontend/App/typer/klage.ts
+++ b/src/frontend/App/typer/klage.ts
@@ -14,6 +14,7 @@ export interface KlageBehandling {
     vedtaksdato: string | undefined;
     årsak: KlageÅrsak | undefined;
     klageinstansResultat: KlageinstansResultat[];
+    henlagtÅrsak: KlageHenlagtÅrsak | undefined;
 }
 
 export interface KlageinstansResultat {
@@ -71,4 +72,9 @@ export enum KlageÅrsak {
     FEIL_PROSESSUELL = 'FEIL_PROSESSUELL',
     KØET_BEHANDLING = 'KØET_BEHANDLING',
     ANNET = 'ANNET',
+}
+
+export enum KlageHenlagtÅrsak {
+    TRUKKET_TILBAKE = 'TRUKKET_TILBAKE',
+    FEILREGISTRERT = 'FEILREGISTRERT',
 }

--- a/src/frontend/Komponenter/Personoversikt/BehandlingsoversiktTabell.tsx
+++ b/src/frontend/Komponenter/Personoversikt/BehandlingsoversiktTabell.tsx
@@ -24,6 +24,7 @@ import { klageBaseUrl, tilbakekrevingBaseUrl } from '../../App/utils/miljø';
 import {
     KlageBehandling,
     KlagebehandlingResultat,
+    KlageHenlagtÅrsak,
     KlageinstansEventType,
     KlageinstansResultat,
     klageinstansUtfallTilTekst,
@@ -55,7 +56,7 @@ interface BehandlingsoversiktTabellBehandling {
     id: string;
     type: Behandlingstype | TilbakekrevingBehandlingstype | string;
     årsak?: Behandlingsårsak | KlageÅrsak;
-    henlagtÅrsak?: EHenlagtårsak;
+    henlagtÅrsak?: EHenlagtårsak | KlageHenlagtÅrsak;
     status: string;
     vedtaksdato?: string;
     resultat?:
@@ -114,6 +115,7 @@ export const BehandlingsoversiktTabell: React.FC<{
                 applikasjon: BehandlingApplikasjon.KLAGE,
                 årsak: behandling.årsak,
                 klageinstansResultat: behandling.klageinstansResultat,
+                henlagtÅrsak: behandling.henlagtÅrsak,
             };
         }
     );


### PR DESCRIPTION
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-9822

Beroende, men ikke avhengig av:
* https://github.com/navikt/familie-kontrakter/pull/660
* https://github.com/navikt/familie-klage/pull/184

Klagebehandlingen har de samme årsakene som `EHenlagtårsak`. Jeg tenker det er fint hvis vi har en egen enum likevel. Samtidig så, ettersom de har de samme verdiene så kan man fortsatt bruke `henlagtÅrsakTilTekst`
```typescript
henlagtÅrsakTilTekst[behandling.henlagtÅrsak]
```

Føler ikke det er helt å gjøre det som dette? Burde man ha en egen mapping av `KlageHenlagtÅrsak` og merge denne med `EHenlagtårsak` som då brukes i `BehandlingsoversiktTabell.tsx`? 