### PR TITLE
Endrer teksten i adresseopplysninger i samliv til å være small for å …

### DIFF
--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Samliv/Addresseopplysninger.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Samliv/Addresseopplysninger.tsx
@@ -15,13 +15,15 @@ export const Addresseopplysninger: FC<Props> = ({ data }) => {
     return (
         <>
             <Søknadsgrunnlag />
-            <BodyShort>Bor på denne adressen ({data.adresse})</BodyShort>
+            <BodyShort size={'small'}>Bor på denne adressen ({data.adresse})</BodyShort>
             <BooleanTekst value={data.søkerBorPåRegistrertAdresse} />
 
             {data.harMeldtAdresseendring && (
                 <>
                     <Søknadsgrunnlag />
-                    <BodyShort>Har meldt adresseendring til Folkeregisteret</BodyShort>
+                    <BodyShort size={'small'}>
+                        Har meldt adresseendring til Folkeregisteret
+                    </BodyShort>
                     <BooleanTekst value={data.harMeldtAdresseendring} />
                 </>
             )}


### PR DESCRIPTION
…ha samme størrelse som gammelt designsystem


Fiks på https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10347

Før:
![image](https://user-images.githubusercontent.com/937168/204836317-124bc724-9857-4e28-a68c-1c65b9c43716.png)


Etter:
![image](https://user-images.githubusercontent.com/937168/204836269-610611b0-50ca-4610-bce7-9c0c16fa76cc.png)
