### PR TITLE
Sorterer behandlinger i behandlingsoversikten etter vedtakstidspunkt …

### DIFF
--- a/src/frontend/App/utils/behandlingutil.ts
+++ b/src/frontend/App/utils/behandlingutil.ts
@@ -1,0 +1,19 @@
+import { compareDesc } from 'date-fns';
+
+/**
+ * Sorterer behandlinger etter vedtaksdato
+ * Hvis vedtaksdato ikke finnes på noen av behandlingene, sorteres de etter opprettet
+ * Hvis vedtaksdato ikke finnes på en av behandlingene sorteres null/undefined først
+ */
+export const sorterBehandlinger = <T extends { vedtaksdato?: string; opprettet: string }>(
+    a: T,
+    b: T
+): number => {
+    if (a.vedtaksdato && b.vedtaksdato) {
+        return compareDesc(new Date(a.vedtaksdato), new Date(b.vedtaksdato));
+    }
+    if (!a.vedtaksdato && !b.vedtaksdato) {
+        return compareDesc(new Date(a.opprettet), new Date(b.opprettet));
+    }
+    return a.vedtaksdato ? 1 : -1;
+};

--- a/src/frontend/App/utils/typeutil.ts
+++ b/src/frontend/App/utils/typeutil.ts
@@ -1,0 +1,1 @@
+export const erString = (verdi: unknown): verdi is string => typeof verdi === 'string';

--- a/src/frontend/App/utils/typeutil.ts
+++ b/src/frontend/App/utils/typeutil.ts
@@ -1,1 +1,0 @@
-export const erString = (verdi: unknown): verdi is string => typeof verdi === 'string';

--- a/src/frontend/Komponenter/Personoversikt/BehandlingsoversiktTabell.tsx
+++ b/src/frontend/Komponenter/Personoversikt/BehandlingsoversiktTabell.tsx
@@ -30,7 +30,6 @@ import {
 } from '../../App/typer/klage';
 import { WarningColored } from '@navikt/ds-icons';
 import { Tooltip } from '@navikt/ds-react';
-import { erString } from '../../App/utils/typeutil';
 import { compareDesc } from 'date-fns';
 
 const StyledTable = styled.table`
@@ -77,21 +76,13 @@ export const sorterBehandlinger = (
     a: BehandlingsoversiktTabellBehandling,
     b: BehandlingsoversiktTabellBehandling
 ): number => {
-    const aVedtaksdato = a.vedtaksdato;
-    const bVedtaksdato = b.vedtaksdato;
-    if (!erString(aVedtaksdato) && !erString(bVedtaksdato)) {
+    if (a.vedtaksdato && b.vedtaksdato) {
+        return compareDesc(new Date(a.vedtaksdato), new Date(b.vedtaksdato));
+    }
+    if (!a.vedtaksdato && !b.vedtaksdato) {
         return compareDesc(new Date(a.opprettet), new Date(b.opprettet));
     }
-    if (erString(aVedtaksdato) && erString(bVedtaksdato)) {
-        return compareDesc(new Date(aVedtaksdato), new Date(bVedtaksdato));
-    }
-    if (erString(aVedtaksdato) && !erString(bVedtaksdato)) {
-        return 1;
-    }
-    if (!erString(aVedtaksdato) && erString(bVedtaksdato)) {
-        return -1;
-    }
-    return 0;
+    return a.vedtaksdato ? 1 : -1;
 };
 
 export const BehandlingsoversiktTabell: React.FC<{

--- a/src/frontend/Komponenter/Personoversikt/BehandlingsoversiktTabell.tsx
+++ b/src/frontend/Komponenter/Personoversikt/BehandlingsoversiktTabell.tsx
@@ -30,7 +30,7 @@ import {
 } from '../../App/typer/klage';
 import { WarningColored } from '@navikt/ds-icons';
 import { Tooltip } from '@navikt/ds-react';
-import { compareDesc } from 'date-fns';
+import { sorterBehandlinger } from '../../App/utils/behandlingutil';
 
 const StyledTable = styled.table`
     width: 60%;
@@ -66,24 +66,6 @@ interface BehandlingsoversiktTabellBehandling {
     applikasjon: BehandlingApplikasjon;
     klageinstansResultat?: KlageinstansResultat[];
 }
-
-/**
- * Sorterer behandlinger etter vedtaksdato
- * Hvis vedtaksdato ikke finnes på noen av behandlingene, sorteres de etter opprettet
- * Hvis vedtaksdato ikke finnes på en av behandlingene sorteres null/undefined først
- */
-export const sorterBehandlinger = (
-    a: BehandlingsoversiktTabellBehandling,
-    b: BehandlingsoversiktTabellBehandling
-): number => {
-    if (a.vedtaksdato && b.vedtaksdato) {
-        return compareDesc(new Date(a.vedtaksdato), new Date(b.vedtaksdato));
-    }
-    if (!a.vedtaksdato && !b.vedtaksdato) {
-        return compareDesc(new Date(a.opprettet), new Date(b.opprettet));
-    }
-    return a.vedtaksdato ? 1 : -1;
-};
 
 export const BehandlingsoversiktTabell: React.FC<{
     behandlinger: Behandling[];

--- a/src/frontend/Komponenter/Personoversikt/Vedtaksperioderoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Vedtaksperioderoversikt.tsx
@@ -14,7 +14,6 @@ import {
     IFagsakPerson,
     IFagsakPersonMedBehandlinger,
 } from '../../App/typer/fagsak';
-import { compareDesc } from 'date-fns';
 import { Stønadstype } from '../../App/typer/behandlingstema';
 import { BehandlingStatus } from '../../App/typer/behandlingstatus';
 import VedtaksperioderBarnetilsyn from './HistorikkVedtaksperioder/VedtaksperioderBarnetilsyn';
@@ -23,6 +22,7 @@ import { IVedtakForSkolepenger } from '../../App/typer/vedtak';
 import VedtaksperioderSkolepenger from './HistorikkVedtaksperioder/VedtaksperioderSkolepeger';
 import { useHentFagsakPersonUtvidet } from '../../App/hooks/useHentFagsakPerson';
 import { Checkbox, Select } from '@navikt/ds-react';
+import { sorterBehandlinger } from '../../App/utils/behandlingutil';
 
 const StyledInputs = styled.div`
     display: flex;
@@ -59,9 +59,7 @@ const filtrerBehandlinger = (fagsak: Fagsak): Behandling[] =>
     );
 
 const filtrerOgSorterBehandlinger = (fagsak: Fagsak): Behandling[] =>
-    filtrerBehandlinger(fagsak).sort((a, b) =>
-        compareDesc(new Date(a.opprettet), new Date(b.opprettet))
-    );
+    filtrerBehandlinger(fagsak).sort(sorterBehandlinger);
 
 interface VedtaksperioderProps {
     fagsak: Fagsak;


### PR DESCRIPTION
…eller opprettet tid

Fjerner sortering av behandlinger i behandlingsoversikten då den skaper trøbbel og at behandlinger burde være sortert på vedtaksdato for å gi et bra bilde

Pga at på-vent kan ha vedtakstidspunkt etter senere oppettet behandling sorteres de nå etter vedtakstidspunkt, og sen 

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10514


Før besluttning:
![image](https://user-images.githubusercontent.com/937168/213443689-d8f2deee-4359-427a-90bd-1db0bba85893.png)
Etter besluttning:
![image](https://user-images.githubusercontent.com/937168/213444189-e433fcb5-0426-49ca-99a1-3731d000c952.png)

Tidligere:
![image](https://user-images.githubusercontent.com/937168/213443831-0578bec0-b768-474c-b2f9-6acc4f67f358.png)
