### PR TITLE
Skal ikke lenke til side om overgangsstønad i brev for barnetilsyn/skolepenger.

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
@@ -1,7 +1,7 @@
 import {
     initielleAvsnittTom,
     initielleAvsnittVarselOmAktivitetsplikt,
-    initielleAvsnittVedtakAvslag,
+    initielleAvsnittVedtakAvslagOvergangsstønad,
     initielleAvsnittVedtakAvslagBarnetilsyn,
     initielleAvsnittVedtakInvilgelse,
     initielleAvsnittVedtakInvilgelseBarnetilsyn,
@@ -10,6 +10,8 @@ import {
     initielleAvsnittVedtakInvilgelseSkolepenger,
     initielleAvsnittVedtakAvslagSkolepenger,
     initielleAvsnittInnhentingAvOpplysninger,
+    initielleAvsnittVedtakOpphørBarnetilsyn,
+    initielleAvsnittVedtakOpphørSkolepenger,
 } from './BrevTyperTekst';
 import { IMellomlagretBrevResponse } from '../../../App/hooks/useMellomlagringBrev';
 import { Stønadstype } from '../../../App/typer/behandlingstema';
@@ -193,8 +195,8 @@ export const BrevtyperTilAvsnitt: Record<FrittståendeBrevtype | FritekstBrevtyp
         VARSEL_OM_AKTIVITETSPLIKT: initielleAvsnittVarselOmAktivitetsplikt,
         VARSEL_OM_SANKSJON: initielleAvsnittTom,
         VEDTAK_INVILGELSE: initielleAvsnittVedtakInvilgelse,
-        VEDTAK_AVSLAG: initielleAvsnittVedtakAvslag,
-        VEDTAK_OPPHØR: initielleAvsnittVedtakAvslag,
+        VEDTAK_AVSLAG: initielleAvsnittVedtakAvslagOvergangsstønad,
+        VEDTAK_OPPHØR: initielleAvsnittVedtakAvslagOvergangsstønad,
         VEDTAK_REVURDERING: initielleAvsnittVedtakInvilgelse,
         VEDTAK_INNVILGELSE_BARNETILSYN: initielleAvsnittVedtakInvilgelseBarnetilsyn,
         VEDTAK_AVSLAG_BARNETILSYN: initielleAvsnittVedtakAvslagBarnetilsyn,
@@ -204,8 +206,8 @@ export const BrevtyperTilAvsnitt: Record<FrittståendeBrevtype | FritekstBrevtyp
             initielleAvsnittInnhentingAvKarakterutskriftUtvidetPeriode,
         VEDTAK_INNVILGELSE_SKOLEPENGER: initielleAvsnittVedtakInvilgelseSkolepenger,
         VEDTAK_AVSLAG_SKOLEPENGER: initielleAvsnittVedtakAvslagSkolepenger,
-        VEDTAK_OPPHØR_BARNETILSYN: initielleAvsnittVedtakAvslag,
-        VEDTAK_OPPHØR_SKOLEPENGER: initielleAvsnittVedtakAvslag,
+        VEDTAK_OPPHØR_BARNETILSYN: initielleAvsnittVedtakOpphørBarnetilsyn,
+        VEDTAK_OPPHØR_SKOLEPENGER: initielleAvsnittVedtakOpphørSkolepenger,
     };
 
 export enum FritekstBrevContext {

--- a/src/frontend/Komponenter/Behandling/Brev/BrevTyperTekst.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevTyperTekst.ts
@@ -41,7 +41,7 @@ export const initielleAvsnittVedtakInvilgelse: AvsnittMedId[] = [
     },
 ];
 
-export const initielleAvsnittVedtakAvslag: AvsnittMedId[] = [
+export const initielleAvsnittVedtakAvslagOvergangsstønad: AvsnittMedId[] = [
     {
         deloverskrift: 'Du har rett til å klage',
         innhold:
@@ -57,6 +57,46 @@ export const initielleAvsnittVedtakAvslag: AvsnittMedId[] = [
         deloverskrift: 'Har du spørsmål?',
         innhold:
             'Du finner nyttig informasjon på nav.no/overgangsstonad-enslig. Du kan også kontakte oss på nav.no/kontakt.',
+        id: uuidv4(),
+    },
+];
+
+export const initielleAvsnittVedtakOpphørBarnetilsyn: AvsnittMedId[] = [
+    {
+        deloverskrift: 'Du har rett til å klage',
+        innhold:
+            'Hvis du vil klage, må du gjøre dette innen 6 uker fra den datoen du fikk dette vedtaket. Du finner skjema og informasjon på nav.no/klage.',
+        id: uuidv4(),
+    },
+    {
+        deloverskrift: 'Du har rett til innsyn',
+        innhold: 'På nav.no/dittnav kan du se dokumentene i saken din.',
+        id: uuidv4(),
+    },
+    {
+        deloverskrift: 'Har du spørsmål?',
+        innhold:
+            'Du finner nyttig informasjon på nav.no/barnetilsyn-enslig. Du kan også kontakte oss på nav.no/kontakt.',
+        id: uuidv4(),
+    },
+];
+
+export const initielleAvsnittVedtakOpphørSkolepenger: AvsnittMedId[] = [
+    {
+        deloverskrift: 'Du har rett til å klage',
+        innhold:
+            'Hvis du vil klage, må du gjøre dette innen 6 uker fra den datoen du fikk dette vedtaket. Du finner skjema og informasjon på nav.no/klage.',
+        id: uuidv4(),
+    },
+    {
+        deloverskrift: 'Du har rett til innsyn',
+        innhold: 'På nav.no/dittnav kan du se dokumentene i saken din.',
+        id: uuidv4(),
+    },
+    {
+        deloverskrift: 'Har du spørsmål?',
+        innhold:
+            'Du finner nyttig informasjon på nav.no/skolepenger-enslig. Du kan også kontakte oss på nav.no/kontakt.',
         id: uuidv4(),
     },
 ];


### PR DESCRIPTION
Etter feil oppdaget på demo. Mulig vi kan rydde litt i tekstene, men har bare lyst til å få ut en fiks midlertidig.