### PR TITLE
Skal kunne opprette førstegangsbehandling manuelt

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -23,6 +23,8 @@ import ScrollToTop from './Felles/ScrollToTop/ScrollToTop';
 import styled from 'styled-components';
 import { ModalWrapper } from './Felles/Modal/ModalWrapper';
 import { JournalføringKlageApp } from './Komponenter/Journalføring/JournalføringKlageApp';
+import VelgPersonOgStønadstype from './Komponenter/Behandling/Førstegangsbehandling/VelgPersonOgStønadstype';
+import OpprettFørstegangsbehandling from './Komponenter/Behandling/Førstegangsbehandling/OpprettFørstegangsbehandling';
 
 // @ts-ignore
 Modal.setAppElement(document.getElementById('modal-a11y-wrapper'));
@@ -117,6 +119,14 @@ const AppInnhold: React.FC<{ innloggetSaksbehandler: ISaksbehandler }> = ({
                 <Route path="/fagsak/:fagsakId" element={<FagsakTilFagsakPersonRedirect />} />
                 <Route path="/person/:fagsakPersonId/*" element={<Personoversikt />} />
                 <Route path="/uttrekk/arbeidssoker" element={<UttrekkArbeidssøker />} />
+                <Route
+                    path={`/opprett-forstegangsbehandling`}
+                    element={<VelgPersonOgStønadstype />}
+                />
+                <Route
+                    path={`/opprett-forstegangsbehandling/:fagsakId`}
+                    element={<OpprettFørstegangsbehandling />}
+                />
                 <Route path="/" element={<Navigate to="/oppgavebenk" replace={true} />} />
             </Routes>
             <UlagretDataModal />

--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -13,4 +13,5 @@ export enum ToggleName {
     visUtestengelse = 'familie.ef.sak.frontend-utestengelse',
     visSatsendring = 'familie.ef.sak.frontend-vis-satsendring',
     avslagMindreInntektsendringer = 'familie.ef.sak.avslag-mindre-inntektsendringer',
+    førstegangsbehandling = 'familie.ef.sak.opprett-forstegangsbehandling',
 }

--- a/src/frontend/Felles/HeaderMedSøk/HeaderMedSøk.tsx
+++ b/src/frontend/Felles/HeaderMedSøk/HeaderMedSøk.tsx
@@ -73,6 +73,12 @@ const lagEksterneLenker = (
         });
         if (toggles[ToggleName.opprettBehandlingForFerdigstiltJournalpost]) {
             eksterneLenker.push({
+                name: 'Opprett førstegangsbehandling manuelt',
+                href: '/opprett-forstegangsbehandling',
+            });
+        }
+        if (toggles[ToggleName.opprettBehandlingForFerdigstiltJournalpost]) {
+            eksterneLenker.push({
                 name: '[Admin] Lag behandling fra journalpost',
                 href: '/admin/ny-behandling-for-ferdigstilt-journalpost/',
             });

--- a/src/frontend/Komponenter/Behandling/Førstegangsbehandling/OpprettFørstegangsbehandling.tsx
+++ b/src/frontend/Komponenter/Behandling/Førstegangsbehandling/OpprettFørstegangsbehandling.tsx
@@ -1,0 +1,174 @@
+import React, { useEffect, useState } from 'react';
+import { useApp } from '../../../App/context/AppContext';
+import LeggTilBarnSomSkalFødes from '../../Journalføring/LeggTilBarnSomSkalFødes';
+import { BarnSomSkalFødes } from '../../../App/hooks/useJournalføringState';
+import { useNavigate, useParams } from 'react-router-dom';
+import { Fagsak } from '../../../App/typer/fagsak';
+import {
+    byggTomRessurs,
+    Ressurs,
+    RessursFeilet,
+    RessursStatus,
+    RessursSuksess,
+} from '../../../App/typer/ressurs';
+import DataViewer from '../../../Felles/DataViewer/DataViewer';
+import { BodyLong, BodyShort, Button, Heading, Label } from '@navikt/ds-react';
+import { TextLabel } from '../../../Felles/Visningskomponenter/Tekster';
+import { stønadstypeTilTekst } from '../../../App/typer/behandlingstema';
+import { FamilieDatovelger, FamilieSelect } from '@navikt/familie-form-elements';
+import { erGyldigDato } from '../../../App/utils/dato';
+import AlertStripeFeilPreWrap from '../../../Felles/Visningskomponenter/AlertStripeFeilPreWrap';
+import styled from 'styled-components';
+import { Behandlingsårsak, behandlingsårsakTilTekst } from '../../../App/typer/Behandlingsårsak';
+
+type IFagsakParam = {
+    fagsakId: string;
+};
+const Container = styled.div`
+    margin: 2rem;
+    max-width: 60rem;
+`;
+
+const SkjemaContainer = styled.div`
+    margin-top: 2rem;
+    max-width: 14rem;
+`;
+
+interface Førstegangsbehandling {
+    kravMottatt: string;
+    behandlingsårsak: Behandlingsårsak;
+    barnSomSkalFødes: BarnSomSkalFødes[];
+}
+
+const inneholderBarnSomErUgyldige = (barnSomSkalFødes: BarnSomSkalFødes[]) =>
+    barnSomSkalFødes.some(
+        (barn) =>
+            !barn.fødselTerminDato ||
+            barn.fødselTerminDato.trim() === '' ||
+            !erGyldigDato(barn.fødselTerminDato)
+    );
+
+const OpprettFørstegangsbehandling = () => {
+    const { fagsakId } = useParams<IFagsakParam>();
+    const [fagsak, settFagsak] = useState<Ressurs<Fagsak>>(byggTomRessurs());
+    const [barnSomSkalFødes, settBarnSomSkalFødes] = useState<BarnSomSkalFødes[]>([]);
+    const [kravMottattDato, settKravMottattDato] = useState<string>();
+    const [årsak, settÅrsak] = useState<Behandlingsårsak>();
+    const [feilmelding, settFeilmelding] = useState<string>();
+    const [senderInn, settSenderInn] = useState<boolean>(false);
+    const { axiosRequest } = useApp();
+    const navigate = useNavigate();
+
+    useEffect(() => {
+        axiosRequest<Fagsak, null>({
+            method: 'GET',
+            url: `/familie-ef-sak/api/fagsak/${fagsakId}`,
+        }).then(settFagsak);
+    }, [fagsakId, axiosRequest]);
+
+    const validerSkjema = (): string => {
+        if (!årsak) {
+            return 'Mangler årsak';
+        } else if (!kravMottattDato) {
+            return 'Mangler krav mottatt dato';
+        } else if (kravMottattDato && !erGyldigDato(kravMottattDato)) {
+            return 'Ugyldig dato for krav mottatt';
+        } else if (inneholderBarnSomErUgyldige(barnSomSkalFødes)) {
+            return 'Et eller flere barn mangler gyldig dato';
+        } else {
+            return '';
+        }
+    };
+
+    const opprettBehandling = (fagsakData: Fagsak) => {
+        const feilFraSkjema = validerSkjema();
+        if (!feilFraSkjema && årsak && kravMottattDato && !senderInn) {
+            settSenderInn(true);
+            axiosRequest<string, Førstegangsbehandling>({
+                method: 'POST',
+                url: `/familie-ef-sak/api/forstegangsbehandling/${fagsakData.id}/opprett`,
+                data: {
+                    kravMottatt: kravMottattDato,
+                    barnSomSkalFødes: barnSomSkalFødes,
+                    behandlingsårsak: årsak,
+                },
+            })
+                .then((respons: RessursSuksess<string> | RessursFeilet) => {
+                    if (respons.status === RessursStatus.SUKSESS) {
+                        const behandlingId = respons.data;
+                        navigate(`/behandling/${behandlingId}`);
+                    } else {
+                        settFeilmelding(respons.frontendFeilmelding);
+                    }
+                })
+                .finally(() => {
+                    settSenderInn(false);
+                });
+        } else {
+            settFeilmelding(feilFraSkjema);
+        }
+    };
+
+    return (
+        <Container>
+            <Heading size={'xlarge'} level={'1'}>
+                Opprett førstegangsbehandling manuelt
+            </Heading>
+            <BodyLong>Velg evt. terminbarn og sett krav mottatt dato</BodyLong>
+
+            <DataViewer response={{ fagsak }}>
+                {({ fagsak }) => (
+                    <>
+                        <TextLabel>Stønadstype: </TextLabel>
+                        <BodyShort>{stønadstypeTilTekst[fagsak.stønadstype]}</BodyShort>
+                        <TextLabel>Fødselsnummer: </TextLabel>
+                        <BodyShort>{fagsak.personIdent}</BodyShort>
+                        <SkjemaContainer>
+                            <Label htmlFor={'krav-mottatt'}>Krav mottatt</Label>
+                            <FamilieDatovelger
+                                id={'krav-mottatt'}
+                                label={''}
+                                onChange={(dato) => {
+                                    settKravMottattDato(dato as string);
+                                }}
+                                valgtDato={kravMottattDato}
+                                feil={
+                                    kravMottattDato &&
+                                    !erGyldigDato(kravMottattDato) &&
+                                    'Ugyldig dato'
+                                }
+                                limitations={{ maxDate: new Date().toISOString() }}
+                            />
+                            <FamilieSelect
+                                value={årsak || ''}
+                                label={'Velg årsak'}
+                                onChange={(e) => settÅrsak(e.target.value as Behandlingsårsak)}
+                            >
+                                <option value="">Velg årsak</option>
+                                <option value={Behandlingsårsak.NYE_OPPLYSNINGER}>
+                                    {behandlingsårsakTilTekst[Behandlingsårsak.NYE_OPPLYSNINGER]}
+                                </option>
+                                <option value={Behandlingsårsak.PAPIRSØKNAD}>
+                                    {behandlingsårsakTilTekst[Behandlingsårsak.PAPIRSØKNAD]}
+                                </option>
+                            </FamilieSelect>
+                        </SkjemaContainer>
+                        <LeggTilBarnSomSkalFødes
+                            barnSomSkalFødes={barnSomSkalFødes}
+                            oppdaterBarnSomSkalFødes={settBarnSomSkalFødes}
+                            tittel={'Terminbarn'}
+                        />
+                        <Button type={'button'} onClick={() => opprettBehandling(fagsak)}>
+                            Opprett førstegangsbehandling
+                        </Button>
+                        {feilmelding && (
+                            <AlertStripeFeilPreWrap>{feilmelding}</AlertStripeFeilPreWrap>
+                        )}
+                    </>
+                )}
+            </DataViewer>
+        </Container>
+    );
+};
+
+export default OpprettFørstegangsbehandling;

--- a/src/frontend/Komponenter/Behandling/Førstegangsbehandling/VelgPersonOgStønadstype.tsx
+++ b/src/frontend/Komponenter/Behandling/Førstegangsbehandling/VelgPersonOgStønadstype.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useState } from 'react';
+import { Stønadstype, stønadstypeTilTekst } from '../../../App/typer/behandlingstema';
+import { useHentFagsak } from '../../../App/hooks/useHentFagsak';
+import { FamilieInput, FamilieSelect } from '@navikt/familie-form-elements';
+import { fnr } from '@navikt/fnrvalidator';
+import AlertStripeFeilPreWrap from '../../../Felles/Visningskomponenter/AlertStripeFeilPreWrap';
+import { BodyLong, Button, Heading } from '@navikt/ds-react';
+import { RessursStatus } from '../../../App/typer/ressurs';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+const Container = styled.div`
+    margin: 2rem;
+    max-width: 60rem;
+`;
+
+const SkjemaContainer = styled.div`
+    margin-top: 2rem;
+    max-width: 14rem;
+`;
+
+const WrapperMedMargin = styled.div`
+    margin-top: 2rem;
+    margin-bottom: 1rem;
+`;
+
+const VelgPersonOgStønadstype = () => {
+    const [stønadstype, settStønadstype] = useState<Stønadstype>();
+    const [personIdent, settPersonIdent] = useState<string>('');
+    const [feilmelding, settFeilmelding] = useState<string>();
+    const [laster, settLaster] = useState<boolean>(false);
+    const { fagsak, hentFagsak } = useHentFagsak();
+    const navigate = useNavigate();
+    const harSattPersonIdent = personIdent.length === 11;
+    const harFeil = feilmelding !== undefined && harSattPersonIdent;
+
+    const bekreftValg = () => {
+        if (personIdent && stønadstype && !harFeil && !laster) {
+            settLaster(true);
+            hentFagsak(personIdent, stønadstype);
+        }
+    };
+
+    useEffect(() => {
+        if (fagsak.status === RessursStatus.SUKSESS) {
+            navigate(`/opprett-forstegangsbehandling/${fagsak.data.id}`);
+        } else if (
+            fagsak.status === RessursStatus.FEILET ||
+            fagsak.status === RessursStatus.FUNKSJONELL_FEIL ||
+            fagsak.status === RessursStatus.IKKE_TILGANG
+        ) {
+            settFeilmelding(fagsak.frontendFeilmelding);
+            settLaster(false);
+        }
+    }, [fagsak, navigate]);
+
+    return (
+        <Container>
+            <Heading size={'xlarge'} level={'1'}>
+                Opprett førstegangsbehandling manuelt
+            </Heading>
+            <BodyLong>
+                Velg stønadstype og fødselsnummer for å gå videre til opprettelse av
+                førstegangsbehandling
+            </BodyLong>
+            <SkjemaContainer>
+                <FamilieSelect
+                    value={stønadstype || ''}
+                    label={'Velg stønadstype'}
+                    onChange={(e) => settStønadstype(e.target.value as Stønadstype)}
+                >
+                    <option value="">Velg stønadstype</option>
+                    {Object.values(Stønadstype).map((stønadstype) => (
+                        <option value={stønadstype} key={stønadstype}>
+                            {stønadstypeTilTekst[stønadstype]}
+                        </option>
+                    ))}
+                </FamilieSelect>
+                <FamilieInput
+                    label={'Fødselsnummer'}
+                    onChange={(e) => {
+                        const verdi = e.target.value;
+                        settPersonIdent(verdi);
+                        settFeilmelding(
+                            fnr(verdi).status === 'invalid' ? 'Ugyldig fødselsnummer' : undefined
+                        );
+                    }}
+                />
+                <WrapperMedMargin>
+                    <Button onClick={bekreftValg} type="button">
+                        Gå videre
+                    </Button>
+                </WrapperMedMargin>
+            </SkjemaContainer>
+            {harFeil && <AlertStripeFeilPreWrap>{feilmelding}</AlertStripeFeilPreWrap>}
+        </Container>
+    );
+};
+
+export default VelgPersonOgStønadstype;

--- a/src/frontend/Komponenter/Journalføring/LeggTilBarnSomSkalFødes.tsx
+++ b/src/frontend/Komponenter/Journalføring/LeggTilBarnSomSkalFødes.tsx
@@ -45,7 +45,8 @@ const LeggTilBarnKnapp = styled(Button)`
 const LeggTilBarnSomSkalFødes: React.FC<{
     barnSomSkalFødes: BarnSomSkalFødes[];
     oppdaterBarnSomSkalFødes: (terminbarn: BarnSomSkalFødes[]) => void;
-}> = ({ barnSomSkalFødes, oppdaterBarnSomSkalFødes }) => {
+    tittel?: string;
+}> = ({ barnSomSkalFødes, oppdaterBarnSomSkalFødes, tittel = 'Journalføre papirsøknad?' }) => {
     useEffect(() => () => oppdaterBarnSomSkalFødes([]), [oppdaterBarnSomSkalFødes]);
 
     const leggTilBarn = () => oppdaterBarnSomSkalFødes([...barnSomSkalFødes, { _id: uuidv4() }]);
@@ -70,7 +71,7 @@ const LeggTilBarnSomSkalFødes: React.FC<{
     return (
         <LeggTilBarnContent>
             <Tittel spacing size="xsmall" level="6">
-                Journalføre papirsøknad?
+                {tittel}
             </Tittel>
             <InlineContent>
                 Dersom søkeren har terminbarn i søknaden må disse legges til her.


### PR DESCRIPTION
[Løser denne](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10524)
Henger sammen med denne: https://github.com/navikt/familie-ef-sak/pull/1953

Menyvalg
<img width="545" alt="Skjermbilde 2022-12-08 kl  22 04 14" src="https://user-images.githubusercontent.com/402915/206567351-47964c7d-b700-409e-be01-2191650bf417.png">

Velg person og stønad (for å enten opprette fagsak eller hente ut riktig fagsak)
<img width="806" alt="Skjermbilde 2022-12-08 kl  22 04 29" src="https://user-images.githubusercontent.com/402915/206567347-8213f9a2-b7b9-4f44-9eb2-731a68afb5ac.png">

Velg minimumsdata for å opprette manuelt. Tar ikke høyde for sivilstandsendringer, men tenker det er like bra som "papirsøknad"
<img width="879" alt="Skjermbilde 2022-12-08 kl  22 04 42" src="https://user-images.githubusercontent.com/402915/206567338-d58de139-893f-4055-ae38-fdb343488cb5.png">
