### PR TITLE
Endre padding på "Må håndteres i gosys"

### DIFF
--- a/src/frontend/Komponenter/Oppgavebenk/OppgaveRad.tsx
+++ b/src/frontend/Komponenter/Oppgavebenk/OppgaveRad.tsx
@@ -176,7 +176,7 @@ const OppgaveRad: React.FC<Props> = ({ oppgave, mapper, settFeilmelding }) => {
                 );
             default:
                 return (
-                    <BodyShortSmall style={{ marginLeft: '2.5rem' }}>
+                    <BodyShortSmall style={{ marginLeft: '0.75rem' }}>
                         Må håndteres i Gosys
                     </BodyShortSmall>
                 );


### PR DESCRIPTION
Oppgave [Tea-10797](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10797)

Løst ved å sette margin-left til samme som for knapper så det matcher resten av radene: 
![image](https://user-images.githubusercontent.com/46678893/212356124-9d8826e1-b50a-4031-9ff1-8c99c51dbf88.png)
