### PR TITLE
fritekstfelt i fane for årsak til revurdering skal ikke flyte ut av s…

### DIFF
--- a/src/frontend/Komponenter/Behandling/Vurdering/StyledVurdering.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/StyledVurdering.tsx
@@ -18,6 +18,7 @@ export const SistOppdatertOgVurderingWrapper = styled.span`
     display: flex;
     flex-direction: column;
     gap: 1rem;
+    width: 40rem;
 `;
 
 export const VertikalStrek = styled.span`


### PR DESCRIPTION
…kjermen ved mye tekst.

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?
card=Tea-10465

Før:
![Skjermbilde 2022-11-22 kl  13 33 34](https://user-images.githubusercontent.com/32769446/203315228-d853bba6-f77a-4f9d-a8eb-c54be0a5f34c.png)

Etter:
![Skjermbilde 2022-11-22 kl  13 33 13](https://user-images.githubusercontent.com/32769446/203315198-db781a0f-3a39-4d06-93e4-9dca78307d3a.png)


