### PR TITLE
Inngangsvilkår ny tabellvisning

### DIFF
--- a/src/frontend/Felles/Personopplysninger/InnvandringUtvandring.tsx
+++ b/src/frontend/Felles/Personopplysninger/InnvandringUtvandring.tsx
@@ -16,15 +16,13 @@ const StyledInnflyttetÅrHeader = styled.div`
     padding-right: 1rem;
 `;
 
-export const headerForInnflyttingTabell: React.ReactNode = (
+export const innflyttingHjelpetekst =
+    'Innflyttet år er basert på Folkeregisteret sitt gyldighetstidspunktet for innflytting. Denne har nødvendigvis ikke noen sammenheng med når innflyttingen skjedde i virkeligheten. Dersom man skal finne ut når en innflytting gjelder fra må man se på andre opplysninger, f.eks. den norske bostedsadressens fra-dato.';
+
+const headerForInnflyttingTabell: React.ReactNode = (
     <div style={{ display: 'flex' }}>
         <StyledInnflyttetÅrHeader>Innflyttet år</StyledInnflyttetÅrHeader>
-        <HelpText>
-            Innflyttet år er basert på Folkeregisteret sitt gyldighetstidspunktet for innflytting.
-            Denne har nødvendigvis ikke noen sammenheng med når innflyttingen skjedde i
-            virkeligheten. Dersom man skal finne ut når en innflytting gjelder fra må man se på
-            andre opplysninger, f.eks. den norske bostedsadressens fra-dato.
-        </HelpText>
+        <HelpText>{innflyttingHjelpetekst}</HelpText>
     </div>
 );
 

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Medlemskap/FolkeregisterPersonstatus.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Medlemskap/FolkeregisterPersonstatus.tsx
@@ -13,7 +13,6 @@ const StyledDiv = styled.div`
     grid-template-rows: min-content;
     grid-gap: 0.5rem;
     grid-template-areas: '. .' '. status';
-    margin-bottom: 3rem;
 `;
 
 const StatusTekst = styled(BodyShortSmall)`

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Medlemskap/InnflyttingUtflytting.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Medlemskap/InnflyttingUtflytting.tsx
@@ -3,12 +3,9 @@ import {
     IInnflyttingTilNorge,
     IUtflyttingFraNorge,
 } from '../../../../App/typer/personopplysninger';
-import { Registergrunnlag } from '../../../../Felles/Ikoner/DataGrunnlagIkoner';
 import { formaterNullableIsoDato, formaterNullableIsoÅr } from '../../../../App/utils/formatter';
 import { slåSammenTekst } from '../../../../App/utils/utils';
-import { FlexDiv } from '../../../Oppgavebenk/OppgaveFiltrering';
 import { innflyttingHjelpetekst } from '../../../../Felles/Personopplysninger/InnvandringUtvandring';
-import { Label } from '@navikt/ds-react';
 import TabellVisning, { TabellIkon } from '../../Tabell/TabellVisning';
 
 interface Props {
@@ -19,12 +16,6 @@ interface Props {
 const InnflyttingUtflytting: React.FC<Props> = ({ innflytting, utflytting }) => {
     return (
         <>
-            <FlexDiv>
-                <Registergrunnlag />
-                <Label as={'h3'} style={{ marginLeft: '0.5rem' }}>
-                    Innflytting og utflytting
-                </Label>
-            </FlexDiv>
             <TabellVisning
                 tittel="Innflytting og utflytting"
                 ikon={TabellIkon.REGISTER}

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Medlemskap/InnflyttingUtflytting.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Medlemskap/InnflyttingUtflytting.tsx
@@ -6,10 +6,10 @@ import {
 import { Registergrunnlag } from '../../../../Felles/Ikoner/DataGrunnlagIkoner';
 import { formaterNullableIsoDato, formaterNullableIsoÅr } from '../../../../App/utils/formatter';
 import { slåSammenTekst } from '../../../../App/utils/utils';
-import { Tabell } from '../NyttBarnSammePartner/Tabell';
 import { FlexDiv } from '../../../Oppgavebenk/OppgaveFiltrering';
-import { headerForInnflyttingTabell } from '../../../../Felles/Personopplysninger/InnvandringUtvandring';
+import { innflyttingHjelpetekst } from '../../../../Felles/Personopplysninger/InnvandringUtvandring';
 import { Label } from '@navikt/ds-react';
+import TabellVisning, { TabellIkon } from '../../Tabell/TabellVisning';
 
 interface Props {
     innflytting: IInnflyttingTilNorge[];
@@ -25,7 +25,9 @@ const InnflyttingUtflytting: React.FC<Props> = ({ innflytting, utflytting }) => 
                     Innflytting og utflytting
                 </Label>
             </FlexDiv>
-            <Tabell
+            <TabellVisning
+                tittel="Innflytting og utflytting"
+                ikon={TabellIkon.REGISTER}
                 kolonner={[
                     {
                         overskrift: 'Innflytting fra',
@@ -36,13 +38,14 @@ const InnflyttingUtflytting: React.FC<Props> = ({ innflytting, utflytting }) => 
                             ),
                     },
                     {
-                        overskrift: headerForInnflyttingTabell,
+                        overskrift: 'Innflyttet år',
+                        hjelpetekst: innflyttingHjelpetekst,
                         tekstVerdi: (innflytting) => formaterNullableIsoÅr(innflytting.dato) || '',
                     },
                 ]}
-                data={innflytting}
+                verdier={innflytting}
             />
-            <Tabell
+            <TabellVisning
                 kolonner={[
                     {
                         overskrift: 'Utflytting til',
@@ -57,7 +60,7 @@ const InnflyttingUtflytting: React.FC<Props> = ({ innflytting, utflytting }) => 
                         tekstVerdi: (utflytting) => formaterNullableIsoDato(utflytting.dato) || '',
                     },
                 ]}
-                data={utflytting}
+                verdier={utflytting}
             />
         </>
     );

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Medlemskap/MedlemskapInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Medlemskap/MedlemskapInfo.tsx
@@ -12,6 +12,7 @@ import InnflyttingUtflytting from './InnflyttingUtflytting';
 import UnntakIMedl from './UnntakIMedl';
 import { Tag } from '@navikt/ds-react';
 import { BodyShortSmall } from '../../../../Felles/Visningskomponenter/Tekster';
+import { InformasjonContainer } from '../../Vilkårpanel/StyledVilkårInfo';
 
 interface Props {
     medlemskap: IMedlemskap;
@@ -27,8 +28,8 @@ const MedlemskapInfo: FC<Props> = ({ medlemskap, skalViseSøknadsdata }) => {
     const finnesUnntakIMedl = medlUnntak.gyldigeVedtaksPerioder.length > 0;
 
     return (
-        <>
-            <GridTabell>
+        <InformasjonContainer>
+            <GridTabell underTabellMargin={0}>
                 {skalViseSøknadsdata && søknadsgrunnlag && (
                     <>
                         <Søknadsgrunnlag />
@@ -64,7 +65,7 @@ const MedlemskapInfo: FC<Props> = ({ medlemskap, skalViseSøknadsdata }) => {
             {skalViseSøknadsdata && finnesUtenlandsperioder && (
                 <Utenlandsopphold utenlandsopphold={søknadsgrunnlag.utenlandsopphold} />
             )}
-        </>
+        </InformasjonContainer>
     );
 };
 

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/NyttBarnSammePartner/NyttBarnSammePartnerInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/NyttBarnSammePartner/NyttBarnSammePartnerInfo.tsx
@@ -19,7 +19,7 @@ const NyttBarnSammePartnerInfo: FC<Props> = ({ barnMedSamvær, tidligereVedtaksp
     const søknadsgrunnlagNyttBarn = mapTilSøknadsgrunnlagNyttBarn(barnMedSamvær);
     return (
         <>
-            <div>
+            <div style={{ marginBottom: '1.5rem' }}>
                 <TidligereVedtaksperioderSøkerOgAndreForeldre
                     tidligereVedtaksperioder={tidligereVedtaksperioder}
                     registergrunnlagNyttBarn={registergrunnlagNyttBarn}

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Opphold/OppholdInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Opphold/OppholdInfo.tsx
@@ -9,6 +9,7 @@ import Utenlandsopphold from '../Medlemskap/Utenlandsopphold';
 import InnflyttingUtflytting from '../Medlemskap/InnflyttingUtflytting';
 import FolkeregisterPersonstatus from '../Medlemskap/FolkeregisterPersonstatus';
 import { BodyShortSmall } from '../../../../Felles/Visningskomponenter/Tekster';
+import { InformasjonContainer } from '../../Vilkårpanel/StyledVilkårInfo';
 
 interface Props {
     medlemskap: IMedlemskap;
@@ -24,8 +25,8 @@ const OppholdInfo: FC<Props> = ({ medlemskap, skalViseSøknadsdata }) => {
         registergrunnlag.innflytting.length > 0 || registergrunnlag.utflytting.length > 0;
 
     return (
-        <>
-            <GridTabell>
+        <InformasjonContainer>
+            <GridTabell underTabellMargin={0}>
                 <Registergrunnlag />
                 <BodyShortSmall>Statsborgerskap</BodyShortSmall>
                 <BodyShortSmall>
@@ -56,7 +57,7 @@ const OppholdInfo: FC<Props> = ({ medlemskap, skalViseSøknadsdata }) => {
             {skalViseSøknadsdata && finnesUtenlandsperioder && (
                 <Utenlandsopphold utenlandsopphold={søknadsgrunnlag.utenlandsopphold} />
             )}
-        </>
+        </InformasjonContainer>
     );
 };
 export default OppholdInfo;

--- a/src/frontend/Komponenter/Behandling/Tabell/TabellVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Tabell/TabellVisning.tsx
@@ -36,6 +36,7 @@ export interface Kolonnedata<T> {
     tittel?: string;
     verdier: T[];
     kolonner: Kolonner<T>[];
+    ikonVisning?: boolean;
 }
 
 export interface Kolonner<T> {
@@ -62,9 +63,9 @@ const mapIkon = (ikon: TabellIkon) => {
 };
 
 function TabellVisning<T>(props: Kolonnedata<T>): React.ReactElement<Kolonnedata<T>> {
-    const { ikon, tittel, verdier, kolonner } = props;
+    const { ikon, tittel, verdier, kolonner, ikonVisning = true } = props;
     return (
-        <GridTabell kolonner={kolonner.length + 1} ikonVisning={!!ikon}>
+        <GridTabell kolonner={kolonner.length + 1} ikonVisning={ikonVisning}>
             {ikon && mapIkon(ikon)}
             {tittel && (
                 <Label size="small" className="tittel" as="h3">

--- a/src/frontend/Komponenter/Behandling/Tabell/TabellVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Tabell/TabellVisning.tsx
@@ -1,12 +1,8 @@
 import * as React from 'react';
 import { Registergrunnlag, Søknadsgrunnlag } from '../../../Felles/Ikoner/DataGrunnlagIkoner';
 import { Calculator } from '@navikt/ds-icons';
-import { Heading, Label } from '@navikt/ds-react';
-import {
-    BodyShortSmall,
-    DetailSmall,
-    SmallTextLabel,
-} from '../../../Felles/Visningskomponenter/Tekster';
+import { Heading } from '@navikt/ds-react';
+import { BodyShortSmall, SmallTextLabel } from '../../../Felles/Visningskomponenter/Tekster';
 import styled from 'styled-components';
 
 const GridTabell = styled.div<{
@@ -40,7 +36,6 @@ export enum TabellIkon {
 export interface Kolonndata<T> {
     ikon?: TabellIkon;
     tittel: string;
-    undertittel?: string;
     tittelType?: 'element' | 'undertittel';
     verdier: T[];
     kolonner: Kolonner<T>[];
@@ -63,23 +58,14 @@ const mapIkon = (ikon: TabellIkon) => {
 };
 
 function TabellVisning<T>(props: Kolonndata<T>): React.ReactElement<Kolonndata<T>> {
-    const { ikon, tittel, undertittel, tittelType, verdier, kolonner } = props;
+    const { ikon, tittel, verdier, kolonner } = props;
     return (
         <GridTabell kolonner={kolonner.length + 1} utenIkon={!ikon}>
             {ikon && mapIkon(ikon)}
-            {tittelType === 'undertittel' ? (
-                <Heading size="small" className="tittel" level={'3'}>
-                    {tittel}
-                </Heading>
-            ) : (
-                <Label className="tittel" as="h3" size={'small'}>
-                    {' '}
-                    {tittel}
-                    {undertittel && (
-                        <DetailSmall style={{ marginLeft: '0.25rem' }}>{undertittel}</DetailSmall>
-                    )}
-                </Label>
-            )}
+
+            <Heading size="small" className="tittel" level={'3'}>
+                {tittel}
+            </Heading>
 
             <>
                 {kolonner.map((kolonne, index) => (

--- a/src/frontend/Komponenter/Behandling/Tabell/TabellVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Tabell/TabellVisning.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Registergrunnlag, Søknadsgrunnlag } from '../../../Felles/Ikoner/DataGrunnlagIkoner';
-import { GridTabell } from '../../../Felles/Visningskomponenter/GridTabell';
 import { Calculator } from '@navikt/ds-icons';
 import { Heading, Label } from '@navikt/ds-react';
 import {
@@ -8,6 +7,29 @@ import {
     DetailSmall,
     SmallTextLabel,
 } from '../../../Felles/Visningskomponenter/Tekster';
+import styled from 'styled-components';
+
+const GridTabell = styled.div<{
+    kolonner?: number;
+    utenIkon: boolean;
+}>`
+    display: grid;
+    grid-template-columns: ${(props) => props.utenIkon && '21px'} min(200px, 250px) repeat(
+            ${(props) => (props.kolonner ? props.kolonner - 2 : 2)},
+            ${(props) => (props.kolonner && props.kolonner > 3 ? '150px' : '325px')}
+        );
+    grid-gap: 0.5rem;
+    .tittel {
+        padding-bottom: 0.25rem;
+        grid-column: ${(props) => (props.utenIkon ? 2 : 1)} /
+            ${(props) => (props.kolonner || 3) + 1};
+        display: flex;
+        align-items: center;
+    }
+    .førsteDataKolonne {
+        grid-column: ${(props) => (props.utenIkon ? '2/3' : '1/2')};
+    }
+`;
 
 export enum TabellIkon {
     REGISTER = 'REGISTER',

--- a/src/frontend/Komponenter/Behandling/Tabell/TabellVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Tabell/TabellVisning.tsx
@@ -1,49 +1,53 @@
 import * as React from 'react';
+import { BodyShortSmall } from '../../../Felles/Visningskomponenter/Tekster';
+import styled from 'styled-components';
+import { Detail, HelpText, Label } from '@navikt/ds-react';
 import { Registergrunnlag, Søknadsgrunnlag } from '../../../Felles/Ikoner/DataGrunnlagIkoner';
 import { Calculator } from '@navikt/ds-icons';
-import { Heading } from '@navikt/ds-react';
-import { BodyShortSmall, SmallTextLabel } from '../../../Felles/Visningskomponenter/Tekster';
-import styled from 'styled-components';
 
 const GridTabell = styled.div<{
     kolonner?: number;
-    utenIkon: boolean;
+    ikonVisning: boolean;
 }>`
     display: grid;
-    grid-template-columns: ${(props) => props.utenIkon && '21px'} min(200px, 250px) repeat(
+    grid-template-columns: ${(props) => props.ikonVisning && '21px'} min(200px, 250px) repeat(
             ${(props) => (props.kolonner ? props.kolonner - 2 : 2)},
             ${(props) => (props.kolonner && props.kolonner > 3 ? '150px' : '325px')}
         );
     grid-gap: 0.5rem;
     .tittel {
         padding-bottom: 0.25rem;
-        grid-column: ${(props) => (props.utenIkon ? 2 : 1)} /
+        grid-column: ${(props) => (props.ikonVisning ? 2 : 1)} /
             ${(props) => (props.kolonner || 3) + 1};
         display: flex;
         align-items: center;
     }
     .førsteDataKolonne {
-        grid-column: ${(props) => (props.utenIkon ? '2/3' : '1/2')};
+        grid-column: ${(props) => (props.ikonVisning ? '2/3' : '1/2')};
     }
 `;
 
-export enum TabellIkon {
-    REGISTER = 'REGISTER',
-    SØKNAD = 'SØKNAD',
-    KALKULATOR = 'KALKULATOR',
-}
-
-export interface Kolonndata<T> {
+const FlexDiv = styled.div`
+    display: flex;
+    gap: 1rem;
+`;
+export interface Kolonnedata<T> {
     ikon?: TabellIkon;
-    tittel: string;
-    tittelType?: 'element' | 'undertittel';
+    tittel?: string;
     verdier: T[];
     kolonner: Kolonner<T>[];
 }
 
 export interface Kolonner<T> {
     overskrift: string;
+    hjelpetekst?: string;
     tekstVerdi: (data: T) => React.ReactNode;
+}
+
+export enum TabellIkon {
+    REGISTER = 'REGISTER',
+    SØKNAD = 'SØKNAD',
+    KALKULATOR = 'KALKULATOR',
 }
 
 const mapIkon = (ikon: TabellIkon) => {
@@ -57,33 +61,31 @@ const mapIkon = (ikon: TabellIkon) => {
     }
 };
 
-function TabellVisning<T>(props: Kolonndata<T>): React.ReactElement<Kolonndata<T>> {
+function TabellVisning<T>(props: Kolonnedata<T>): React.ReactElement<Kolonnedata<T>> {
     const { ikon, tittel, verdier, kolonner } = props;
     return (
-        <GridTabell kolonner={kolonner.length + 1} utenIkon={!ikon}>
+        <GridTabell kolonner={kolonner.length + 1} ikonVisning={!!ikon}>
             {ikon && mapIkon(ikon)}
-
-            <Heading size="small" className="tittel" level={'3'}>
-                {tittel}
-            </Heading>
-
-            <>
-                {kolonner.map((kolonne, index) => (
-                    <SmallTextLabel className={index === 0 ? 'førsteDataKolonne' : ''} key={index}>
-                        {kolonne.overskrift}
-                    </SmallTextLabel>
-                ))}
-                {verdier.map((item) =>
-                    kolonner.map((kolonne, index) => (
-                        <BodyShortSmall
-                            className={index === 0 ? 'førsteDataKolonne' : 'kolonne'}
-                            key={index}
-                        >
-                            {kolonne.tekstVerdi(item) || ''}
-                        </BodyShortSmall>
-                    ))
-                )}
-            </>
+            {tittel && (
+                <Label size="small" className="tittel" as="h3">
+                    {tittel}
+                </Label>
+            )}
+            {kolonner.map((kolonne, index) => (
+                <FlexDiv className={index === 0 ? 'førsteDataKolonne' : ''} key={index}>
+                    <Detail>
+                        <strong>{kolonne.overskrift}</strong>
+                    </Detail>
+                    {kolonne.hjelpetekst && <HelpText>{kolonne.hjelpetekst}</HelpText>}
+                </FlexDiv>
+            ))}
+            {verdier.map((item) =>
+                kolonner.map((kolonne, index) => (
+                    <BodyShortSmall className={index === 0 ? 'førsteDataKolonne' : ''} key={index}>
+                        {kolonne.tekstVerdi(item) || ''}
+                    </BodyShortSmall>
+                ))
+            )}
         </GridTabell>
     );
 }

--- a/src/frontend/Komponenter/Behandling/Vilkårpanel/StyledVilkårInfo.ts
+++ b/src/frontend/Komponenter/Behandling/Vilkårpanel/StyledVilkårInfo.ts
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const InformasjonContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+`;


### PR DESCRIPTION
### Hensikt
I forbindelse med generell utbedring av GUI på inngangsvilkår ([TEA-10996](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10996)).

Denne PR-en endrer på `TabellVisning`: 
- Fjerner props som ikke brukes (som undertittel)
- Fjerner muligheter for å spesialtilpasse for mye, for å sikre at tabellVisninger blir lik alle steder. 
- Margin-bottom er fjernet, og styres heller fra en flexbox som ligger rundt informasjonskomponenten. Denne skal tas i bruk på i alle vilkårspanel for å styre spacing med gap, men kommer i egen PR senere. 