### PR TITLE
Skal skjule delmal om hjemler fra brevmeny

### DIFF
--- a/src/frontend/App/hooks/useVerdierForBrev.ts
+++ b/src/frontend/App/hooks/useVerdierForBrev.ts
@@ -29,7 +29,7 @@ enum EDelmaler {
 }
 
 export type FlettefeltStore = { [navn: string]: string };
-export type DelmalStore = string[];
+export type DelmalStore = { delmal: string; skjulIBrevmeny: boolean }[];
 
 export type ValgfeltStore = {
     [valgfelt: string]: string;
@@ -65,7 +65,10 @@ export const useVerdierForBrev = (
                         : EValg.hjemlerUtenSamordning,
                 }));
 
-                settDelmalStore((prevState) => [...prevState, EDelmaler.avslutningHjemler]);
+                settDelmalStore((prevState) => [
+                    ...prevState,
+                    { delmal: EDelmaler.avslutningHjemler, skjulIBrevmeny: true },
+                ]);
             }
 
             settFlettefeltStore((prevState) => ({

--- a/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
@@ -29,6 +29,7 @@ interface Props {
     settValgteDelmaler: Dispatch<SetStateAction<Record<string, boolean>>>;
     settKanSendeTilBeslutter: (kanSendeTilBeslutter: boolean) => void;
     valgt: boolean;
+    skjul: boolean;
 }
 
 export const BrevMenyDelmal: React.FC<Props> = ({
@@ -41,6 +42,7 @@ export const BrevMenyDelmal: React.FC<Props> = ({
     settValgteDelmaler,
     settKanSendeTilBeslutter,
     valgt,
+    skjul,
 }) => {
     const { delmalValgfelt, delmalFlettefelter } = delmal;
     const [ekspanderbartPanelÅpen, settEkspanderbartPanelÅpen] = useState(false);
@@ -64,6 +66,10 @@ export const BrevMenyDelmal: React.FC<Props> = ({
 
         settKanSendeTilBeslutter(false);
     };
+
+    if (skjul) {
+        return null;
+    }
 
     return (
         <DelmalValg>

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
@@ -30,6 +30,8 @@ import { Stønadstype } from '../../../App/typer/behandlingstema';
 import { delmalTilUtregningstabellOS } from './UtregningstabellOvergangsstønad';
 import { delmalTilUtregningstabellBT } from './UtregningstabellBarnetilsyn';
 import { useVerdierForBrev } from '../../../App/hooks/useVerdierForBrev';
+import { useToggles } from '../../../App/context/TogglesContext';
+import { ToggleName } from '../../../App/context/toggles';
 
 const BrevFelter = styled.div`
     display: flex;
@@ -75,6 +77,7 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
     const [alleFlettefelter, settAlleFlettefelter] = useState<FlettefeltMedVerdi[]>([]);
     const [brevmalFeil, settBrevmalFeil] = useState('');
     const { flettefeltStore, valgfeltStore, delmalStore } = useVerdierForBrev(beløpsperioder);
+    const { toggles } = useToggles();
 
     useEffect(() => {
         const parsetMellomlagretBrev =
@@ -224,7 +227,7 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
                     )?.skjulIBrevmeny;
                     return automatiskFeltSomSkalSkjules || false;
                 });
-                if (key === 'Lovhjemmel') {
+                if (key === 'Lovhjemmel' && toggles[ToggleName.automatiskeHjemlerBrev]) {
                     return (
                         <AlertMedMargin variant={'info'} inline>
                             Valget om lovhjemmel utføres nå automatisk av systemet

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
@@ -89,7 +89,7 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
         if (delmalStore.length > 0) {
             settValgteDelmaler((prevState) => ({
                 ...prevState,
-                ...delmalStore.reduce((acc, delmal) => ({ ...acc, [delmal]: true }), {}),
+                ...delmalStore.reduce((acc, delmal) => ({ ...acc, [delmal.delmal]: true }), {}),
             }));
         }
         // eslint-disable-next-line
@@ -214,6 +214,15 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
         <BrevFelter>
             {brevmalFeil && <Alert variant={'warning'}>{brevmalFeil}</Alert>}
             {Object.entries(delmalerGruppert).map(([key, delmaler]: [string, Delmal[]]) => {
+                const alleDelmalerSkjules = delmaler.every((delmal) => {
+                    const automatiskFeltSomSkalSkjules = delmalStore.find(
+                        (mal) => mal.delmal === delmal.delmalApiNavn
+                    )?.skjulIBrevmeny;
+                    return automatiskFeltSomSkalSkjules || false;
+                });
+                if (alleDelmalerSkjules) {
+                    return null;
+                }
                 return (
                     <Panel key={key}>
                         {key !== 'undefined' && (
@@ -224,6 +233,10 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
                             </BrevMenyTittel>
                         )}
                         {delmaler.map((delmal: Delmal, index: number) => {
+                            const automatiskFeltsomSkalSkjules = delmalStore.find(
+                                (mal) => mal.delmal === delmal.delmalApiNavn
+                            )?.skjulIBrevmeny;
+                            const skjulDelmal = automatiskFeltsomSkalSkjules || false;
                             return (
                                 <BrevMenyDelmalWrapper
                                     førsteElement={index === 0}
@@ -240,6 +253,7 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
                                         settValgteDelmaler={settValgteDelmaler}
                                         key={delmal.delmalApiNavn}
                                         settKanSendeTilBeslutter={settKanSendesTilBeslutter}
+                                        skjul={skjulDelmal}
                                     />
                                 </BrevMenyDelmalWrapper>
                             );

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
@@ -47,6 +47,10 @@ const BrevMenyDelmalWrapper = styled.div<{ førsteElement?: boolean }>`
     margin-top: ${(props) => (props.førsteElement ? '0' : '1rem')};
 `;
 
+const AlertMedMargin = styled(Alert)`
+    margin: 1rem;
+`;
+
 export interface BrevmenyVisningProps extends BrevmenyProps {
     brevStruktur: BrevStruktur;
     beløpsperioder?: IBeløpsperiode[] | IBeregningsperiodeBarnetilsyn[];
@@ -220,6 +224,13 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
                     )?.skjulIBrevmeny;
                     return automatiskFeltSomSkalSkjules || false;
                 });
+                if (key === 'Lovhjemmel') {
+                    return (
+                        <AlertMedMargin variant={'info'} inline>
+                            Valget om lovhjemmel utføres nå automatisk av systemet
+                        </AlertMedMargin>
+                    );
+                }
                 if (alleDelmalerSkjules) {
                     return null;
                 }


### PR DESCRIPTION
Fortsettelse av https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10977

Delmalen om hjemler skal settes automatisk, og bør derfor skjules fra brevmeny.

Tar gjerne i mot forslag til bedre måter å gjøre dette på, synes det ble litt komplisert 🤔 

**Før**
![image](https://user-images.githubusercontent.com/21220467/214344656-1e8a61b9-ac18-41e9-b806-bc99bf40c476.png)


**Etter**
![image](https://user-images.githubusercontent.com/21220467/214516874-a8d1a04d-51cc-4d6d-b77e-8fa912d8b4b8.png)

