### PR TITLE
Saksbehandlere får bedre oversikt hvis vi viser hele datoer inkludert…

### DIFF
--- a/src/frontend/Komponenter/Migrering/SummertePerioder.tsx
+++ b/src/frontend/Komponenter/Migrering/SummertePerioder.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { SummertPeriode } from '../../App/typer/infotrygd';
-import { formaterNullableMånedÅr, formaterTallMedTusenSkille } from '../../App/utils/formatter';
+import { formaterNullableIsoDato, formaterTallMedTusenSkille } from '../../App/utils/formatter';
 import { Stønadstype } from '../../App/typer/behandlingstema';
 import { Table } from '@navikt/ds-react';
 
 const formatFomTom = (periode: SummertPeriode) => (
     <>
-        {formaterNullableMånedÅr(periode.stønadFom)}
+        {formaterNullableIsoDato(periode.stønadFom)}
         {' - '}
-        {formaterNullableMånedÅr(periode.stønadTom)}
+        {formaterNullableIsoDato(periode.stønadTom)}
     </>
 );
 

--- a/src/frontend/Komponenter/Migrering/TabellInfotrygdPerioder.tsx
+++ b/src/frontend/Komponenter/Migrering/TabellInfotrygdPerioder.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
 import { InfotrygdPeriodeMedFlereEndringer } from '../Infotrygd/typer';
-import {
-    formaterNullableIsoDato,
-    formaterNullableMånedÅr,
-    formaterTallMedTusenSkille,
-} from '../../App/utils/formatter';
+import { formaterNullableIsoDato, formaterTallMedTusenSkille } from '../../App/utils/formatter';
 import {
     aktivitetstypeTilKode,
     aktivitetstypeTilTekst,
@@ -29,9 +25,9 @@ const HøyrestiltTekst = styled.p`
 `;
 
 const formatStønadTom = (periode: InfotrygdPeriodeMedFlereEndringer): string => {
-    const stønadTom = formaterNullableMånedÅr(periode.stønadTom) as string;
+    const stønadTom = formaterNullableIsoDato(periode.stønadTom) as string;
     if (periode.kode === Kode.OPPHØRT || periode.kode === Kode.OVERTFØRT_NY_LØSNING) {
-        return `${formaterNullableMånedÅr(periode.opphørsdato)} (${stønadTom})`;
+        return `${formaterNullableIsoDato(periode.opphørsdato)} (${stønadTom})`;
     } else {
         return stønadTom;
     }
@@ -115,7 +111,7 @@ export const TabellInfotrygdOvergangsstønadperioder: React.FC<{
                         <Table.Row key={`${periode.stønadId}-${periode.vedtakId}`}>
                             <Tooltip content={stønadOgVedtaksIdString}>
                                 <Table.DataCell>
-                                    {formaterNullableMånedÅr(periode.stønadFom)}
+                                    {formaterNullableIsoDato(periode.stønadFom)}
                                     {' - '}
                                     {formatStønadTom(periode)}
                                 </Table.DataCell>
@@ -216,7 +212,7 @@ export const TabellInfotrygdBarnetilsynperioder: React.FC<{
                         <Table.Row key={`${periode.stønadId}-${periode.vedtakId}`}>
                             <Tooltip content={stønadOgVedtaksIdString}>
                                 <Table.DataCell>
-                                    {formaterNullableMånedÅr(periode.stønadFom)}
+                                    {formaterNullableIsoDato(periode.stønadFom)}
                                     {' - '}
                                     {formatStønadTom(periode)}
                                 </Table.DataCell>
@@ -279,7 +275,7 @@ export const InfotrygdPerioderSkolepenger: React.FC<{
                     return (
                         <Table.Row key={`${periode.stønadId}-${periode.vedtakId}`}>
                             <Table.DataCell>
-                                {formaterNullableMånedÅr(periode.stønadFom)}
+                                {formaterNullableIsoDato(periode.stønadFom)}
                                 {' - '}
                                 {formatStønadTom(periode)}
                             </Table.DataCell>

--- a/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderBarnetilsyn.tsx
@@ -3,7 +3,7 @@ import { behandlingstypeTilTekst } from '../../../App/typer/behandlingstype';
 import { Link } from 'react-router-dom';
 import {
     formaterIsoDatoTid,
-    formaterNullableMånedÅr,
+    formaterNullableIsoDato,
     formaterTallMedTusenSkille,
 } from '../../../App/utils/formatter';
 import { Sanksjonsårsak, sanksjonsårsakTilTekst } from '../../../App/typer/Sanksjonsårsak';
@@ -38,9 +38,9 @@ const historikkRad = (andel: AndelHistorikk, sanksjonFinnes: boolean, index: num
     return (
         <HistorikkRad type={andel.endring?.type} key={index}>
             <td>
-                {formaterNullableMånedÅr(andel.andel.stønadFra)}
+                {formaterNullableIsoDato(andel.andel.stønadFra)}
                 {' - '}
-                {formaterNullableMånedÅr(andel.andel.stønadTil)}
+                {formaterNullableIsoDato(andel.andel.stønadTil)}
             </td>
             {sanksjonFinnes && (
                 <td>

--- a/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderOvergangsstønad.tsx
@@ -3,7 +3,7 @@ import { behandlingstypeTilTekst } from '../../../App/typer/behandlingstype';
 import { Link } from 'react-router-dom';
 import {
     formaterIsoDatoTid,
-    formaterNullableMånedÅr,
+    formaterNullableIsoDato,
     formaterTallMedTusenSkille,
 } from '../../../App/utils/formatter';
 import { aktivitetTilTekst, EPeriodetype, periodetypeTilTekst } from '../../../App/typer/vedtak';
@@ -34,9 +34,9 @@ const historikkRad = (andel: AndelHistorikk, index: number) => {
     return (
         <HistorikkRad type={andel.endring?.type} key={index}>
             <td>
-                {formaterNullableMånedÅr(andel.andel.stønadFra)}
+                {formaterNullableIsoDato(andel.andel.stønadFra)}
                 {' - '}
-                {formaterNullableMånedÅr(andel.andel.stønadTil)}
+                {formaterNullableIsoDato(andel.andel.stønadTil)}
             </td>
             <td>
                 <Tag variant={etikettType(andel.periodeType)} size={'small'}>


### PR DESCRIPTION
… dag i perioder. Vil derfor inkluderer "dag" i periodeoversikt-datoer. Vil endre dette for Vedtaksperioder og Vedtaksperioder infotrygd.

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10260




![image](https://user-images.githubusercontent.com/53942238/203804592-286a45fe-9a35-4582-be60-d1afd901c416.png)

![image](https://user-images.githubusercontent.com/53942238/203804651-3202f4ec-7361-41ba-87ff-47f8552d6bfb.png)

![image](https://user-images.githubusercontent.com/53942238/203804795-b9b1ac53-e5e6-4220-abae-d5a0ef121351.png)

![image](https://user-images.githubusercontent.com/53942238/203804890-381cd5a5-da04-414f-9eda-1f3f8d300028.png)

