### PR TITLE
Viser opphør i vedtakshistorikken for OS og BT

### DIFF
--- a/src/frontend/App/typer/tilkjentytelse.ts
+++ b/src/frontend/App/typer/tilkjentytelse.ts
@@ -45,6 +45,7 @@ export interface AndelHistorikk {
     behandlingType: Behandlingstype;
     behandlingÅrsak: Behandlingsårsak;
     sanksjonsårsak?: Sanksjonsårsak;
+    erOpphør?: boolean; // TODO fjern optional når backend er merget
 }
 
 export interface AndelHistorikkEndring {

--- a/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderBarnetilsyn.tsx
@@ -16,17 +16,17 @@ import { utledHjelpetekstForBeløpFørFratrekkOgSatsjusteringForVedtaksside } fr
 import { HelpText, Tag } from '@navikt/ds-react';
 import styled from 'styled-components';
 
+const Rad = styled.div`
+    display: grid;
+    grid-template-area: beløp hjelpetekst;
+    grid-template-columns: 3rem 1.75rem;
+`;
+
+const LinjeSplitter = styled.div`
+    margin-top: 0.25rem;
+`;
+
 const historikkRad = (andel: AndelHistorikk, index: number) => {
-    const Rad = styled.div`
-        display: grid;
-        grid-template-area: beløp hjelpetekst;
-        grid-template-columns: 3rem 1.75rem;
-    `;
-
-    const LinjeSplitter = styled.div`
-        margin-top: 0.25rem;
-    `;
-
     const beløpErRedusertPgaSats = andel.andel.beløpFørFratrekkOgSatsJustering > andel.andel.sats;
     const beløpErRedusertPgaTilleggsstønad = andel.andel.tilleggsstønad > 0;
     const stønadsbeløpetErRedusert = beløpErRedusertPgaSats || beløpErRedusertPgaTilleggsstønad;

--- a/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderBarnetilsyn.tsx
@@ -1,14 +1,11 @@
 import { AktivitetArbeidTilTekst, AndelHistorikk } from '../../../App/typer/tilkjentytelse';
 import { behandlingstypeTilTekst } from '../../../App/typer/behandlingstype';
 import { Link } from 'react-router-dom';
-import {
-    formaterIsoDatoTid,
-    formaterNullableIsoDato,
-    formaterTallMedTusenSkille,
-} from '../../../App/utils/formatter';
+import { formaterIsoDatoTid, formaterTallMedTusenSkille } from '../../../App/utils/formatter';
 import { Sanksjonsårsak, sanksjonsårsakTilTekst } from '../../../App/typer/Sanksjonsårsak';
 import React from 'react';
 import {
+    datoAndelHistorikk,
     etikettType,
     historikkEndring,
     HistorikkRad,
@@ -19,7 +16,7 @@ import { utledHjelpetekstForBeløpFørFratrekkOgSatsjusteringForVedtaksside } fr
 import { HelpText, Tag } from '@navikt/ds-react';
 import styled from 'styled-components';
 
-const historikkRad = (andel: AndelHistorikk, sanksjonFinnes: boolean, index: number) => {
+const historikkRad = (andel: AndelHistorikk, index: number) => {
     const Rad = styled.div`
         display: grid;
         grid-template-area: beløp hjelpetekst;
@@ -35,33 +32,34 @@ const historikkRad = (andel: AndelHistorikk, sanksjonFinnes: boolean, index: num
     const stønadsbeløpetErRedusert = beløpErRedusertPgaSats || beløpErRedusertPgaTilleggsstønad;
 
     const erSanksjon = andel.erSanksjon;
+    const erOpphør = andel.erOpphør;
+    const visDetaljer = !erSanksjon && !erOpphør;
     return (
         <HistorikkRad type={andel.endring?.type} key={index}>
+            <td>{datoAndelHistorikk(andel)}</td>
             <td>
-                {formaterNullableIsoDato(andel.andel.stønadFra)}
-                {' - '}
-                {formaterNullableIsoDato(andel.andel.stønadTil)}
+                {erOpphør && (
+                    <Tag variant={'error'} size={'small'}>
+                        Opphør
+                    </Tag>
+                )}
+                {erSanksjon && (
+                    <Tag variant={etikettType(EPeriodetype.SANKSJON)} size={'small'}>
+                        {periodetypeTilTekst[EPeriodetype.SANKSJON]}
+                    </Tag>
+                )}
             </td>
-            {sanksjonFinnes && (
-                <td>
-                    {erSanksjon && (
-                        <Tag variant={etikettType(EPeriodetype.SANKSJON)} size={'small'}>
-                            {periodetypeTilTekst[EPeriodetype.SANKSJON]}
-                        </Tag>
-                    )}
-                </td>
-            )}
             <td>
                 {erSanksjon
                     ? sanksjonsårsakTilTekst[andel.sanksjonsårsak as Sanksjonsårsak]
                     : andel.aktivitetArbeid && AktivitetArbeidTilTekst[andel.aktivitetArbeid]}
             </td>
-            <td>{!erSanksjon && andel.andel.antallBarn}</td>
-            <td>{!erSanksjon && formaterTallMedTusenSkille(andel.andel.utgifter)}</td>
-            <td>{!erSanksjon && formaterTallMedTusenSkille(andel.andel.kontantstøtte)}</td>
+            <td>{visDetaljer && andel.andel.antallBarn}</td>
+            <td>{visDetaljer && formaterTallMedTusenSkille(andel.andel.utgifter)}</td>
+            <td>{visDetaljer && formaterTallMedTusenSkille(andel.andel.kontantstøtte)}</td>
             <td>
                 <Rad>
-                    {!erSanksjon && formaterTallMedTusenSkille(andel.andel.beløp)}
+                    {visDetaljer && formaterTallMedTusenSkille(andel.andel.beløp)}
                     {stønadsbeløpetErRedusert && (
                         <HelpText title="Hvor kommer beløpet fra?" placement={'right'}>
                             {utledHjelpetekstForBeløpFørFratrekkOgSatsjusteringForVedtaksside(
@@ -95,13 +93,12 @@ const historikkRad = (andel: AndelHistorikk, sanksjonFinnes: boolean, index: num
 };
 
 const VedtaksperioderBarnetilsyn: React.FC<{ andeler: AndelHistorikk[] }> = ({ andeler }) => {
-    const sanksjonFinnes = andeler.some((andel) => andel.erSanksjon);
     return (
         <HistorikkTabell className="tabell">
             <thead>
                 <tr>
                     <th>Periode (fom-tom)</th>
-                    {sanksjonFinnes && <th></th>}
+                    <th>Periodetype</th>
                     <th>Aktivitet</th>
                     <th>Antall barn</th>
                     <th>Utgifter</th>
@@ -113,9 +110,7 @@ const VedtaksperioderBarnetilsyn: React.FC<{ andeler: AndelHistorikk[] }> = ({ a
                     <th>Endring</th>
                 </tr>
             </thead>
-            <tbody>
-                {andeler.map((periode, index) => historikkRad(periode, sanksjonFinnes, index))}
-            </tbody>
+            <tbody>{andeler.map((periode, index) => historikkRad(periode, index))}</tbody>
         </HistorikkTabell>
     );
 };

--- a/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/VedtaksperioderOvergangsstønad.tsx
@@ -1,15 +1,12 @@
 import { AndelHistorikk } from '../../../App/typer/tilkjentytelse';
 import { behandlingstypeTilTekst } from '../../../App/typer/behandlingstype';
 import { Link } from 'react-router-dom';
-import {
-    formaterIsoDatoTid,
-    formaterNullableIsoDato,
-    formaterTallMedTusenSkille,
-} from '../../../App/utils/formatter';
+import { formaterIsoDatoTid, formaterTallMedTusenSkille } from '../../../App/utils/formatter';
 import { aktivitetTilTekst, EPeriodetype, periodetypeTilTekst } from '../../../App/typer/vedtak';
 import { Sanksjonsårsak, sanksjonsårsakTilTekst } from '../../../App/typer/Sanksjonsårsak';
 import React from 'react';
 import {
+    datoAndelHistorikk,
     etikettType,
     historikkEndring,
     HistorikkRad,
@@ -31,26 +28,30 @@ const lenketekst = (andel: AndelHistorikk) => {
 
 const historikkRad = (andel: AndelHistorikk, index: number) => {
     const erSanksjon = andel.periodeType === EPeriodetype.SANKSJON;
+    const erOpphør = andel.erOpphør;
+    const visDetaljer = !erSanksjon && !erOpphør;
     return (
         <HistorikkRad type={andel.endring?.type} key={index}>
+            <td>{datoAndelHistorikk(andel)}</td>
             <td>
-                {formaterNullableIsoDato(andel.andel.stønadFra)}
-                {' - '}
-                {formaterNullableIsoDato(andel.andel.stønadTil)}
-            </td>
-            <td>
-                <Tag variant={etikettType(andel.periodeType)} size={'small'}>
-                    {periodetypeTilTekst[andel.periodeType || '']}
-                </Tag>
+                {erOpphør ? (
+                    <Tag variant={'error'} size={'small'}>
+                        Opphør
+                    </Tag>
+                ) : (
+                    <Tag variant={etikettType(andel.periodeType)} size={'small'}>
+                        {periodetypeTilTekst[andel.periodeType || '']}
+                    </Tag>
+                )}
             </td>
             <td>
                 {erSanksjon
                     ? sanksjonsårsakTilTekst[andel.sanksjonsårsak as Sanksjonsårsak]
                     : aktivitetTilTekst[andel.aktivitet || '']}
             </td>
-            <td>{!erSanksjon && formaterTallMedTusenSkille(andel.andel.inntekt)}</td>
-            <td>{!erSanksjon && formaterTallMedTusenSkille(andel.andel.samordningsfradrag)}</td>
-            <td>{!erSanksjon && formaterTallMedTusenSkille(andel.andel.beløp)}</td>
+            <td>{visDetaljer && formaterTallMedTusenSkille(andel.andel.inntekt)}</td>
+            <td>{visDetaljer && formaterTallMedTusenSkille(andel.andel.samordningsfradrag)}</td>
+            <td>{visDetaljer && formaterTallMedTusenSkille(andel.andel.beløp)}</td>
             <td>{formaterIsoDatoTid(andel.vedtakstidspunkt)}</td>
             <td>{andel.saksbehandler}</td>
             <td>

--- a/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/vedtakshistorikkUtil.tsx
+++ b/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/vedtakshistorikkUtil.tsx
@@ -1,10 +1,11 @@
 import {
     AndelEndringType,
+    AndelHistorikk,
     AndelHistorikkEndring,
     AndelHistorikkTypeTilTekst,
 } from '../../../App/typer/tilkjentytelse';
 import { Link } from 'react-router-dom';
-import { formaterIsoDatoTid } from '../../../App/utils/formatter';
+import { formaterIsoDatoTid, formaterNullableIsoDato } from '../../../App/utils/formatter';
 import { EPeriodetype } from '../../../App/typer/vedtak';
 import React from 'react';
 import styled from 'styled-components';
@@ -48,5 +49,14 @@ export const etikettType = (periodeType?: EPeriodetype): TagProps['variant'] => 
             return 'error';
         default:
             return 'info';
+    }
+};
+
+export const datoAndelHistorikk = (andel: AndelHistorikk) => {
+    const fra = formaterNullableIsoDato(andel.andel.stønadFra);
+    if (andel.erOpphør) {
+        return fra;
+    } else {
+        return `${fra} - ${formaterNullableIsoDato(andel.andel.stønadTil)}`;
     }
 };


### PR DESCRIPTION
Backend er under arbeid, trenger noen flere tester, 
* https://github.com/navikt/familie-ef-sak/compare/vedtakshistorikk-opph%C3%B8r-ta-med

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-7981

OS:
![image](https://user-images.githubusercontent.com/937168/211049780-5ee89b0e-6173-4775-8e37-131009250fb7.png)

BT:
![image](https://user-images.githubusercontent.com/937168/211049889-c45479e5-5e5a-40a4-997f-7ffc07cd060f.png)
