### PR TITLE
Skal forenkle teksten i vedtaksperioder infotrygd - kvitte oss med ut…

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -17,6 +17,7 @@ interface IEnvironment {
     aInntekt: string;
     gosys: string;
     modia: string;
+    historiskPensjon: string;
     redisUrl?: string;
     roller: Roller;
 }
@@ -49,6 +50,7 @@ const Environment = (): IEnvironment => {
             aInntekt: 'https://arbeid-og-inntekt.dev.adeo.no',
             gosys: 'https://gosys-q1.dev.intern.nav.no/gosys',
             modia: 'https://app-q1.adeo.no/modiapersonoversikt',
+            historiskPensjon: 'https://historisk-pensjon.dev.intern.nav.no',
             endringsloggProxyUrl: 'https://familie-endringslogg.dev.intern.nav.no',
             roller: rollerDev,
         };
@@ -61,6 +63,7 @@ const Environment = (): IEnvironment => {
             aInntekt: 'https://arbeid-og-inntekt.dev.adeo.no',
             gosys: 'https://gosys-q1.dev.intern.nav.no/gosys',
             modia: 'https://app-q1.adeo.no/modiapersonoversikt',
+            historiskPensjon: 'https://historisk-pensjon.dev.intern.nav.no',
             endringsloggProxyUrl: 'https://familie-endringslogg.dev.intern.nav.no',
             roller: rollerDev,
             //Har ikke satt opp redis
@@ -74,6 +77,7 @@ const Environment = (): IEnvironment => {
             aInntekt: 'https://arbeid-og-inntekt.dev.adeo.no',
             gosys: 'https://gosys-q1.dev.intern.nav.no/gosys',
             modia: 'https://app-q1.adeo.no/modiapersonoversikt',
+            historiskPensjon: 'https://historisk-pensjon.dev.intern.nav.no',
             redisUrl: 'familie-ef-sak-frontend-redis',
             endringsloggProxyUrl: 'https://familie-endringslogg.dev.intern.nav.no',
             roller: rollerDev,
@@ -88,6 +92,7 @@ const Environment = (): IEnvironment => {
         aInntekt: 'https://arbeid-og-inntekt.nais.adeo.no',
         gosys: 'https://gosys.intern.nav.no/gosys',
         modia: 'https://app.adeo.no/modiapersonoversikt',
+        historiskPensjon: 'https://historisk-pensjon.intern.nav.no',
         redisUrl: 'familie-ef-sak-frontend-redis',
         endringsloggProxyUrl: 'https://familie-endringslogg.intern.nav.no',
         roller: rollerProd,
@@ -121,4 +126,5 @@ export const namespace = env.namespace;
 export const urlAInntekt = env.aInntekt;
 export const urlGosys = env.gosys;
 export const urlModia = env.modia;
+export const urlHistoriskPensjon = env.historiskPensjon;
 export const roller = env.roller;

--- a/src/backend/router.ts
+++ b/src/backend/router.ts
@@ -1,7 +1,7 @@
 import { Client, ensureAuthenticated, logRequest } from '@navikt/familie-backend';
 import { Request, Response, Router } from 'express';
 import path from 'path';
-import { buildPath, roller, urlAInntekt, urlGosys, urlModia } from './config';
+import { buildPath, roller, urlAInntekt, urlGosys, urlHistoriskPensjon, urlModia } from './config';
 import { prometheusTellere } from './metrikker';
 import { LOG_LEVEL } from '@navikt/familie-logging';
 
@@ -11,7 +11,13 @@ export default (authClient: Client, router: Router): Router => {
     });
     router.get('/env', (_req: Request, res: Response) => {
         res.status(200)
-            .send({ aInntekt: urlAInntekt, gosys: urlGosys, modia: urlModia, roller })
+            .send({
+                aInntekt: urlAInntekt,
+                gosys: urlGosys,
+                modia: urlModia,
+                historiskPensjon: urlHistoriskPensjon,
+                roller,
+            })
             .end();
     });
 

--- a/src/frontend/App/api/env.ts
+++ b/src/frontend/App/api/env.ts
@@ -5,6 +5,7 @@ export interface AppEnv {
     aInntekt: string;
     gosys: string;
     modia: string;
+    historiskPensjon: string;
     roller: Roller;
 }
 

--- a/src/frontend/Felles/HeaderMedSøk/HeaderMedSøk.tsx
+++ b/src/frontend/Felles/HeaderMedSøk/HeaderMedSøk.tsx
@@ -68,6 +68,14 @@ const lagModia = (appEnv: AppEnv, personIdent: string | undefined): PopoverItem 
     };
 };
 
+const lagHistoriskPensjon = (appEnv: AppEnv): PopoverItem => {
+    return {
+        name: 'Vedtak før des. 2008 (Historisk pensjon)',
+        href: appEnv.historiskPensjon,
+        isExternal: true,
+    };
+};
+
 const lagEksterneLenker = (
     axiosRequest: AxiosRequestCallback,
     appEnv: AppEnv,
@@ -81,6 +89,7 @@ const lagEksterneLenker = (
         lagAInntekt(axiosRequest, appEnv, fagsakId, fagsakPersonId),
         lagGosys(appEnv, personIdent),
         lagModia(appEnv, personIdent),
+        lagHistoriskPensjon(appEnv),
     ];
     if (harTilgangTilRolle(appEnv, innloggetSaksbehandler, 'saksbehandler')) {
         eksterneLenker.push({

--- a/src/frontend/Komponenter/Personoversikt/Historiskpensjon/Historiskpensjon.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Historiskpensjon/Historiskpensjon.tsx
@@ -1,14 +1,26 @@
 import React, { useMemo } from 'react';
 import styled from 'styled-components';
-import { AlertWarning } from '../../../Felles/Visningskomponenter/Alerts';
+import { AlertInfo, AlertWarning } from '../../../Felles/Visningskomponenter/Alerts';
 import { AxiosRequestConfig } from 'axios';
 import { useDataHenter } from '../../../App/hooks/felles/useDataHenter';
 import { IHistoriskPensjon } from '../../../App/typer/historiskpensjon';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
+import { BodyShort, Button, Link } from '@navikt/ds-react';
+
+const FlexBox = styled.div`
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 2rem;
+    align-items: center;
+`;
 
 const StyledWarningStripe = styled(AlertWarning)`
     width: 40rem;
-    vertical-align: text-top;
+`;
+
+const StyledInfoStripe = styled(AlertInfo)`
+    width: 40rem;
 `;
 
 const Historiskpensjon: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
@@ -28,10 +40,18 @@ const Historiskpensjon: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId
                 const harPensjondata = historiskPensjon.harPensjonsdata;
                 return harPensjondata ? (
                     <StyledWarningStripe>
-                        Bruker har saker før desember 2008 som kan sees i{' '}
-                        <a href={historiskPensjon.webAppUrl}>PE PP - Historisk pensjon</a>
+                        <FlexBox>
+                            <BodyShort>Bruker har fått stønad før desember 2008</BodyShort>
+                            <Link href={historiskPensjon.webAppUrl} target={'_blank'}>
+                                <Button type={'button'} as={'p'} size={'small'}>
+                                    Se vedtaksperioder
+                                </Button>
+                            </Link>
+                        </FlexBox>
                     </StyledWarningStripe>
-                ) : null;
+                ) : (
+                    <StyledInfoStripe>Bruker har ikke stønad før desember 2008</StyledInfoStripe>
+                );
             }}
         </DataViewer>
     );

--- a/src/frontend/Komponenter/Personoversikt/Historiskpensjon/Historiskpensjon.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Historiskpensjon/Historiskpensjon.tsx
@@ -6,12 +6,13 @@ import { useDataHenter } from '../../../App/hooks/felles/useDataHenter';
 import { IHistoriskPensjon } from '../../../App/typer/historiskpensjon';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { BodyShort, Button, Link } from '@navikt/ds-react';
+import { ExternalLink } from '@navikt/ds-icons';
 
 const FlexBox = styled.div`
     display: flex;
     flex-direction: row;
     flex-wrap: wrap;
-    gap: 2rem;
+    gap: 1rem;
     align-items: center;
 `;
 
@@ -43,14 +44,23 @@ const Historiskpensjon: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId
                         <FlexBox>
                             <BodyShort>Bruker har fått stønad før desember 2008</BodyShort>
                             <Link href={historiskPensjon.webAppUrl} target={'_blank'}>
-                                <Button type={'button'} as={'p'} size={'small'}>
+                                <Button
+                                    type={'button'}
+                                    as={'p'}
+                                    size={'small'}
+                                    variant={'tertiary'}
+                                    icon={<ExternalLink />}
+                                    iconPosition={'right'}
+                                >
                                     Se vedtaksperioder
                                 </Button>
                             </Link>
                         </FlexBox>
                     </StyledWarningStripe>
                 ) : (
-                    <StyledInfoStripe>Bruker har ikke stønad før desember 2008</StyledInfoStripe>
+                    <StyledInfoStripe>
+                        Bruker har ikke fått stønad før desember 2008
+                    </StyledInfoStripe>
                 );
             }}
         </DataViewer>

--- a/src/frontend/Komponenter/Personoversikt/Infotrygdperioderoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Infotrygdperioderoversikt.tsx
@@ -13,7 +13,7 @@ import SummertePerioder from '../Migrering/SummertePerioder';
 import InfotrygdPerioder from '../Migrering/InfotrygdPerioder';
 import MigrerBarnetilsyn from '../Migrering/MigrerBarnetilsyn';
 import { AlertInfo } from '../../Felles/Visningskomponenter/Alerts';
-import { Checkbox } from '@navikt/ds-react';
+import { BodyShort, Checkbox } from '@navikt/ds-react';
 import Historiskpensjon from './Historiskpensjon/Historiskpensjon';
 
 const FlexBox = styled.div`
@@ -21,6 +21,7 @@ const FlexBox = styled.div`
     flex-direction: row;
     flex-wrap: wrap;
     gap: 1rem;
+    align-items: flex-start;
 `;
 const StyledAlertStripe = styled(AlertInfo)`
     width: 40rem;
@@ -59,8 +60,9 @@ const InfotrygdEllerSummertePerioder: React.FC<{
         <>
             <FlexBox>
                 <StyledAlertStripe>
-                    Denne siden viser vedtakshistorikk fra EV VP. (Saker før desember 2008 - PE PP
-                    må sjekkes manuelt i Infotrygd)
+                    <BodyShort>
+                        Denne siden viser vedtaksperioder fra og med desember 2008
+                    </BodyShort>
                 </StyledAlertStripe>
                 <Historiskpensjon fagsakPersonId={fagsakPersonId} />
             </FlexBox>


### PR DESCRIPTION
…trykk som PE PP osv. og formulere FØR/etter desember 2008. Legger inn lenke direkte til historisk pensjon via lenke-boksen vår

<img width="267" alt="Skjermbilde 2023-01-31 kl  14 28 33" src="https://user-images.githubusercontent.com/402915/215773776-1751acde-9eb9-4b28-af15-f2c357296c94.png">
<img width="1339" alt="Skjermbilde 2023-01-31 kl  14 28 25" src="https://user-images.githubusercontent.com/402915/215773781-a1b1abb2-d2a3-4269-8aa2-b98ffc9f3307.png">


[Løser denne](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10704)