### PR TITLE
Aktivitetsvilkår skolepenger gui utbedringer

### DIFF
--- a/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/Utdanning.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/Utdanning.tsx
@@ -8,9 +8,9 @@ import {
     UtdanningsformTilTekst,
 } from './typer';
 import { BooleanTekst } from '../../../../Felles/Visningskomponenter/BooleanTilTekst';
-import { GridTabellWrapper } from '../../../../Felles/Visningskomponenter/GridTabell';
 import { formaterIsoMånedÅr, formaterNullableIsoDato } from '../../../../App/utils/formatter';
 import { BodyShortSmall, SmallTextLabel } from '../../../../Felles/Visningskomponenter/Tekster';
+import TabellVisning from '../../Tabell/TabellVisning';
 
 export const UnderUtdanning: FC<{
     underUtdanning: IUnderUtdanning;
@@ -67,23 +67,21 @@ export const UnderUtdanning: FC<{
 export const TidligereUtdanninger: FC<{ tidligereUtdanninger?: ITidligereUtdanning[] }> = ({
     tidligereUtdanninger,
 }) => {
-    return (
-        <>
-            <SmallTextLabel className={'førsteDataKolonne'}>Linje/Kurs/grad</SmallTextLabel>
-            <SmallTextLabel>Tidsperiode</SmallTextLabel>
-
-            {tidligereUtdanninger?.map((utdanning, index) => (
-                <GridTabellWrapper key={utdanning.linjeKursGrad + index}>
-                    <BodyShortSmall className={'førsteDataKolonne'}>
-                        {utdanning.linjeKursGrad}
-                    </BodyShortSmall>
-                    <BodyShortSmall>
-                        {`${formaterIsoMånedÅr(utdanning.fra)} - ${formaterIsoMånedÅr(
-                            utdanning.til
-                        )}`}
-                    </BodyShortSmall>
-                </GridTabellWrapper>
-            ))}
-        </>
-    );
+    return tidligereUtdanninger ? (
+        <TabellVisning
+            ikonVisning={true}
+            verdier={tidligereUtdanninger}
+            kolonner={[
+                {
+                    overskrift: 'Linje/kurs/grad',
+                    tekstVerdi: (d) => d.linjeKursGrad,
+                },
+                {
+                    overskrift: 'Tidsperiode',
+                    tekstVerdi: (d) =>
+                        `${formaterIsoMånedÅr(d.fra)} - ${formaterIsoMånedÅr(d.til)}`,
+                },
+            ]}
+        />
+    ) : null;
 };

--- a/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/Utdanning.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/Utdanning.tsx
@@ -64,10 +64,10 @@ export const UnderUtdanning: FC<{
     );
 };
 
-export const TidligereUtdanninger: FC<{ tidligereUtdanninger?: ITidligereUtdanning[] }> = ({
+export const TidligereUtdanninger: FC<{ tidligereUtdanninger: ITidligereUtdanning[] }> = ({
     tidligereUtdanninger,
 }) => {
-    return tidligereUtdanninger ? (
+    return (
         <TabellVisning
             ikonVisning={true}
             verdier={tidligereUtdanninger}
@@ -83,5 +83,5 @@ export const TidligereUtdanninger: FC<{ tidligereUtdanninger?: ITidligereUtdanni
                 },
             ]}
         />
-    ) : null;
+    );
 };

--- a/src/frontend/Komponenter/Behandling/Aktivitet/Skolepenger/DokumentasjonUtdanning.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Skolepenger/DokumentasjonUtdanning.tsx
@@ -36,10 +36,9 @@ export const DokumentasjonUtdanning: React.FC<VilkårProps> = ({
         >
             <VilkårpanelInnhold>
                 {{
-                    venstre: grunnlag.aktivitet && (
+                    venstre: grunnlag.aktivitet && skalViseSøknadsdata && (
                         <DokumentasjonUtdanningInfo
                             aktivitet={grunnlag.aktivitet}
-                            skalViseSøknadsdata={skalViseSøknadsdata}
                             dokumentasjon={grunnlag.dokumentasjon}
                         />
                     ),

--- a/src/frontend/Komponenter/Behandling/Aktivitet/Skolepenger/DokumentasjonUtdanningInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Skolepenger/DokumentasjonUtdanningInfo.tsx
@@ -7,29 +7,18 @@ import { InformasjonContainer } from '../../Vilkårpanel/StyledVilkårInnhold';
 
 interface Props {
     aktivitet: IAktivitet;
-    skalViseSøknadsdata: boolean;
     dokumentasjon?: IDokumentasjonGrunnlag;
 }
 
-const DokumentasjonUtdanningInfo: FC<Props> = ({
-    aktivitet,
-    skalViseSøknadsdata,
-    dokumentasjon,
-}) => {
+const DokumentasjonUtdanningInfo: FC<Props> = ({ aktivitet, dokumentasjon }) => {
     return (
         <InformasjonContainer>
-            {skalViseSøknadsdata && (
-                <Dokumentasjonsvisning
-                    aktivitet={aktivitet}
-                    skalViseSøknadsdata={skalViseSøknadsdata}
-                />
-            )}
-            {skalViseSøknadsdata && (
-                <DokumentasjonSendtInn
-                    dokumentasjon={dokumentasjon?.utdanningsutgifter}
-                    tittel={'Utgifter til skolepenger'}
-                />
-            )}
+            <Dokumentasjonsvisning aktivitet={aktivitet} />
+
+            <DokumentasjonSendtInn
+                dokumentasjon={dokumentasjon?.utdanningsutgifter}
+                tittel={'Utgifter til skolepenger'}
+            />
         </InformasjonContainer>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Aktivitet/Skolepenger/DokumentasjonUtdanningInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Skolepenger/DokumentasjonUtdanningInfo.tsx
@@ -1,9 +1,9 @@
 import React, { FC } from 'react';
-import { GridTabell } from '../../../../Felles/Visningskomponenter/GridTabell';
 import Dokumentasjonsvisning from './Dokumentasjonsvisning';
 import { IAktivitet } from '../../../../App/typer/aktivitetstyper';
 import { IDokumentasjonGrunnlag } from '../../Inngangsvilkår/vilkår';
 import DokumentasjonSendtInn from '../../Inngangsvilkår/DokumentasjonSendtInn';
+import { InformasjonContainer } from '../../Vilkårpanel/StyledVilkårInnhold';
 
 interface Props {
     aktivitet: IAktivitet;
@@ -17,22 +17,20 @@ const DokumentasjonUtdanningInfo: FC<Props> = ({
     dokumentasjon,
 }) => {
     return (
-        <>
-            <GridTabell>
-                {skalViseSøknadsdata ? (
-                    <Dokumentasjonsvisning
-                        aktivitet={aktivitet}
-                        skalViseSøknadsdata={skalViseSøknadsdata}
-                    />
-                ) : null}
-            </GridTabell>
+        <InformasjonContainer>
+            {skalViseSøknadsdata && (
+                <Dokumentasjonsvisning
+                    aktivitet={aktivitet}
+                    skalViseSøknadsdata={skalViseSøknadsdata}
+                />
+            )}
             {skalViseSøknadsdata && (
                 <DokumentasjonSendtInn
                     dokumentasjon={dokumentasjon?.utdanningsutgifter}
                     tittel={'Utgifter til skolepenger'}
                 />
             )}
-        </>
+        </InformasjonContainer>
     );
 };
 

--- a/src/frontend/Komponenter/Behandling/Aktivitet/Skolepenger/Dokumentasjonsvisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Skolepenger/Dokumentasjonsvisning.tsx
@@ -8,7 +8,6 @@ import { VilkårInfoIkon } from '../../Vilkårpanel/VilkårInformasjonKomponente
 
 interface Props {
     aktivitet: IAktivitet;
-    skalViseSøknadsdata: boolean;
 }
 
 const Dokumentasjonsvisning: FC<Props> = ({ aktivitet }) => {

--- a/src/frontend/Komponenter/Behandling/Aktivitet/Skolepenger/Dokumentasjonsvisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Skolepenger/Dokumentasjonsvisning.tsx
@@ -1,122 +1,66 @@
 import React, { FC } from 'react';
-import { Søknadsgrunnlag } from '../../../../Felles/Ikoner/DataGrunnlagIkoner';
 import { formaterNullableIsoDato, utledUtgiftsbeløp } from '../../../../App/utils/formatter';
 import { IAktivitet } from '../../../../App/typer/aktivitetstyper';
 import { UtdanningsformTilTekst } from '../Aktivitet/typer';
-import styled from 'styled-components';
 import { utledVisningForStudiebelastning } from '../../Inngangsvilkår/utils';
-import { BodyShortSmall } from '../../../../Felles/Visningskomponenter/Tekster';
+import Informasjonsrad from '../../Vilkårpanel/Informasjonsrad';
+import { VilkårInfoIkon } from '../../Vilkårpanel/VilkårInformasjonKomponenter';
 
 interface Props {
     aktivitet: IAktivitet;
     skalViseSøknadsdata: boolean;
 }
 
-const UtgiftContainer = styled.div<{ kolonneBredde: string }>`
-    display: grid;
-    grid-template-columns: ${(props) => props.kolonneBredde};
-`;
-
-const HøyrestiltTekst = styled(BodyShortSmall)`
-    display: flex;
-    justify-content: right;
-`;
-
-const utledKolonnebredde = (utgifter: number[]): string => {
-    const høyesteUtgift = Math.max(...utgifter);
-    if (høyesteUtgift >= 100000) {
-        return '4rem';
-    } else if (høyesteUtgift >= 10000) {
-        return '3.5rem';
-    } else if (høyesteUtgift >= 1000) {
-        return '3rem';
-    }
-    return '2.3rem';
-};
-
-const søknadsutgifterTilListe = (
-    semesteravgift?: number,
-    studieavgift?: number,
-    eksamensgebyr?: number
-): number[] => {
-    return Array.of(
-        semesteravgift ? semesteravgift : 0,
-        studieavgift ? studieavgift : 0,
-        eksamensgebyr ? eksamensgebyr : 0
-    );
-};
-
 const Dokumentasjonsvisning: FC<Props> = ({ aktivitet }) => {
     const { underUtdanning } = aktivitet;
 
-    const søknadsutgifter = søknadsutgifterTilListe(
-        underUtdanning?.semesteravgift,
-        underUtdanning?.studieavgift,
-        underUtdanning?.eksamensgebyr
-    );
-
-    const kolonnebredde = utledKolonnebredde(søknadsutgifter);
-
     return (
         <>
-            <>
-                <Søknadsgrunnlag />
-                <BodyShortSmall>Skole/utdanningssted</BodyShortSmall>
-                <BodyShortSmall>{underUtdanning?.skoleUtdanningssted}</BodyShortSmall>
-            </>
-            <>
-                <Søknadsgrunnlag />
-                <BodyShortSmall>Linje/kurs/grad</BodyShortSmall>
-                <BodyShortSmall>{underUtdanning?.linjeKursGrad}</BodyShortSmall>
-            </>
-            <>
-                <Søknadsgrunnlag />
-                <BodyShortSmall>Utdanningstype</BodyShortSmall>
-                {underUtdanning?.offentligEllerPrivat && (
-                    <BodyShortSmall>
-                        {UtdanningsformTilTekst[underUtdanning?.offentligEllerPrivat]}
-                    </BodyShortSmall>
-                )}
-            </>
-            <>
-                <Søknadsgrunnlag />
-                <BodyShortSmall>Studieperiode</BodyShortSmall>
-                <BodyShortSmall>{`${formaterNullableIsoDato(
+            <Informasjonsrad
+                ikon={VilkårInfoIkon.SØKNAD}
+                label="Skole/utdanningssted"
+                verdi={underUtdanning?.skoleUtdanningssted}
+            />
+            <Informasjonsrad
+                ikon={VilkårInfoIkon.SØKNAD}
+                label="Linje/kurs/grad"
+                verdi={underUtdanning?.linjeKursGrad}
+            />
+            <Informasjonsrad
+                ikon={VilkårInfoIkon.SØKNAD}
+                label="Utdanningstype"
+                verdi={
+                    underUtdanning?.offentligEllerPrivat &&
+                    UtdanningsformTilTekst[underUtdanning?.offentligEllerPrivat]
+                }
+            />
+            <Informasjonsrad
+                ikon={VilkårInfoIkon.SØKNAD}
+                label="Studieperiode"
+                verdi={`${formaterNullableIsoDato(
                     underUtdanning?.fra
-                )} -  ${formaterNullableIsoDato(underUtdanning?.til)}`}</BodyShortSmall>
-            </>
-            <>
-                <Søknadsgrunnlag />
-                <BodyShortSmall>Studiebelastning</BodyShortSmall>
-                <BodyShortSmall>{utledVisningForStudiebelastning(underUtdanning)}</BodyShortSmall>
-            </>
-            <>
-                <Søknadsgrunnlag />
-                <BodyShortSmall>Semesteravgift</BodyShortSmall>
-                <UtgiftContainer kolonneBredde={kolonnebredde}>
-                    <HøyrestiltTekst>
-                        {utledUtgiftsbeløp(underUtdanning?.semesteravgift)}
-                    </HøyrestiltTekst>
-                </UtgiftContainer>
-            </>
-            <>
-                <Søknadsgrunnlag />
-                <BodyShortSmall>Studieavgift</BodyShortSmall>
-                <UtgiftContainer kolonneBredde={kolonnebredde}>
-                    <HøyrestiltTekst>
-                        {utledUtgiftsbeløp(underUtdanning?.studieavgift)}
-                    </HøyrestiltTekst>
-                </UtgiftContainer>
-            </>
-            <>
-                <Søknadsgrunnlag />
-                <BodyShortSmall>Eksamensgebyr</BodyShortSmall>
-                <UtgiftContainer kolonneBredde={kolonnebredde}>
-                    <HøyrestiltTekst>
-                        {utledUtgiftsbeløp(underUtdanning?.eksamensgebyr)}
-                    </HøyrestiltTekst>
-                </UtgiftContainer>
-            </>
+                )} -  ${formaterNullableIsoDato(underUtdanning?.til)}`}
+            />
+            <Informasjonsrad
+                ikon={VilkårInfoIkon.SØKNAD}
+                label="Studiebelastning"
+                verdi={utledVisningForStudiebelastning(underUtdanning)}
+            />
+            <Informasjonsrad
+                ikon={VilkårInfoIkon.SØKNAD}
+                label="Semesteravgift"
+                verdi={utledUtgiftsbeløp(underUtdanning?.semesteravgift)}
+            />
+            <Informasjonsrad
+                ikon={VilkårInfoIkon.SØKNAD}
+                label="Studieavgift"
+                verdi={utledUtgiftsbeløp(underUtdanning?.studieavgift)}
+            />
+            <Informasjonsrad
+                ikon={VilkårInfoIkon.SØKNAD}
+                label="Eksamensgebyr"
+                verdi={utledUtgiftsbeløp(underUtdanning?.eksamensgebyr)}
+            />
         </>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Aktivitet/Skolepenger/UtdanningHensiktsmessigInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Skolepenger/UtdanningHensiktsmessigInfo.tsx
@@ -1,12 +1,14 @@
 import React, { FC } from 'react';
 import { GridTabell } from '../../../../Felles/Visningskomponenter/GridTabell';
-import { Søknadsgrunnlag } from '../../../../Felles/Ikoner/DataGrunnlagIkoner';
 import styled from 'styled-components';
 import Dokumentasjonsvisning from './Dokumentasjonsvisning';
 import { TidligereUtdanninger } from '../Aktivitet/Utdanning';
 import { IAktivitet } from '../../../../App/typer/aktivitetstyper';
-import { BodyLongSmall, BodyShortSmall } from '../../../../Felles/Visningskomponenter/Tekster';
+import { BodyLongSmall } from '../../../../Felles/Visningskomponenter/Tekster';
 import { ABlue300 } from '@navikt/ds-tokens/dist/tokens';
+import Informasjonsrad from '../../Vilkårpanel/Informasjonsrad';
+import { VilkårInfoIkon } from '../../Vilkårpanel/VilkårInformasjonKomponenter';
+import { FlexColumnContainer, InformasjonContainer } from '../../Vilkårpanel/StyledVilkårInnhold';
 
 const BlåStrek = styled.span`
     border-left: 2px solid ${ABlue300};
@@ -15,21 +17,11 @@ const BlåStrek = styled.span`
 
 const Flex = styled.div`
     display: flex;
-    margin-top: 0.25rem;
-    margin-bottom: 1rem;
 `;
 
 const BegrunnelseTekst = styled(BodyLongSmall)`
     margin-left: 1.32rem;
     max-width: 30rem;
-`;
-
-const HovedTabell = styled(GridTabell)`
-    margin-bottom: 0rem;
-`;
-
-const UtdanningTabell = styled(GridTabell)`
-    margin-bottom: 0.5rem;
 `;
 
 interface Props {
@@ -42,35 +34,34 @@ const UtdanningHensiktsmessigInfo: FC<Props> = ({ aktivitet, skalViseSøknadsdat
     return (
         <>
             {skalViseSøknadsdata ? (
-                <>
-                    <HovedTabell>
-                        <Dokumentasjonsvisning aktivitet={aktivitet} />
-                        <>
-                            <Søknadsgrunnlag />
-                            <BodyShortSmall>Målet med utdanningen</BodyShortSmall>
-                        </>
-                    </HovedTabell>
-                    <Flex>
-                        <BlåStrek />
-                        <BegrunnelseTekst>
-                            {underUtdanning?.hvaErMåletMedUtdanningen}
-                        </BegrunnelseTekst>
-                    </Flex>
-                    <UtdanningTabell>
-                        <>
-                            <Søknadsgrunnlag />
-                            <BodyShortSmall>Har tatt utdanning etter grunnskolen?</BodyShortSmall>
-                            <BodyShortSmall>
-                                {underUtdanning?.utdanningEtterGrunnskolen ? 'Ja' : 'Nei'}
-                            </BodyShortSmall>
-                        </>
-                    </UtdanningTabell>
-                    {underUtdanning?.utdanningEtterGrunnskolen && (
-                        <GridTabell kolonner={3}>
-                            <TidligereUtdanninger tidligereUtdanninger={tidligereUtdanninger} />
-                        </GridTabell>
-                    )}
-                </>
+                <InformasjonContainer>
+                    <Dokumentasjonsvisning aktivitet={aktivitet} />
+                    <FlexColumnContainer gap={0.75}>
+                        <Informasjonsrad
+                            ikon={VilkårInfoIkon.SØKNAD}
+                            label="Målet med utdanningen"
+                            verdi={undefined}
+                        />
+                        <Flex>
+                            <BlåStrek />
+                            <BegrunnelseTekst>
+                                {underUtdanning?.hvaErMåletMedUtdanningen}
+                            </BegrunnelseTekst>
+                        </Flex>
+                    </FlexColumnContainer>
+                    <FlexColumnContainer gap={1}>
+                        <Informasjonsrad
+                            ikon={VilkårInfoIkon.SØKNAD}
+                            label="Har tatt utdanning etter grunnskolen?"
+                            verdi={underUtdanning?.utdanningEtterGrunnskolen ? 'Ja' : 'Nei'}
+                        />
+                        {underUtdanning?.utdanningEtterGrunnskolen && (
+                            <GridTabell kolonner={3} underTabellMargin={0}>
+                                <TidligereUtdanninger tidligereUtdanninger={tidligereUtdanninger} />
+                            </GridTabell>
+                        )}
+                    </FlexColumnContainer>
+                </InformasjonContainer>
             ) : null}
         </>
     );

--- a/src/frontend/Komponenter/Behandling/Aktivitet/Skolepenger/UtdanningHensiktsmessigInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Skolepenger/UtdanningHensiktsmessigInfo.tsx
@@ -44,10 +44,7 @@ const UtdanningHensiktsmessigInfo: FC<Props> = ({ aktivitet, skalViseSøknadsdat
             {skalViseSøknadsdata ? (
                 <>
                     <HovedTabell>
-                        <Dokumentasjonsvisning
-                            aktivitet={aktivitet}
-                            skalViseSøknadsdata={skalViseSøknadsdata}
-                        />
+                        <Dokumentasjonsvisning aktivitet={aktivitet} />
                         <>
                             <Søknadsgrunnlag />
                             <BodyShortSmall>Målet med utdanningen</BodyShortSmall>


### PR DESCRIPTION
### Hensikt
Oppgave [TEA-10996](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10996)

Presentere informasjonen på aktivitetsvilkår for skolepenger på en strukturert og enhetlig måte ved å bruke felles komponenter for visning. 

### Hva er gjort

- Tatt i bruk `Informasjonsrad`
- Tatt i bruk `TabellVisning` for å presentere tabell
- Noe refaktorering
   - Fjernet at `tidligereUtdanninger` kan være `undefined` i `TidligereUtdanninger` fordi det ikke er nødvendig og forenkler logikken i komponenten. 
   - Flyttet sjekk av `skalViseSøknadsdata` ut av `DokumentasjonUtdanningInfo` fordi ikke noe skulle vises dersom denne var oppfylt, og den ble sendt videre som prop til child uten grunn. 
   
### Ekstra info
Ble litt mer enn bare informasjonsrad som ble endret, men 90% av informasjonsrad er samlet i første commit🫶

PR laget inn i eksisterende branch for å enklere kunne se endringene som er her (måtte branche ut for å få med informasjonsrad og resterende komponenter)

### Bilder
<img width="772" alt="image" src="https://user-images.githubusercontent.com/46678893/217466686-30db9286-db56-4cea-a5c0-8ff58522eb01.png">

