### PR TITLE
Hovedperiode barn i rett alder

### DIFF
--- a/src/frontend/App/typer/vedtak.ts
+++ b/src/frontend/App/typer/vedtak.ts
@@ -83,6 +83,7 @@ export type IInnvilgeVedtakForOvergangsstønad = {
     perioder: IVedtaksperiode[];
     inntekter: IInntektsperiode[];
     samordningsfradragType?: ESamordningsfradragtype | string | undefined;
+    yngsteBarnDato: string;
 };
 
 export type IInnvilgeVedtakForBarnetilsyn = {

--- a/src/frontend/App/utils/dato.ts
+++ b/src/frontend/App/utils/dato.ts
@@ -10,7 +10,10 @@ import {
     isValid,
     parse,
     parseISO,
+    subYears,
 } from 'date-fns';
+
+export const minusÅr = (date: Date, antall: number): Date => subYears(date, antall);
 
 export const plusMåneder = (date: Date, antall: number): Date => addMonths(date, antall);
 

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
@@ -423,7 +423,7 @@ export const InnvilgeVedtak: React.FC<{
                                 disabled={laster || !!revurderesFraOgMedFeilmelding}
                                 type={'submit'}
                             >
-                                Lagre vedtak!
+                                Lagre vedtak
                             </Button>
                         </WrapperDobbelMarginTop>
                     )}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
@@ -150,10 +150,10 @@ export const InnvilgeVedtak: React.FC<{
     );
 
     useEffect(() => {
-        if (vilkår.status === RessursStatus.SUKSESS) {
+        if (vilkår.status === RessursStatus.SUKSESS && yngsteBarnDato.value == '3000-01-01') {
             yngsteBarnFødselsdato(vilkår);
         }
-    }, [vilkår, yngsteBarnFødselsdato]);
+    }, [vilkår, yngsteBarnFødselsdato, yngsteBarnDato.value]);
 
     useEffect(() => {
         if (!revurderesFra || !vedtakshistorikk) {

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
@@ -59,8 +59,9 @@ export const InnvilgeVedtak: React.FC<{
             ? (lagretVedtak as IInnvilgeVedtakForOvergangsstønad)
             : undefined;
 
-    const { vilkår } = useHentVilkår();
-    const [yngsteBarn, settYngsteBarn] = useState<string | null>(null);
+    const { vilkår, hentVilkår } = useHentVilkår();
+
+    const [yngsteBarn, settYngsteBarn] = useState<string>('3000-01-01');
 
     const { hentBehandling, behandlingErRedigerbar } = useBehandling();
     const { axiosRequest, nullstillIkkePersisterteKomponenter, settIkkePersistertKomponent } =
@@ -83,6 +84,10 @@ export const InnvilgeVedtak: React.FC<{
     const [feilmelding, settFeilmelding] = useState<string>();
 
     useEffect(() => {
+        hentVilkår(behandling.id);
+    }, [behandling.id, hentVilkår]);
+
+    useEffect(() => {
         if (vilkår.status === RessursStatus.SUKSESS) {
             const tidligsteDato = vilkår.data.grunnlag.barnMedSamvær
                 .map((b) => b.registergrunnlag)
@@ -98,7 +103,7 @@ export const InnvilgeVedtak: React.FC<{
                         return erEtter(a, b) ? b : a;
                     }
                 });
-
+            console.log('Tidligste dato: ' + tidligsteDato);
             tidligsteDato && settYngsteBarn(tidligsteDato);
         }
     }, [vilkår]);
@@ -114,6 +119,7 @@ export const InnvilgeVedtak: React.FC<{
                 ? lagretInnvilgetVedtak?.inntekter
                 : [tomInntektsperiodeRad()],
             samordningsfradragType: lagretInnvilgetVedtak?.samordningsfradragType || '',
+            yngsteBarnDato: yngsteBarn,
         },
         validerInnvilgetVedtakForm
     );
@@ -287,6 +293,7 @@ export const InnvilgeVedtak: React.FC<{
             perioder: form.perioder,
             inntekter: form.inntekter,
             samordningsfradragType: skalVelgeSamordningstype ? form.samordningsfradragType : null,
+            yngsteBarnDato: yngsteBarn,
         };
         switch (behandling.type) {
             case Behandlingstype.FØRSTEGANGSBEHANDLING:
@@ -298,7 +305,6 @@ export const InnvilgeVedtak: React.FC<{
 
     return (
         <form onSubmit={formState.onSubmit(handleSubmit)}>
-            <p>{yngsteBarn}</p>s
             <WrapperDobbelMarginTop>
                 {behandling.forrigeBehandlingId && behandlingErRedigerbar ? (
                     <RevurderesFraOgMed

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
@@ -14,7 +14,12 @@ import {
     IVedtaksperiode,
     IVedtakType,
 } from '../../../../../App/typer/vedtak';
-import { byggTomRessurs, Ressurs, RessursStatus } from '../../../../../App/typer/ressurs';
+import {
+    byggTomRessurs,
+    Ressurs,
+    RessursStatus,
+    RessursSuksess,
+} from '../../../../../App/typer/ressurs';
 import { useBehandling } from '../../../../../App/context/BehandlingContext';
 import { useNavigate } from 'react-router-dom';
 import { useApp } from '../../../../../App/context/AppContext';
@@ -36,6 +41,7 @@ import { useEffectNotInitialRender } from '../../../../../App/hooks/felles/useEf
 import { fyllHullMedOpphør, revurderFraInitPeriode } from './revurderFraUtils';
 import { useHentVilkår } from '../../../../../App/hooks/useHentVilkår';
 import { erEtter, erGyldigDato, minusÅr } from '../../../../../App/utils/dato';
+import { IVilkår } from '../../../Inngangsvilkår/vilkår';
 
 export type InnvilgeVedtakForm = Omit<
     Omit<IInnvilgeVedtakForOvergangsstønad, 'resultatType'>,
@@ -115,8 +121,8 @@ export const InnvilgeVedtak: React.FC<{
 
     const låsVedtaksperiodeRad = !!revurderesFra;
 
-    useEffect(() => {
-        if (vilkår.status === RessursStatus.SUKSESS) {
+    const yngsteBarnFødselsdato = useCallback(
+        (vilkår: RessursSuksess<IVilkår>) => {
             const terminbarnFødselsdatoer = vilkår.data.grunnlag.barnMedSamvær
                 .map((b) => b.søknadsgrunnlag)
                 .map((sb) => sb.fødselTermindato)
@@ -139,8 +145,15 @@ export const InnvilgeVedtak: React.FC<{
                     return erEtter(a, b) ? a : b;
                 });
             tidligsteDato && yngsteBarnDato.setValue(tidligsteDato);
+        },
+        [yngsteBarnDato]
+    );
+
+    useEffect(() => {
+        if (vilkår.status === RessursStatus.SUKSESS) {
+            yngsteBarnFødselsdato(vilkår);
         }
-    }, [vilkår, yngsteBarnDato]);
+    }, [vilkår, yngsteBarnFødselsdato]);
 
     useEffect(() => {
         if (!revurderesFra || !vedtakshistorikk) {

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
@@ -92,16 +92,9 @@ export const InnvilgeVedtak: React.FC<{
             const tidligsteDato = vilkår.data.grunnlag.barnMedSamvær
                 .map((b) => b.registergrunnlag)
                 .map((r) => r.fødselsdato)
+                .filter((fødselsdato): fødselsdato is string => !!fødselsdato)
                 .reduce((a, b) => {
-                    if (!a && b) {
-                        return b;
-                    }
-                    if (!b && a) {
-                        return a;
-                    }
-                    if (a && b) {
-                        return erEtter(a, b) ? b : a;
-                    }
+                    return erEtter(a, b) ? a : b;
                 });
             console.log('Tidligste dato: ' + tidligsteDato);
             tidligsteDato && settYngsteBarn(tidligsteDato);

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
@@ -9,7 +9,6 @@ import {
     erMånedÅrEtter,
     erMånedÅrEtterEllerLik,
     erMånedÅrLik,
-    månedÅrTilDate,
     plusMåneder,
     tilDato,
     tilÅrMåned,
@@ -71,19 +70,14 @@ export const validerVedtaksperioder = ({
     let harPeriodeFør7mndFremITiden = false;
 
     const åtteÅrFremITiden = (barnDatoStreng: string) => {
-        const barnDato = månedÅrTilDate(barnDatoStreng);
-        return plusMåneder(tilDato(barnDato), 96);
+        return plusMåneder(tilDato(barnDatoStreng), 96);
     };
 
     const yngsteBarnErOver8FørUtgangAvPerioden = (
         yngsteBarnFødselsdato: string,
         årMånedTil: string | undefined
     ) => {
-        console.log('VALIDER: ', yngsteBarnFødselsdato);
-        if (årMånedTil && erEtter(årMånedTil, åtteÅrFremITiden(yngsteBarnFødselsdato))) {
-            true;
-        }
-        return false;
+        return årMånedTil && erEtter(årMånedTil, åtteÅrFremITiden(yngsteBarnFødselsdato));
     };
 
     const feilIVedtaksPerioder = (yngsteBarnDato: string) =>
@@ -100,15 +94,11 @@ export const validerVedtaksperioder = ({
                 periodeType === EPeriodetype.HOVEDPERIODE &&
                 yngsteBarnErOver8FørUtgangAvPerioden(yngsteBarnDato, årMånedTil)
             ) {
-                console.log('VALIDER: FEIL FUNNET!', yngsteBarnDato);
-
                 vedtaksperiodeFeil = {
                     ...vedtaksperiodeFeil,
                     periodeType:
                         'Yngste barn er over 8 før utgang av perioden. Må ha barn under 8 i hele hovedperioden. ',
                 };
-            } else {
-                console.log('VALIDER: INGEN FEIL FUNNET', yngsteBarnDato);
             }
 
             if (periodeType === '' || periodeType === undefined) {

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
@@ -94,8 +94,7 @@ export const validerVedtaksperioder = ({
         ) {
             vedtaksperiodeFeil = {
                 ...vedtaksperiodeFeil,
-                periodeType:
-                    'Yngste barn er over 8 før utgang av perioden. Må ha barn under 8 i hele hovedperioden. ',
+                periodeType: 'Yngste barn er over 8 før utgang av hovedperiode.',
             };
         }
 

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
@@ -60,6 +60,15 @@ export const validerVedtaksperioder = ({
     const syvMånederFremITiden = tilÅrMåned(plusMåneder(new Date(), 7));
     const tolvMånederFremITiden = tilÅrMåned(plusMåneder(new Date(), 12));
     let harPeriodeFør7mndFremITiden = false;
+
+    const yngsteBarnErOver8FørUtgangAvPerioden = (
+        yngsteBarnFødselsdato: string,
+        årMånedTil: string | undefined
+    ) => {
+        console.log(yngsteBarnFødselsdato + årMånedTil);
+        return false;
+    };
+
     const feilIVedtaksPerioder = perioder.map((vedtaksperiode, index) => {
         const { årMånedFra, årMånedTil, aktivitet, periodeType } = vedtaksperiode;
         let vedtaksperiodeFeil: FormErrors<IVedtaksperiode> = {
@@ -68,6 +77,17 @@ export const validerVedtaksperioder = ({
             årMånedFra: undefined,
             årMånedTil: undefined,
         };
+
+        if (
+            periodeType === EPeriodetype.HOVEDPERIODE &&
+            yngsteBarnErOver8FørUtgangAvPerioden('2022-01-01', årMånedTil) //TODO bruk riktig dato
+        ) {
+            vedtaksperiodeFeil = {
+                ...vedtaksperiodeFeil,
+                periodeType:
+                    'Yngste barn er over 8 før utgang av perioden. Må ha barn under 8 i hele hovedperioden. ',
+            };
+        }
 
         if (periodeType === '' || periodeType === undefined) {
             vedtaksperiodeFeil = { ...vedtaksperiodeFeil, periodeType: 'Mangler periodetype' };

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
@@ -79,6 +79,7 @@ export const validerVedtaksperioder = ({
         yngsteBarnFødselsdato: string,
         årMånedTil: string | undefined
     ) => {
+        console.log('VALIDER: ', yngsteBarnFødselsdato);
         if (årMånedTil && erEtter(årMånedTil, åtteÅrFremITiden(yngsteBarnFødselsdato))) {
             true;
         }
@@ -99,11 +100,15 @@ export const validerVedtaksperioder = ({
                 periodeType === EPeriodetype.HOVEDPERIODE &&
                 yngsteBarnErOver8FørUtgangAvPerioden(yngsteBarnDato, årMånedTil)
             ) {
+                console.log('VALIDER: FEIL FUNNET!', yngsteBarnDato);
+
                 vedtaksperiodeFeil = {
                     ...vedtaksperiodeFeil,
                     periodeType:
                         'Yngste barn er over 8 før utgang av perioden. Må ha barn under 8 i hele hovedperioden. ',
                 };
+            } else {
+                console.log('VALIDER: INGEN FEIL FUNNET', yngsteBarnDato);
             }
 
             if (periodeType === '' || periodeType === undefined) {

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
@@ -79,7 +79,7 @@ export const validerVedtaksperioder = ({
         yngsteBarnFødselsdato: string,
         årMånedTil: string | undefined
     ) => {
-        if (årMånedTil && erEtter(yngsteBarnFødselsdato, åtteÅrFremITiden(yngsteBarnFødselsdato))) {
+        if (årMånedTil && erEtter(årMånedTil, åtteÅrFremITiden(yngsteBarnFødselsdato))) {
             true;
         }
         return false;


### PR DESCRIPTION
Mål med oppgave: dersom ingen barn er under 8 ved utgang av innvilgelse av hovedperiode -> vis feilmelding.  

Kunne nesten laget en draft på denne, antar vi får noen tilbakemeldinger 😝 , men vi får fikse disse fortløpende 🤹   

Noen hacks jeg gjerne vil ha tilbakemeldinger på(få hjelp til): 

Hack 1: Vi initierer formstate med dato langt fram i tid:  yngsteBarnDato: '3000-01-01', (resultat = ingen valideringsfeil når vi starter, eller hvis vi ikke finner barn 😬, men da er det kanskje flere ting som er feil 😁  )

Hack 2: Vi bruker dato vi setter i formstate for kun hente yngsteBarnFødselsdato en gang i en useEffekt: 
if (vilkår.status === RessursStatus.SUKSESS && yngsteBarnDato.value == '3000-01-01') {
            yngsteBarnFødselsdato(vilkår);
        }
        
Den siste sjekken er kanskje unødvendig, men vi slipper å regne ut denne på nytt hele tiden. Men det er kanskje bedre måter å gjøre det på? (Evt. bedre å gjøre det hver gang state endrer seg? ) 

Kommentar til kode (søknadsbarn: vi tenkte dette var "godt nok"):
 
Vi tar ikke så mye stilling til om det er termindato fra søknad, eller registerdato som er riktig, men vi bryr oss ikke om gamle termindatoer. Målet er å sjekke om alle barn er over 8 ved utgang av hovedperiode (det skal ikke være mulig). Da antar jeg at gamle termindatoer egentlig ikke så viktige lenger. 

Men er det riktig å hente barn fra vilkår slik? 




  
        