### PR TITLE
Legge til nye brekkepunkter i PersonHeader

### DIFF
--- a/src/frontend/Felles/PersonHeader/PersonHeader.tsx
+++ b/src/frontend/Felles/PersonHeader/PersonHeader.tsx
@@ -49,17 +49,17 @@ const TagsKnyttetTilBehandling = styled.div`
 `;
 
 const TagsLitenSkjerm = styled.div`
-    @media screen and (min-width: 946px) {
+    @media screen and (min-width: 990px) {
         display: none;
     }
 
-    @media screen and (max-width: 760px) {
+    @media screen and (max-width: 815px) {
         display: none;
     }
 `;
 
 const TagsStorSkjerm = styled.div`
-    @media screen and (max-width: 946px) {
+    @media screen and (max-width: 990px) {
         display: none;
     }
 `;
@@ -72,7 +72,7 @@ export const PersonHeaderWrapper = styled(Sticky)`
     top: 55px;
 
     .visittkort {
-        padding: 0 1.5rem;
+        padding-left: 1.5rem;
         border-bottom: none;
     }
 `;
@@ -87,6 +87,28 @@ const StyledHamburgermeny = styled(PersonHeaderHamburgermeny)`
 
 const ElementWrapper = styled.div`
     margin-left: 1rem;
+`;
+
+const TagsKnyttetTilPerson = styled.div`
+    display: flex;
+    gap: 1rem;
+    margin-left: 1rem;
+
+    @media screen and (max-width: 690px) {
+        display: none;
+    }
+`;
+
+const PersonTagsLitenSkjerm = styled(Tag)`
+    @media screen and (min-width: 760px) {
+        display: none;
+    }
+`;
+
+const PersonTagsStorSkjerm = styled(Tag)`
+    @media screen and (max-width: 760px) {
+        display: none;
+    }
 `;
 
 const PersonHeaderComponent: FC<{ data: IPersonopplysninger; behandling?: Behandling }> = ({
@@ -169,54 +191,66 @@ const PersonHeaderComponent: FC<{ data: IPersonopplysninger; behandling?: Behand
                     </ResponsivLenke>
                 }
             >
-                {folkeregisterpersonstatus && (
-                    <ElementWrapper>
+                <TagsKnyttetTilPerson>
+                    {folkeregisterpersonstatus && (
                         <PersonStatusVarsel folkeregisterpersonstatus={folkeregisterpersonstatus} />
-                    </ElementWrapper>
-                )}
-                {adressebeskyttelse && (
-                    <ElementWrapper>
+                    )}
+                    {adressebeskyttelse && (
                         <AdressebeskyttelseVarsel adressebeskyttelse={adressebeskyttelse} />
-                    </ElementWrapper>
-                )}
-                {alder && alder < 18 && (
-                    <ElementWrapper>
-                        <Tag variant={'warning'} size={'small'}>
-                            Under 18 år
-                        </Tag>
-                    </ElementWrapper>
-                )}
-                {egenAnsatt && (
-                    <ElementWrapper>
-                        <Tag variant={'warning'} size={'small'}>
-                            Egen ansatt
-                        </Tag>
-                    </ElementWrapper>
-                )}
-                {fullmakt.some((f) => erEtterDagensDato(f.gyldigTilOgMed)) && (
-                    <ElementWrapper>
-                        <Tag variant={'warning'} size={'small'}>
-                            Fullmakt
-                        </Tag>
-                    </ElementWrapper>
-                )}
+                    )}
+                    {alder && alder < 18 && (
+                        <>
+                            <PersonTagsStorSkjerm variant={'warning'} size={'small'}>
+                                Under 18 år
+                            </PersonTagsStorSkjerm>
+                            <PersonTagsLitenSkjerm variant={'warning'} size={'small'}>
+                                U18
+                            </PersonTagsLitenSkjerm>
+                        </>
+                    )}
+                    {egenAnsatt && (
+                        <>
+                            <PersonTagsStorSkjerm variant={'warning'} size={'small'}>
+                                Egen ansatt
+                            </PersonTagsStorSkjerm>
+                            <PersonTagsLitenSkjerm variant={'warning'} size={'small'}>
+                                E..
+                            </PersonTagsLitenSkjerm>
+                        </>
+                    )}
+                    {fullmakt.some((f) => erEtterDagensDato(f.gyldigTilOgMed)) && (
+                        <>
+                            <PersonTagsStorSkjerm variant={'warning'} size={'small'}>
+                                Fullmakt
+                            </PersonTagsStorSkjerm>
+                            <PersonTagsLitenSkjerm variant={'warning'} size={'small'}>
+                                F..
+                            </PersonTagsLitenSkjerm>
+                        </>
+                    )}
 
-                {vergemål.length > 0 && (
-                    <ElementWrapper>
-                        <Tag variant={'warning'} size={'small'}>
-                            Verge
-                        </Tag>
-                    </ElementWrapper>
-                )}
+                    {vergemål.length > 0 && (
+                        <>
+                            <PersonTagsStorSkjerm variant={'warning'} size={'small'}>
+                                Verge
+                            </PersonTagsStorSkjerm>
+                            <PersonTagsLitenSkjerm variant={'warning'} size={'small'}>
+                                V..
+                            </PersonTagsLitenSkjerm>
+                        </>
+                    )}
 
-                {erMigrert && (
-                    <ElementWrapper>
-                        <Tag variant={'warning'} size={'small'}>
-                            Migrert
-                        </Tag>
-                    </ElementWrapper>
-                )}
-
+                    {erMigrert && (
+                        <>
+                            <PersonTagsStorSkjerm variant={'warning'} size={'small'}>
+                                Migrert
+                            </PersonTagsStorSkjerm>
+                            <PersonTagsLitenSkjerm variant={'warning'} size={'small'}>
+                                M..
+                            </PersonTagsLitenSkjerm>
+                        </>
+                    )}
+                </TagsKnyttetTilPerson>
                 <TagsKnyttetTilBehandling>
                     {behandling && (
                         <ElementWrapper>

--- a/src/frontend/Felles/PersonHeader/Status/StatusElementer.tsx
+++ b/src/frontend/Felles/PersonHeader/Status/StatusElementer.tsx
@@ -69,7 +69,7 @@ export const Statuser = styled.div`
 
     white-space: nowrap;
 
-    @media screen and (max-width: 1540px) {
+    @media screen and (max-width: 1750px) {
         display: none;
     }
 `;
@@ -81,7 +81,7 @@ export const StatuserLitenSkjerm = styled.div`
 
     white-space: nowrap;
 
-    @media screen and (min-width: 1540px) {
+    @media screen and (min-width: 1750px) {
         display: none;
     }
 `;


### PR DESCRIPTION
Oppgave på favro: [Tea-10390](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10390)

### Hva er gjort?
Lagt til nye brekkepunkter i `PersonHeader` for å slippe at menyen forsvinner og at resizing av vinduer skal bli litt smoothere. Er også lagt inn kortere titler på noen tags slik at de tar mindre plass på liten skjerm. 

### Disclaimers
- Det er ikke gjort endringer i `HeaderMedSøk` (den svarte) selvom det stod i oppgaven fordi den ikke er et problem før på veldig liten skjerm og krever oppdatering av `familie-header`. 

### Video ✨
![Ny header](https://user-images.githubusercontent.com/46678893/212064209-7400a495-c478-4904-a08f-98282135a76e.gif)
