### PR TITLE
Tidligere vedtaksperioder - Småfiks etter testing

### DIFF
--- a/src/frontend/Felles/Visningskomponenter/GridTabell.tsx
+++ b/src/frontend/Felles/Visningskomponenter/GridTabell.tsx
@@ -5,7 +5,7 @@ const breddeKolonner = (antallKolonner?: number) => {
     if (antallKolonner === 4) {
         return '150px';
     } else if (antallKolonner === 5) {
-        return '100ox';
+        return 'auto';
     } else {
         return '325px';
     }

--- a/src/frontend/Felles/Visningskomponenter/GridTabell.tsx
+++ b/src/frontend/Felles/Visningskomponenter/GridTabell.tsx
@@ -1,6 +1,16 @@
 import styled from 'styled-components';
 import { AGray800 } from '@navikt/ds-tokens/dist/tokens';
 
+const breddeKolonner = (antallKolonner?: number) => {
+    if (antallKolonner === 4) {
+        return '150px';
+    } else if (antallKolonner === 5) {
+        return '100ox';
+    } else {
+        return '325px';
+    }
+};
+
 export const GridTabell = styled.div<{
     kolonner?: number;
     underTabellMargin?: number;
@@ -10,7 +20,7 @@ export const GridTabell = styled.div<{
     display: grid;
     grid-template-columns: ${(props) => (props.utenIkon ? 0 : 21)}px 250px repeat(
             ${(props) => (props.kolonner ? props.kolonner - 2 : 2)},
-            ${(props) => (props.kolonner && props.kolonner > 3 ? '150px' : '325px')}
+            ${(props) => breddeKolonner(props.kolonner)}
         );
     grid-auto-rows: min-content;
     grid-gap: ${(props) => props.gridGap || 0.5}rem;

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/NyttBarnSammePartner/TidligereVedtaksperioderSøkerOgAndreForeldre.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/NyttBarnSammePartner/TidligereVedtaksperioderSøkerOgAndreForeldre.tsx
@@ -57,7 +57,9 @@ const jaNeiMedToolTip = (tidligereVedtak: ITidligereInnvilgetVedtak | undefined)
         harTidligereOvergangsstønad || harTidligereBarnetilsyn || harTidligereSkolepenger;
     return (
         <Tooltip
-            content={`OS: ${harTidligereOvergangsstønad} BT: ${harTidligereBarnetilsyn} SP: ${harTidligereSkolepenger}`}
+            content={`OS: ${mapTrueFalse(harTidligereOvergangsstønad)} BT: ${mapTrueFalse(
+                harTidligereBarnetilsyn
+            )} SP: ${mapTrueFalse(harTidligereSkolepenger)}`}
         >
             <BodyShortSmall>{mapTrueFalse(harTidligereVedtak)}</BodyShortSmall>
         </Tooltip>

--- a/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/TidligereVedtaksperioderInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/TidligereVedtaksperioderInfo.tsx
@@ -31,7 +31,7 @@ const TabellTidligereVedtaksperioder: React.FC<ITidligereVedtaksperioder> = ({
             verdi: { sak?: boolean; infotrygd?: boolean };
         }>
             ikon={TabellIkon.REGISTER}
-            tittel="Har bruker tidligere vedtaksperioder i EF Sak eller Infotrygd"
+            tittel="Har bruker tidligere vedtaksperioder i EF Sak eller Infotrygd (kun EF VP)"
             verdier={[
                 {
                     stønad: Stønadstype.OVERGANGSSTØNAD,


### PR DESCRIPTION
* Fikset bredden på Gridtabell for å håndtere 4 kolonner
* Legger tilbake EF VP i TabellTidligereVedtaksperioder for å vise at det kun gjelder EF VP
* Mapper boolean til ja/nei i tooltip

Fiks på https://github.com/navikt/familie-ef-sak-frontend/pull/2030
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10740

Før:
![image](https://user-images.githubusercontent.com/937168/216984329-ee55db24-8c33-4906-bd45-56ca2deb48be.png)

Etter:
![image](https://user-images.githubusercontent.com/937168/216984250-db50cd15-e241-47f2-91a4-c156bf6b17b6.png)
