### PR TITLE
Ny brevmal for bruk når bruker har trukket søknaden

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
@@ -15,6 +15,7 @@ import {
     initielleAvsnittSvartidKlage,
     initielleAvsnittForlengetSvartidKlage,
     initielleAvsnittForlengetSvartid,
+    initielleAvsnittTrukketSøknad,
 } from './BrevTyperTekst';
 import { IMellomlagretBrevResponse } from '../../../App/hooks/useMellomlagringBrev';
 import { Stønadstype } from '../../../App/typer/behandlingstema';
@@ -113,6 +114,7 @@ export enum FrittståendeBrevtype {
     BREV_OM_SVARTID_KLAGE = 'BREV_OM_SVARTID_KLAGE',
     BREV_OM_FORLENGET_SVARTID = 'BREV_OM_FORLENGET_SVARTID',
     BREV_OM_FORLENGET_SVARTID_KLAGE = 'BREV_OM_FORLENGET_SVARTID_KLAGE',
+    INFORMASJONSBREV_TRUKKET_SØKNAD = 'INFORMASJONSBREV_TRUKKET_SØKNAD',
 }
 
 export enum FritekstBrevtype {
@@ -150,6 +152,7 @@ export const BrevtyperTilOverskrift: Record<FrittståendeBrevtype | FritekstBrev
     BREV_OM_SVARTID_KLAGE: 'Vi har fått klagen din',
     BREV_OM_FORLENGET_SVARTID: 'Saksbehandlingen vil ta lenger tid',
     BREV_OM_FORLENGET_SVARTID_KLAGE: 'Saksbehandlingen vil ta lenger tid',
+    INFORMASJONSBREV_TRUKKET_SØKNAD: 'Saken din om [stønad] er avsluttet',
 };
 
 export const BrevtyperTilSelectNavn: Record<
@@ -177,6 +180,7 @@ export const BrevtyperTilSelectNavn: Record<
     BREV_OM_SVARTID_KLAGE: 'Brev om svartid - klage',
     BREV_OM_FORLENGET_SVARTID: 'Brev om forlenget svartid',
     BREV_OM_FORLENGET_SVARTID_KLAGE: 'Brev om forlenget svartid - klage',
+    INFORMASJONSBREV_TRUKKET_SØKNAD: 'Informasjonsbrev - bruker har trukket søknad',
 };
 
 export const stønadstypeTilBrevtyper: Record<Stønadstype, FritekstBrevtype[]> = {
@@ -223,6 +227,7 @@ export const BrevtyperTilAvsnitt: Record<FrittståendeBrevtype | FritekstBrevtyp
         BREV_OM_SVARTID_KLAGE: initielleAvsnittSvartidKlage,
         BREV_OM_FORLENGET_SVARTID: initielleAvsnittForlengetSvartid,
         BREV_OM_FORLENGET_SVARTID_KLAGE: initielleAvsnittForlengetSvartidKlage,
+        INFORMASJONSBREV_TRUKKET_SØKNAD: initielleAvsnittTrukketSøknad,
     };
 
 export enum FritekstBrevContext {

--- a/src/frontend/Komponenter/Behandling/Brev/BrevTyperTekst.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevTyperTekst.ts
@@ -389,3 +389,19 @@ export const initielleAvsnittForlengetSvartid: AvsnittMedId[] = [
         id: uuidv4(),
     },
 ];
+
+export const initielleAvsnittTrukketSøknad: AvsnittMedId[] = [
+    {
+        deloverskrift: '',
+        innhold:
+            'Du har gitt oss beskjed om at du trekker søknaden din om [stønad]. Vi har derfor avsluttet saken din.',
+        id: uuidv4(),
+        skalSkjulesIBrevbygger: false,
+    },
+    {
+        deloverskrift: 'Har du spørsmål?',
+        innhold:
+            'Du finner informasjon som kan være nyttig for deg på nav.no/alene-med-barn. Du kan også kontakte oss på nav.no/kontakt.',
+        id: uuidv4(),
+    },
+];


### PR DESCRIPTION
Etter bestilling fra Mirja: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-11362
<img width="1369" alt="image" src="https://user-images.githubusercontent.com/21220467/216470230-f95d9551-8337-48e9-917c-b63d21e6e121.png">