### PR TITLE
Autoutfylling samordning hjemler

### DIFF
--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -16,4 +16,5 @@ export enum ToggleName {
     brukValidering8årHovedperiode = 'familie.ef.sak.frontend-bruk-validering-8ar-hovedperiode',
     automatiskeVedtaksdatoerBrev = 'familie.ef.sak.frontend.automatiskeVedtaksdatoer',
     visSettPåVentKnapp = 'familie.ef.sak.frontend.vis-sett-pa-vent-knapp',
+    automatiskeHjemlerBrev = 'familie.ef.sak.frontend.automatiske-hjemler-brev',
 }

--- a/src/frontend/App/hooks/useVerdierForBrev.ts
+++ b/src/frontend/App/hooks/useVerdierForBrev.ts
@@ -58,7 +58,10 @@ export const useVerdierForBrev = (
             const tilDato = formaterIsoDato(perioder[perioder.length - 1].periode.tildato);
             const fraDato = formaterIsoDato(perioder[0].periode.fradato);
 
-            if (erOvergangstønad(perioder) && toggles[ToggleName.automatiskeHjemlerBrev]) {
+            if (
+                innholderBeløpsperioderForOvergangsstønad(perioder) &&
+                toggles[ToggleName.automatiskeHjemlerBrev]
+            ) {
                 settValgfeltStore((prevState) => ({
                     ...prevState,
                     [EBehandlingValgfelt.avslutningHjemmel]: harSamordningsfradrag(perioder)
@@ -95,7 +98,7 @@ const harSamordningsfradrag = (beløpsperioder: IBeløpsperiode[]): boolean => {
     );
 };
 
-const erOvergangstønad = (
+const innholderBeløpsperioderForOvergangsstønad = (
     beløpsperioder: IBeløpsperiode[] | IBeregningsperiodeBarnetilsyn[]
 ): beløpsperioder is IBeløpsperiode[] => {
     return beløpsperioder.some(

--- a/src/frontend/App/hooks/useVerdierForBrev.ts
+++ b/src/frontend/App/hooks/useVerdierForBrev.ts
@@ -2,6 +2,8 @@ import { useEffect, useState } from 'react';
 import { formaterIsoDato } from '../utils/formatter';
 import { Ressurs, RessursStatus } from '../typer/ressurs';
 import { IBeløpsperiode, IBeregningsperiodeBarnetilsyn } from '../typer/vedtak';
+import { useToggles } from '../context/TogglesContext';
+import { ToggleName } from '../context/toggles';
 
 enum EBehandlingFlettefelt {
     fomdatoInnvilgelseForstegangsbehandling = 'fomdatoInnvilgelseForstegangsbehandling',
@@ -44,6 +46,7 @@ export const useVerdierForBrev = (
     const [flettefeltStore, settFlettefeltStore] = useState<FlettefeltStore>({});
     const [valgfeltStore, settValgfeltStore] = useState<ValgfeltStore>({});
     const [delmalStore, settDelmalStore] = useState<DelmalStore>([]);
+    const { toggles } = useToggles();
 
     useEffect(() => {
         if (
@@ -55,7 +58,7 @@ export const useVerdierForBrev = (
             const tilDato = formaterIsoDato(perioder[perioder.length - 1].periode.tildato);
             const fraDato = formaterIsoDato(perioder[0].periode.fradato);
 
-            if (erOvergangstønad(perioder)) {
+            if (erOvergangstønad(perioder) && toggles[ToggleName.automatiskeHjemlerBrev]) {
                 settValgfeltStore((prevState) => ({
                     ...prevState,
                     [EBehandlingValgfelt.avslutningHjemmel]: harSamordningsfradrag(perioder)

--- a/src/frontend/App/hooks/useVerdierForBrev.ts
+++ b/src/frontend/App/hooks/useVerdierForBrev.ts
@@ -20,19 +20,15 @@ enum EBehandlingValgfelt {
     avslutningHjemmel = 'avslutningHjemmel',
 }
 
-enum EBehandlingValgmulighet {
-    vedtakInneholderSamordning = 'hjemmelM1513',
-    vedtakInneholderIkkeSamordning = 'hjemmelInnvilgetTilbakeITidM1513',
+enum EValg {
+    hjemlerMedSamordning = 'hjemmelM1513',
+    hjemlerUtenSamordning = 'hjemmelInnvilgetTilbakeITidM1513',
 }
-
-type Valgmulighet = {
-    valgmulighet: string;
-};
 
 type IFlettefeltStore = { [navn: string]: string };
 
 export type IValgfeltStore = {
-    [valgfeltKategori: string]: Valgmulighet;
+    [valgfelt: string]: string;
 };
 
 export const useVerdierForBrev = (
@@ -59,8 +55,8 @@ export const useVerdierForBrev = (
                 settValgfeltStore({
                     ...valgfeltStore,
                     [EBehandlingValgfelt.avslutningHjemmel]: harSamordningsfradrag(perioder)
-                        ? { valgmulighet: EBehandlingValgmulighet.vedtakInneholderSamordning }
-                        : { valgmulighet: EBehandlingValgmulighet.vedtakInneholderIkkeSamordning },
+                        ? EValg.hjemlerMedSamordning
+                        : EValg.hjemlerUtenSamordning,
                 });
 
             const toggledeVedtaksdatoFlettefelter: { [flettefeltNavn: string]: string } = toggles[
@@ -85,11 +81,6 @@ export const useVerdierForBrev = (
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [beløpsperioder, toggles]);
-
-    useEffect(() => {
-        // eslint-disable-next-line no-console
-        console.log('valgfeltstore: ', valgfeltStore);
-    }, [valgfeltStore]);
 
     return { flettefeltStore, valgfeltStore };
 };

--- a/src/frontend/App/hooks/useVerdierForBrev.ts
+++ b/src/frontend/App/hooks/useVerdierForBrev.ts
@@ -89,7 +89,9 @@ export const useVerdierForBrev = (
 
 const harSamordningsfradrag = (beløpsperioder: IBeløpsperiode[]): boolean => {
     return beløpsperioder.some(
-        (beløpsperiode) => beløpsperiode.beregningsgrunnlag.samordningsfradrag
+        (beløpsperiode) =>
+            beløpsperiode.beregningsgrunnlag.samordningsfradrag &&
+            beløpsperiode.beregningsgrunnlag.samordningsfradrag > 0
     );
 };
 

--- a/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
@@ -9,7 +9,7 @@ import {
 } from './BrevTyper';
 import { v4 as uuidv4 } from 'uuid';
 import { Dispatch, SetStateAction } from 'react';
-import { IValgfeltStore } from '../../../App/hooks/useVerdierForBrev';
+import { FlettefeltStore, ValgfeltStore } from '../../../App/hooks/useVerdierForBrev';
 
 const lagTomtAvsnitt = (): AvsnittMedId => ({
     deloverskrift: '',
@@ -66,7 +66,7 @@ const hentVerdiFraMellomlagerEllerNull = (
 export const initFlettefelterMedVerdi = (
     brevStruktur: BrevStruktur,
     flettefeltFraMellomlager: FlettefeltMedVerdi[] | undefined,
-    flettefeltStore: { [flettefeltNavn: string]: string }
+    flettefeltStore: FlettefeltStore
 ): FlettefeltMedVerdi[] =>
     brevStruktur.flettefelter.flettefeltReferanse.map((flettefeltReferanse) => ({
         _ref: flettefeltReferanse._id,
@@ -78,7 +78,7 @@ export const initFlettefelterMedVerdi = (
 export const initValgteFelt = (
     valgteFeltFraMellomlager: ValgtFelt | undefined,
     brevStruktur: BrevStruktur,
-    valgfeltStore: IValgfeltStore
+    valgfeltStore: ValgfeltStore
 ): ValgtFelt => {
     const valgfeltMellomlager = Object.entries(valgteFeltFraMellomlager || {}).reduce(
         (acc, [valgfeltApiNavn, mulighet]) => {

--- a/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
@@ -9,6 +9,7 @@ import {
 } from './BrevTyper';
 import { v4 as uuidv4 } from 'uuid';
 import { Dispatch, SetStateAction } from 'react';
+import { IValgfeltStore } from '../../../App/hooks/useVerdierForBrev';
 
 const lagTomtAvsnitt = (): AvsnittMedId => ({
     deloverskrift: '',
@@ -74,34 +75,52 @@ export const initFlettefelterMedVerdi = (
             hentVerdiFraMellomlagerEllerNull(flettefeltFraMellomlager, flettefeltReferanse._id),
     }));
 
-export const initValgteFeltMedMellomlager = (
+export const initValgteFelt = (
     valgteFeltFraMellomlager: ValgtFelt | undefined,
-    brevStruktur: BrevStruktur
-): ValgtFelt =>
-    Object.entries(valgteFeltFraMellomlager || {}).reduce((acc, [valgfeltApiNavn, mulighet]) => {
-        const utledOppdaterteFlettefeltFraSanity = () =>
-            brevStruktur.dokument.delmalerSortert.flatMap((delmal) => {
-                const valgfelt = delmal.delmalValgfelt.find(
-                    (valgFelt) => valgFelt.valgFeltApiNavn === valgfeltApiNavn
-                );
+    brevStruktur: BrevStruktur,
+    valgfeltStore: IValgfeltStore
+): ValgtFelt => {
+    const valgfeltMellomlager = Object.entries(valgteFeltFraMellomlager || {}).reduce(
+        (acc, [valgfeltApiNavn, mulighet]) => {
+            const utledOppdaterteFlettefeltFraSanity = () =>
+                brevStruktur.dokument.delmalerSortert.flatMap((delmal) => {
+                    const valgfelt = delmal.delmalValgfelt.find(
+                        (valgFelt) => valgFelt.valgFeltApiNavn === valgfeltApiNavn
+                    );
 
-                const valgtValgmulighet = valgfelt?.valgMuligheter.find(
-                    (valgmulighet) => valgmulighet.valgmulighet === mulighet.valgmulighet
-                );
+                    const valgtValgmulighet = valgfelt?.valgMuligheter.find(
+                        (valgmulighet) => valgmulighet.valgmulighet === mulighet.valgmulighet
+                    );
 
-                const flettefeltFraSanity = valgtValgmulighet?.flettefelter || [];
+                    const flettefeltFraSanity = valgtValgmulighet?.flettefelter || [];
 
-                return flettefeltFraSanity;
-            });
+                    return flettefeltFraSanity;
+                });
 
-        return {
-            ...acc,
-            [valgfeltApiNavn]: {
-                ...mulighet,
-                flettefelter: utledOppdaterteFlettefeltFraSanity(),
-            },
-        };
+            return {
+                ...acc,
+                [valgfeltApiNavn]: {
+                    ...mulighet,
+                    flettefelter: utledOppdaterteFlettefeltFraSanity(),
+                },
+            };
+        },
+        {}
+    );
+
+    const automatiskeValgfelt = Object.entries(valgfeltStore).reduce((acc, [valgfelt, valg]) => {
+        const delmal = brevStruktur.dokument.delmalerSortert.find((delmal) =>
+            delmal.delmalValgfelt.some((v) => v.valgFeltApiNavn === valgfelt)
+        );
+
+        const valgmulighet = delmal?.delmalValgfelt
+            .find((v) => v.valgFeltApiNavn === valgfelt)
+            ?.valgMuligheter.find((valgmulighet) => valgmulighet.valgmulighet === valg);
+        return { ...acc, [valgfelt]: valgmulighet };
     }, {});
+
+    return { ...valgfeltMellomlager, ...automatiskeValgfelt };
+};
 
 export const harValgfeltFeil = (
     valgteFelt: ValgtFelt,

--- a/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
@@ -52,7 +52,7 @@ const Brevmeny: React.FC<BrevmenyProps> = (props) => {
         byggTomRessurs()
     );
     const { mellomlagretBrev } = useMellomlagringBrev(behandlingId);
-    const { flettefeltStore, valgfeltStore } = useVerdierForBrev(beløpsperioder);
+    const { flettefeltStore, valgfeltStore, delmalStore } = useVerdierForBrev(beløpsperioder);
     const { toggles } = useToggles();
 
     useEffect(() => {
@@ -165,6 +165,7 @@ const Brevmeny: React.FC<BrevmenyProps> = (props) => {
                                 }
                                 flettefeltStore={flettefeltStore}
                                 valgfeltStore={valgfeltStore}
+                                delmalStore={delmalStore}
                                 stønadstype={behandling.stønadstype}
                             />
                         ) : null

--- a/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
@@ -52,7 +52,7 @@ const Brevmeny: React.FC<BrevmenyProps> = (props) => {
         byggTomRessurs()
     );
     const { mellomlagretBrev } = useMellomlagringBrev(behandlingId);
-    const { flettefeltStore } = useVerdierForBrev(beløpsperioder);
+    const { flettefeltStore, valgfeltStore } = useVerdierForBrev(beløpsperioder);
     const { toggles } = useToggles();
 
     useEffect(() => {
@@ -164,6 +164,7 @@ const Brevmeny: React.FC<BrevmenyProps> = (props) => {
                                     (mellomlagretBrev as IMellomlagretBrevResponse)?.brevverdier
                                 }
                                 flettefeltStore={flettefeltStore}
+                                valgfeltStore={valgfeltStore}
                                 stønadstype={behandling.stønadstype}
                             />
                         ) : null

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
@@ -15,7 +15,7 @@ import {
     grupperDelmaler,
     harValgfeltFeil,
     initFlettefelterMedVerdi,
-    initValgteFeltMedMellomlager,
+    initValgteFelt,
 } from './BrevUtils';
 import { Ressurs } from '../../../App/typer/ressurs';
 import { useApp } from '../../../App/context/AppContext';
@@ -29,6 +29,7 @@ import { Alert, Heading, Panel } from '@navikt/ds-react';
 import { Stønadstype } from '../../../App/typer/behandlingstema';
 import { delmalTilUtregningstabellOS } from './UtregningstabellOvergangsstønad';
 import { delmalTilUtregningstabellBT } from './UtregningstabellBarnetilsyn';
+import { IValgfeltStore } from '../../../App/hooks/useVerdierForBrev';
 
 const BrevFelter = styled.div`
     display: flex;
@@ -52,6 +53,7 @@ export interface BrevmenyVisningProps extends BrevmenyProps {
     mellomlagretBrevVerdier?: string;
     brevMal: string;
     flettefeltStore: { [navn: string]: string };
+    valgfeltStore: IValgfeltStore;
     stønadstype: Stønadstype;
 }
 
@@ -66,6 +68,7 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
     brevMal,
     flettefeltStore,
     stønadstype,
+    valgfeltStore,
 }) => {
     const { axiosRequest } = useApp();
     const { mellomlagreSanitybrev } = useMellomlagringBrev(behandlingId);
@@ -81,7 +84,7 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
         settAlleFlettefelter(
             initFlettefelterMedVerdi(brevStruktur, flettefeltFraMellomlager, flettefeltStore)
         );
-        settValgteFelt(initValgteFeltMedMellomlager(valgteFeltFraMellomlager, brevStruktur));
+        settValgteFelt(initValgteFelt(valgteFeltFraMellomlager, brevStruktur, valgfeltStore));
         if (valgteDelmalerFraMellomlager) {
             settValgteDelmaler(valgteDelmalerFraMellomlager);
         }

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
@@ -29,7 +29,7 @@ import { Alert, Heading, Panel } from '@navikt/ds-react';
 import { Stønadstype } from '../../../App/typer/behandlingstema';
 import { delmalTilUtregningstabellOS } from './UtregningstabellOvergangsstønad';
 import { delmalTilUtregningstabellBT } from './UtregningstabellBarnetilsyn';
-import { IValgfeltStore } from '../../../App/hooks/useVerdierForBrev';
+import { DelmalStore, FlettefeltStore, ValgfeltStore } from '../../../App/hooks/useVerdierForBrev';
 
 const BrevFelter = styled.div`
     display: flex;
@@ -52,9 +52,10 @@ export interface BrevmenyVisningProps extends BrevmenyProps {
     beløpsperioder?: IBeløpsperiode[] | IBeregningsperiodeBarnetilsyn[];
     mellomlagretBrevVerdier?: string;
     brevMal: string;
-    flettefeltStore: { [navn: string]: string };
-    valgfeltStore: IValgfeltStore;
+    flettefeltStore: FlettefeltStore;
+    valgfeltStore: ValgfeltStore;
     stønadstype: Stønadstype;
+    delmalStore: DelmalStore;
 }
 
 const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
@@ -69,6 +70,7 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
     flettefeltStore,
     stønadstype,
     valgfeltStore,
+    delmalStore,
 }) => {
     const { axiosRequest } = useApp();
     const { mellomlagreSanitybrev } = useMellomlagringBrev(behandlingId);
@@ -87,6 +89,13 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
         settValgteFelt(initValgteFelt(valgteFeltFraMellomlager, brevStruktur, valgfeltStore));
         if (valgteDelmalerFraMellomlager) {
             settValgteDelmaler(valgteDelmalerFraMellomlager);
+        }
+
+        if (delmalStore.length > 0) {
+            settValgteDelmaler((prevState) => ({
+                ...prevState,
+                ...delmalStore.reduce((acc, delmal) => ({ ...acc, [delmal]: true }), {}),
+            }));
         }
         // eslint-disable-next-line
     }, [brevStruktur, flettefeltStore, mellomlagretBrevVerdier]);


### PR DESCRIPTION
Del 1 av https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10977

Valgfeltet for hjemler blir automatisk tatt stilling til utifra om bruker har perioder med samordning eller ikke. Delmalen for hjemler også automatisk avhuket.

**Hva gjennstår?**
- Skjule eller disable delmal i brevmenyen
- Håndtere brevmaler som ikke skal ha med delmalen
