### PR TITLE
Sett på vent infostripe og ta av vent funksjonalitet

### DIFF
--- a/src/frontend/App/context/BehandlingContext.tsx
+++ b/src/frontend/App/context/BehandlingContext.tsx
@@ -62,7 +62,7 @@ const [BehandlingProvider, useBehandling] = constate(() => {
     }, []);
 
     const [visHenleggModal, settVisHenleggModal] = useState(false);
-    const [visSettpåVentModal, settVisSettpåVentModal] = useState(false);
+    const [visSettPåVentModal, settVisSettPåVentModal] = useState(false);
     const [åpenHøyremeny, settÅpenHøyremeny] = useState(true);
 
     return {
@@ -77,8 +77,8 @@ const [BehandlingProvider, useBehandling] = constate(() => {
         regler,
         visHenleggModal,
         settVisHenleggModal,
-        visSettpåVentModal,
-        settVisSettpåVentModal,
+        visSettPåVentModal,
+        settVisSettPåVentModal,
         åpenHøyremeny,
         settÅpenHøyremeny,
         utestengelser,

--- a/src/frontend/App/context/BehandlingContext.tsx
+++ b/src/frontend/App/context/BehandlingContext.tsx
@@ -63,6 +63,7 @@ const [BehandlingProvider, useBehandling] = constate(() => {
 
     const [visHenleggModal, settVisHenleggModal] = useState(false);
     const [visSettPåVentModal, settVisSettPåVentModal] = useState(false);
+    const [visTaAvVentModal, settVisTaAvVentModal] = useState(false);
     const [åpenHøyremeny, settÅpenHøyremeny] = useState(true);
 
     return {
@@ -82,6 +83,8 @@ const [BehandlingProvider, useBehandling] = constate(() => {
         åpenHøyremeny,
         settÅpenHøyremeny,
         utestengelser,
+        visTaAvVentModal,
+        settVisTaAvVentModal,
     };
 });
 

--- a/src/frontend/App/context/BehandlingContext.tsx
+++ b/src/frontend/App/context/BehandlingContext.tsx
@@ -9,7 +9,7 @@ import { useHentBehandlingHistorikk } from '../hooks/useHentBehandlingHistorikk'
 import { useHentTotrinnskontroll } from '../hooks/useHentTotrinnStatus';
 import { useHentRegler } from '../hooks/useHentRegler';
 import { RessursStatus } from '../typer/ressurs';
-import { erBehandlingRedigerbar } from '../typer/behandlingstatus';
+import { erBehandlingRedigerbar, ETaAvVentStatus } from '../typer/behandlingstatus';
 import { useApp } from './AppContext';
 import { useHentUtestengelser } from '../hooks/useHentUtestengelser';
 
@@ -63,7 +63,7 @@ const [BehandlingProvider, useBehandling] = constate(() => {
 
     const [visHenleggModal, settVisHenleggModal] = useState(false);
     const [visSettPåVentModal, settVisSettPåVentModal] = useState(false);
-    const [visTaAvVentModal, settVisTaAvVentModal] = useState(false);
+    const [taAvVentStatus, settTaAvVentStatus] = useState<ETaAvVentStatus>();
     const [åpenHøyremeny, settÅpenHøyremeny] = useState(true);
 
     return {
@@ -83,8 +83,8 @@ const [BehandlingProvider, useBehandling] = constate(() => {
         åpenHøyremeny,
         settÅpenHøyremeny,
         utestengelser,
-        visTaAvVentModal,
-        settVisTaAvVentModal,
+        taAvVentStatus,
+        settTaAvVentStatus,
     };
 });
 

--- a/src/frontend/App/typer/behandlingstatus.ts
+++ b/src/frontend/App/typer/behandlingstatus.ts
@@ -25,3 +25,13 @@ export const erBehandlingUnderArbeid = (behandling: Behandling): boolean =>
     [BehandlingStatus.OPPRETTET, BehandlingStatus.UTREDES, BehandlingStatus.FATTER_VEDTAK].includes(
         behandling.status
     );
+
+export enum ETaAvVentStatus {
+    OK = 'OK',
+    ANNEN_BEHANDLING_MÅ_FERDIGSTILLES = 'ANNEN_BEHANDLING_MÅ_FERDIGSTILLES',
+    MÅ_NULSTILLE_VEDTAK = 'MÅ_NULSTILLE_VEDTAK',
+}
+
+export type TaAvVentStatus = {
+    status: ETaAvVentStatus;
+};

--- a/src/frontend/Felles/PersonHeader/PersonHeaderHamburgermeny.tsx
+++ b/src/frontend/Felles/PersonHeader/PersonHeaderHamburgermeny.tsx
@@ -5,7 +5,7 @@ import { useToggles } from '../../App/context/TogglesContext';
 import { Hamburgermeny } from '../Hamburgermeny/Hamburgermeny';
 
 export const PersonHeaderHamburgermeny = () => {
-    const { settVisHenleggModal, settVisSettpåVentModal } = useBehandling();
+    const { settVisHenleggModal, settVisSettPåVentModal } = useBehandling();
     const { toggles } = useToggles();
 
     const skalViseSettPåVentKnapp = toggles[ToggleName.visSettPåVentKnapp];
@@ -20,7 +20,7 @@ export const PersonHeaderHamburgermeny = () => {
     if (skalViseSettPåVentKnapp) {
         menyvalg.push({
             tekst: 'Sett på vent',
-            onClick: () => settVisSettpåVentModal(true),
+            onClick: () => settVisSettPåVentModal(true),
         });
     }
 

--- a/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
@@ -16,6 +16,7 @@ import { InfostripeUtestengelse } from './InfostripeUtestengelse';
 import { ABorderDefault } from '@navikt/ds-tokens/dist/tokens';
 import { SettPåVentModal } from './SettPåVent/SettPåVentModal';
 import { InfostripeSattPåVent } from './SettPåVent/InfostripeSattPåVent';
+import { TaAvVentModal } from './SettPåVent/TaAvVentModal';
 
 const Container = styled.div`
     display: flex;
@@ -81,6 +82,7 @@ const BehandlingContent: FC<{
                     <BehandlingRoutes />
                     <HenleggModal behandling={behandling} />
                     <SettPåVentModal behandlingId={behandling.id} />
+                    <TaAvVentModal behandlingId={behandling.id} />
                 </InnholdWrapper>
                 <HøyreMenyWrapper åpenHøyremeny={åpenHøyremeny}>
                     <Høyremeny åpenHøyremeny={åpenHøyremeny} behandlingId={behandling.id} />

--- a/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
@@ -15,6 +15,7 @@ import { useSetPersonIdent } from '../../App/hooks/useSetPersonIdent';
 import { InfostripeUtestengelse } from './InfostripeUtestengelse';
 import { ABorderDefault } from '@navikt/ds-tokens/dist/tokens';
 import { SettPåVentModal } from './SettPåVent/SettPåVentModal';
+import { InfostripeSattPåVent } from './SettPåVent/InfostripeSattPåVent';
 
 const Container = styled.div`
     display: flex;
@@ -76,6 +77,7 @@ const BehandlingContent: FC<{
                 <InnholdWrapper åpenHøyremeny={åpenHøyremeny}>
                     <Fanemeny behandlingId={behandling.id} />
                     <InfostripeUtestengelse utestengelser={utestengelser} />
+                    <InfostripeSattPåVent behandling={behandling} />
                     <BehandlingRoutes />
                     <HenleggModal behandling={behandling} />
                     <SettPåVentModal behandlingId={behandling.id} />

--- a/src/frontend/Komponenter/Behandling/SettPåVent/InfostripeSattPåVent.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/InfostripeSattPåVent.tsx
@@ -1,0 +1,17 @@
+import React, { FC } from 'react';
+import { Alert } from '@navikt/ds-react';
+import styled from 'styled-components';
+import { Behandling } from '../../../App/typer/fagsak';
+import { BehandlingStatus } from '../../../App/typer/behandlingstatus';
+
+const InformasjonVisning = styled(Alert)`
+    margin: 0.5rem 0.5rem 0 0.5rem;
+`;
+
+export const InfostripeSattPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
+    return behandling.status === BehandlingStatus.SATT_PÅ_VENT ? (
+        <InformasjonVisning variant={'info'} size={'small'}>
+            Behandlingen er satt på vent
+        </InformasjonVisning>
+    ) : null;
+};

--- a/src/frontend/Komponenter/Behandling/SettPåVent/InfostripeSattPåVent.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/InfostripeSattPåVent.tsx
@@ -1,17 +1,27 @@
 import React, { FC } from 'react';
-import { Alert } from '@navikt/ds-react';
+import { Alert, Button } from '@navikt/ds-react';
 import styled from 'styled-components';
 import { Behandling } from '../../../App/typer/fagsak';
 import { BehandlingStatus } from '../../../App/typer/behandlingstatus';
+import { useBehandling } from '../../../App/context/BehandlingContext';
 
 const InformasjonVisning = styled(Alert)`
     margin: 0.5rem 0.5rem 0 0.5rem;
 `;
 
+const StyledButton = styled(Button)`
+    margin-left: 1rem;
+`;
+
 export const InfostripeSattPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
+    const { settVisTaAvVentModal } = useBehandling();
+
     return behandling.status === BehandlingStatus.SATT_PÅ_VENT ? (
-        <InformasjonVisning variant={'info'} size={'small'}>
+        <InformasjonVisning variant={'info'} size={'medium'}>
             Behandlingen er satt på vent
+            <StyledButton size={'small'} onClick={() => settVisTaAvVentModal(true)}>
+                Fortsett behandling
+            </StyledButton>
         </InformasjonVisning>
     ) : null;
 };

--- a/src/frontend/Komponenter/Behandling/SettPåVent/InfostripeSattPåVent.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/InfostripeSattPåVent.tsx
@@ -1,9 +1,12 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 import { Alert, Button } from '@navikt/ds-react';
 import styled from 'styled-components';
 import { Behandling } from '../../../App/typer/fagsak';
 import { BehandlingStatus } from '../../../App/typer/behandlingstatus';
 import { useBehandling } from '../../../App/context/BehandlingContext';
+import { useApp } from '../../../App/context/AppContext';
+import { RessursStatus } from '@navikt/familie-typer';
+import { RessursFeilet, RessursSuksess } from '../../../App/typer/ressurs';
 
 const InformasjonVisning = styled(Alert)`
     margin: 0.5rem 0.5rem 0 0.5rem;
@@ -14,14 +17,50 @@ const StyledButton = styled(Button)`
 `;
 
 export const InfostripeSattPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
-    const { settVisTaAvVentModal } = useBehandling();
+    const { settVisTaAvVentModal, hentBehandling } = useBehandling();
+    const { axiosRequest } = useApp();
 
-    return behandling.status === BehandlingStatus.SATT_PÅ_VENT ? (
-        <InformasjonVisning variant={'info'} size={'medium'}>
-            Behandlingen er satt på vent
-            <StyledButton size={'small'} onClick={() => settVisTaAvVentModal(true)}>
-                Fortsett behandling
-            </StyledButton>
-        </InformasjonVisning>
-    ) : null;
+    const [feilmelding, settFeilmelding] = useState('');
+
+    const taAvVent = () => {
+        axiosRequest<string, null>({
+            method: 'POST',
+            url: `/familie-ef-sak/api/behandling/${behandling.id}/aktiver`,
+        }).then((respons: RessursFeilet | RessursSuksess<string>) => {
+            if (respons.status == RessursStatus.SUKSESS) {
+                hentBehandling.rerun();
+            } else {
+                settFeilmelding(respons.frontendFeilmelding);
+            }
+        });
+    };
+
+    const håndterFortsettBehandling = () => {
+        axiosRequest<boolean, null>({
+            method: 'GET',
+            url: `/familie-ef-sak/api/behandling/${behandling.id}/har-nyere-vedtak`,
+        }).then((respons: RessursFeilet | RessursSuksess<boolean>) => {
+            if (respons.status == RessursStatus.SUKSESS) {
+                respons.data ? settVisTaAvVentModal(true) : taAvVent();
+            } else {
+                return 'Feilet';
+            }
+        });
+    };
+
+    return (
+        <>
+            {behandling.status === BehandlingStatus.SATT_PÅ_VENT && (
+                <InformasjonVisning variant={'info'} size={'medium'}>
+                    Behandlingen er satt på vent
+                    <StyledButton size={'small'} onClick={håndterFortsettBehandling}>
+                        Fortsett behandling
+                    </StyledButton>
+                </InformasjonVisning>
+            )}
+            {feilmelding && (
+                <Alert variant="error">Kunne ikke ta behandling av vent: {feilmelding} </Alert>
+            )}
+        </>
+    );
 };

--- a/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVentModal.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVentModal.tsx
@@ -58,7 +58,7 @@ export const SettPåVentModal: FC<{ behandlingId: string }> = ({ behandlingId })
                 },
                 lukkKnapp: { onClick: () => settVisSettPåVentModal(false), tekst: 'Avbryt' },
             }}
-            ariaLabel={'Velg årsak til henleggelse av behandlingen'}
+            ariaLabel={'Sett behandling på vent'}
         >
             Behandlingen settes på vent, men du må inntil videre huske å oppdatere oppgaven i Gosys
             i henhold til gjeldene venterutiner.

--- a/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVentModal.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVentModal.tsx
@@ -11,7 +11,7 @@ const AlertStripe = styled(Alert)`
 `;
 
 export const SettPåVentModal: FC<{ behandlingId: string }> = ({ behandlingId }) => {
-    const { visSettpåVentModal, settVisSettpåVentModal, hentBehandling } = useBehandling();
+    const { visSettPåVentModal, settVisSettPåVentModal, hentBehandling } = useBehandling();
 
     const { axiosRequest } = useApp();
 
@@ -20,7 +20,7 @@ export const SettPåVentModal: FC<{ behandlingId: string }> = ({ behandlingId })
 
     const lukkModal = () => {
         settFeilmelding('');
-        settVisSettpåVentModal(false);
+        settVisSettPåVentModal(false);
     };
 
     const settPåVent = () => {
@@ -48,15 +48,15 @@ export const SettPåVentModal: FC<{ behandlingId: string }> = ({ behandlingId })
     return (
         <ModalWrapper
             tittel={'Sett behandling på vent'}
-            visModal={visSettpåVentModal}
-            onClose={() => settVisSettpåVentModal(false)}
+            visModal={visSettPåVentModal}
+            onClose={() => settVisSettPåVentModal(false)}
             aksjonsknapper={{
                 hovedKnapp: {
                     onClick: () => settPåVent(),
                     tekst: 'Sett på vent',
                     disabled: låsKnapp,
                 },
-                lukkKnapp: { onClick: () => settVisSettpåVentModal(false), tekst: 'Avbryt' },
+                lukkKnapp: { onClick: () => settVisSettPåVentModal(false), tekst: 'Avbryt' },
             }}
             ariaLabel={'Velg årsak til henleggelse av behandlingen'}
         >

--- a/src/frontend/Komponenter/Behandling/SettPåVent/TaAvVentModal.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/TaAvVentModal.tsx
@@ -1,22 +1,33 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import { useBehandling } from '../../../App/context/BehandlingContext';
 import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../App/typer/ressurs';
 import { useApp } from '../../../App/context/AppContext';
 import { ModalWrapper } from '../../../Felles/Modal/ModalWrapper';
 import { Alert } from '@navikt/ds-react';
 import styled from 'styled-components';
+import { ETaAvVentStatus } from '../../../App/typer/behandlingstatus';
 
 const AlertStripe = styled(Alert)`
     margin-top: 1rem;
 `;
 
 export const TaAvVentModal: FC<{ behandlingId: string }> = ({ behandlingId }) => {
-    const { visTaAvVentModal, settVisTaAvVentModal, hentBehandling } = useBehandling();
+    const { taAvVentStatus, hentBehandling } = useBehandling();
+    const [visTaAvVentModal, settVisTaAvVentModal] = useState(false);
 
     const { axiosRequest } = useApp();
 
     const [låsKnapp, settLåsKnapp] = useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState<string>();
+
+    useEffect(() => {
+        if (
+            taAvVentStatus === ETaAvVentStatus.ANNEN_BEHANDLING_MÅ_FERDIGSTILLES ||
+            taAvVentStatus === ETaAvVentStatus.MÅ_NULSTILLE_VEDTAK
+        ) {
+            settVisTaAvVentModal(true);
+        }
+    }, [taAvVentStatus]);
 
     const lukkModal = () => {
         settFeilmelding('');
@@ -45,16 +56,23 @@ export const TaAvVentModal: FC<{ behandlingId: string }> = ({ behandlingId }) =>
             .finally(() => settLåsKnapp(false));
     };
 
+    const tittel =
+        taAvVentStatus === ETaAvVentStatus.MÅ_NULSTILLE_VEDTAK
+            ? 'Behandlingen kan miste data!'
+            : 'Kan ikke ta behandling av vent';
+
     return (
         <ModalWrapper
-            tittel={'Sett behandling på vent'}
+            tittel={tittel}
             visModal={visTaAvVentModal}
             onClose={() => settVisTaAvVentModal(false)}
             aksjonsknapper={{
                 hovedKnapp: {
                     onClick: () => taAvVent(),
                     tekst: 'Fortsett behandling og tilbakestill data',
-                    disabled: låsKnapp,
+                    disabled:
+                        låsKnapp ||
+                        taAvVentStatus === ETaAvVentStatus.ANNEN_BEHANDLING_MÅ_FERDIGSTILLES,
                 },
                 lukkKnapp: {
                     onClick: () => settVisTaAvVentModal(false),
@@ -63,12 +81,23 @@ export const TaAvVentModal: FC<{ behandlingId: string }> = ({ behandlingId }) =>
             }}
             ariaLabel={'Fortsett behandling'}
         >
-            Så flott at du vil fortsette behandlingen. Siden det har blitt fattet et annet vedtak på
-            denne fagsaken i tidsrommet denne behandlingen har vært på vent, er vi nødt til å
-            tilbakestille vedtak og beregningssiden, samt brevsiden. Dette fordi det forrige
-            vedtaket kan ha påvirket denne behandlingen. Ligger det informasjon på disse sidene du
-            vil ha med videre må du velge “AVBRYT”, deretter kopiere det du vil ta vare på, og så ta
-            den av vent.
+            {taAvVentStatus === ETaAvVentStatus.ANNEN_BEHANDLING_MÅ_FERDIGSTILLES && (
+                <>Behandling kan ikke tas av vent før annen behandling er ferdigstilt.</>
+            )}
+            {taAvVentStatus === ETaAvVentStatus.MÅ_NULSTILLE_VEDTAK && (
+                <>
+                    Siden det har blitt fattet et annet vedtak på denne fagsaken i tidsrommet denne
+                    behandlingen har vært på vent, er vi nødt til å tilbakestille vedtak- og
+                    beregningssiden og brevsiden. Dette er fordi det forrige vedtaket kan påvirke
+                    denne behandlingen.
+                    <br />
+                    <br />
+                    Hvis det ligger informasjon på en av disse sidene som du vil ha med videre, må
+                    du velge "AVBRYT". Deretter kopierer du det du vil ta vare på før du tar
+                    behandlingen av vent.
+                </>
+            )}
+
             {feilmelding && <AlertStripe variant={'error'}>{feilmelding}</AlertStripe>}
         </ModalWrapper>
     );

--- a/src/frontend/Komponenter/Behandling/SettPåVent/TaAvVentModal.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/TaAvVentModal.tsx
@@ -23,7 +23,7 @@ export const TaAvVentModal: FC<{ behandlingId: string }> = ({ behandlingId }) =>
         settVisTaAvVentModal(false);
     };
 
-    const fortsettBehandling = () => {
+    const taAvVent = () => {
         if (låsKnapp) {
             return;
         }
@@ -52,7 +52,7 @@ export const TaAvVentModal: FC<{ behandlingId: string }> = ({ behandlingId }) =>
             onClose={() => settVisTaAvVentModal(false)}
             aksjonsknapper={{
                 hovedKnapp: {
-                    onClick: () => fortsettBehandling(),
+                    onClick: () => taAvVent(),
                     tekst: 'Fortsett behandling og tilbakestill data',
                     disabled: låsKnapp,
                 },

--- a/src/frontend/Komponenter/Behandling/SettPåVent/TaAvVentModal.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/TaAvVentModal.tsx
@@ -1,0 +1,75 @@
+import React, { FC, useState } from 'react';
+import { useBehandling } from '../../../App/context/BehandlingContext';
+import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../App/typer/ressurs';
+import { useApp } from '../../../App/context/AppContext';
+import { ModalWrapper } from '../../../Felles/Modal/ModalWrapper';
+import { Alert } from '@navikt/ds-react';
+import styled from 'styled-components';
+
+const AlertStripe = styled(Alert)`
+    margin-top: 1rem;
+`;
+
+export const TaAvVentModal: FC<{ behandlingId: string }> = ({ behandlingId }) => {
+    const { visTaAvVentModal, settVisTaAvVentModal, hentBehandling } = useBehandling();
+
+    const { axiosRequest } = useApp();
+
+    const [låsKnapp, settLåsKnapp] = useState<boolean>(false);
+    const [feilmelding, settFeilmelding] = useState<string>();
+
+    const lukkModal = () => {
+        settFeilmelding('');
+        settVisTaAvVentModal(false);
+    };
+
+    const fortsettBehandling = () => {
+        if (låsKnapp) {
+            return;
+        }
+
+        settLåsKnapp(true);
+
+        axiosRequest<string, null>({
+            method: 'POST',
+            url: `/familie-ef-sak/api/behandling/${behandlingId}/aktiver`,
+        })
+            .then((respons: RessursFeilet | RessursSuksess<string>) => {
+                if (respons.status == RessursStatus.SUKSESS) {
+                    hentBehandling.rerun();
+                    lukkModal();
+                } else {
+                    settFeilmelding(respons.frontendFeilmelding);
+                }
+            })
+            .finally(() => settLåsKnapp(false));
+    };
+
+    return (
+        <ModalWrapper
+            tittel={'Sett behandling på vent'}
+            visModal={visTaAvVentModal}
+            onClose={() => settVisTaAvVentModal(false)}
+            aksjonsknapper={{
+                hovedKnapp: {
+                    onClick: () => fortsettBehandling(),
+                    tekst: 'Fortsett behandling og tilbakestill data',
+                    disabled: låsKnapp,
+                },
+                lukkKnapp: {
+                    onClick: () => settVisTaAvVentModal(false),
+                    tekst: 'Avbryt',
+                },
+            }}
+            ariaLabel={'Fortsett behandling'}
+        >
+            Så flott at du vil fortsette behandlingen. Siden det har blitt fattet et annet vedtak på
+            denne fagsaken i tidsrommet denne behandlingen har vært på vent, er vi nødt til å
+            tilbakestille vedtak og beregningssiden, samt brevsiden. Dette fordi det forrige
+            vedtaket kan ha påvirket denne behandlingen. Ligger det informasjon på disse sidene du
+            vil ha med videre må du velge “AVBRYT”, deretter kopiere det du vil ta vare på, og så ta
+            den av vent.
+            {feilmelding && <AlertStripe variant={'error'}>{feilmelding}</AlertStripe>}
+        </ModalWrapper>
+    );
+};


### PR DESCRIPTION
Oppgave [Tea-10972](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10872)

### Hva er gjort? 🤔
- Lagt inn info-alert hvis en behandling er satt på vent, med tekst og knapp for å "fortsette behandling"
- Ved trykk på knapp vurderes det om behandlingen kan tas av vent uten å nullstille data. Se [PR 2020](https://github.com/navikt/familie-ef-sak/pull/2020) i familie-ef-sak
  - Hvis ja tas behandling av vent
  - Hvis nei vises en modal om at det er mulig data blir sletta/nullstilt

### Disclaimers 🔥
- Det er per nå ikke mulig å opprette en ny behandling på samme fagsak om den er på vent, så modalen vil aldri vises før dette legges inn. 
- Mangler funksjonalitet for å nullstille dersom det er nødvendig  

### Bilder 🎨
Satt på vent:
<img width="1172" alt="image" src="https://user-images.githubusercontent.com/46678893/212335003-b4afe777-18d3-47ce-83aa-15b0f5030c20.png">

`taAvVentStatus = ANNEN_BEHANDLING_MÅ_FERDIGSTILLES`:
![image](https://user-images.githubusercontent.com/46678893/212702651-4a8693a8-67d4-4d2f-b30a-fcd4128dcf02.png)

`taAvVentStatus = MÅ_NULSTILLE_VEDTAK`:
![image](https://user-images.githubusercontent.com/46678893/212702165-4ec46eb0-4b5e-4fb5-87e3-c0b1ef9d5908.png)

Det finnes **ikke** nyere vedtak -> går rett tilbake til vanlig visning (`taAvVentStatus = OK`): 
<img width="1722" alt="image" src="https://user-images.githubusercontent.com/46678893/212335326-cb388452-3250-4c36-9e14-ad1ecfef66ed.png">