### PR TITLE
Skal vise bekreftelsemodal hvis man er i ferd å fjerne sanksjonsperio…

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtgiftsperiodeValg.tsx
@@ -4,7 +4,7 @@ import {
     IUtgiftsperiode,
 } from '../../../../App/typer/vedtak';
 import MånedÅrPeriode, { PeriodeVariant } from '../../../../Felles/Input/MånedÅr/MånedÅrPeriode';
-import React, { Dispatch, SetStateAction } from 'react';
+import React, { Dispatch, SetStateAction, useState } from 'react';
 import styled from 'styled-components';
 import { useBehandling } from '../../../../App/context/BehandlingContext';
 import LeggTilKnapp from '../../../../Felles/Knapper/LeggTilKnapp';
@@ -24,6 +24,7 @@ import { BodyShortSmall } from '../../../../Felles/Visningskomponenter/Tekster';
 import { erOpphørEllerSanksjon, tomUtgiftsperiodeRad } from './utils';
 import PeriodetypeSelect from './PeriodetypeSelect';
 import AktivitetSelect from './AktivitetSelect';
+import { Sanksjonsmodal, SlettSanksjonsperiodeModal } from '../Felles/SlettSanksjonsperiodeModal';
 
 const UtgiftsperiodeRad = styled.div<{ lesevisning?: boolean; erHeader?: boolean }>`
     display: grid;
@@ -69,6 +70,9 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
 }) => {
     const { behandlingErRedigerbar } = useBehandling();
     const { settIkkePersistertKomponent } = useApp();
+    const [sanksjonsmodal, settSanksjonsmodal] = useState<Sanksjonsmodal>({
+        visModal: false,
+    });
 
     const oppdaterUtgiftsperiode = (
         index: number,
@@ -121,6 +125,34 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
                 return EUtgiftsperiodeProperty.årMånedFra;
             case PeriodeVariant.ÅR_MÅNED_TIL:
                 return EUtgiftsperiodeProperty.årMånedTil;
+        }
+    };
+
+    const lukkSanksjonsmodal = () => {
+        settSanksjonsmodal({ visModal: false });
+    };
+
+    const slettPeriode = (index: number) => {
+        if (sanksjonsmodal.visModal) {
+            lukkSanksjonsmodal();
+        }
+        utgiftsperioder.remove(index);
+        settValideringsFeil((prevState: FormErrors<InnvilgeVedtakForm>) => {
+            const utgiftsperioder = (prevState.utgiftsperioder ?? []).filter((_, i) => i !== index);
+            return { ...prevState, utgiftsperioder };
+        });
+    };
+
+    const slettPeriodeModalHvisSanksjon = (index: number) => {
+        const periode = utgiftsperioder.value[index];
+        if (periode.periodetype === EUtgiftsperiodetype.SANKSJON_1_MND) {
+            settSanksjonsmodal({
+                visModal: true,
+                index: index,
+                årMånedFra: periode.årMånedFra,
+            });
+        } else {
+            slettPeriode(index);
         }
     };
 
@@ -251,17 +283,7 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
                         {skalViseFjernKnapp ? (
                             <IkonKnappWrapper>
                                 <FjernKnapp
-                                    onClick={() => {
-                                        utgiftsperioder.remove(index);
-                                        settValideringsFeil(
-                                            (prevState: FormErrors<InnvilgeVedtakForm>) => {
-                                                const utgiftsperioder = (
-                                                    prevState.utgiftsperioder ?? []
-                                                ).filter((_, i) => i !== index);
-                                                return { ...prevState, utgiftsperioder };
-                                            }
-                                        );
-                                    }}
+                                    onClick={() => slettPeriodeModalHvisSanksjon(index)}
                                     ikontekst={'Fjern utgiftsperiode'}
                                 />
                             </IkonKnappWrapper>
@@ -289,6 +311,11 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
                     />
                 )}
             </ContainerMedLuftUnder>
+            <SlettSanksjonsperiodeModal
+                sanksjonsmodal={sanksjonsmodal}
+                slettPeriode={slettPeriode}
+                lukkModal={lukkSanksjonsmodal}
+            />
         </>
     );
 };

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/SlettSanksjonsperiodeModal.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/SlettSanksjonsperiodeModal.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { ModalWrapper } from '../../../../Felles/Modal/ModalWrapper';
+import { formaterIsoMånedÅrFull } from '../../../../App/utils/formatter';
+
+export type Sanksjonsmodal =
+    | { visModal: false }
+    | { visModal: true; index: number; årMånedFra: string };
+
+export const SlettSanksjonsperiodeModal: React.FC<{
+    sanksjonsmodal: Sanksjonsmodal;
+    slettPeriode: (index: number) => void;
+    lukkModal: () => void;
+}> = ({ sanksjonsmodal, slettPeriode, lukkModal }) => {
+    if (!sanksjonsmodal.visModal) {
+        return null;
+    }
+    return (
+        <ModalWrapper
+            tittel={'Vil du oppheve sanksjon'}
+            visModal={true}
+            aksjonsknapper={{
+                hovedKnapp: {
+                    onClick: () => slettPeriode(sanksjonsmodal.index),
+                    tekst: 'Fjern sanksjon',
+                },
+                lukkKnapp: {
+                    onClick: lukkModal,
+                    tekst: 'Avbryt',
+                },
+            }}
+            onClose={lukkModal}
+        >
+            Du er i ferd med å fjerne en periode bruker er ilagt sanksjon (
+            {formaterIsoMånedÅrFull(sanksjonsmodal.årMånedFra)}
+            ). Er du sikker på at du vil gjøre dette?
+        </ModalWrapper>
+    );
+};


### PR DESCRIPTION
…de ved revurdering

Tenkte ikke på at vi viste modal ved sletting av sanksjonsperiode i OS, så hadde ikke fått med meg den for barnetilsyn
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10612

Tar i bruk sanksjonsmodalen fra https://github.com/navikt/familie-ef-sak-frontend/pull/1833 men til barnetilsyn

<img width="763" alt="image" src="https://user-images.githubusercontent.com/937168/217247515-ac74b91f-3939-4adc-9e28-ceebca89e96f.png">
