### PR TITLE
Fritekstbrev og frittstående brev for utestengelse

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
@@ -16,6 +16,8 @@ import {
     initielleAvsnittForlengetSvartidKlage,
     initielleAvsnittForlengetSvartid,
     initielleAvsnittTrukketSøknad,
+    initielleAvsnittVarselUtestengelse,
+    initielleAvsnittVedtaklUtestengelse,
 } from './BrevTyperTekst';
 import { IMellomlagretBrevResponse } from '../../../App/hooks/useMellomlagringBrev';
 import { Stønadstype } from '../../../App/typer/behandlingstema';
@@ -115,6 +117,8 @@ export enum FrittståendeBrevtype {
     BREV_OM_FORLENGET_SVARTID = 'BREV_OM_FORLENGET_SVARTID',
     BREV_OM_FORLENGET_SVARTID_KLAGE = 'BREV_OM_FORLENGET_SVARTID_KLAGE',
     INFORMASJONSBREV_TRUKKET_SØKNAD = 'INFORMASJONSBREV_TRUKKET_SØKNAD',
+    VARSEL_UTESTENGELSE = 'VARSEL_UTESTENGELSE',
+    VEDTAK_UTESTENGELSE = 'VEDTAK_UTESTENGELSE',
 }
 
 export enum FritekstBrevtype {
@@ -129,6 +133,7 @@ export enum FritekstBrevtype {
     VEDTAK_AVSLAG_SKOLEPENGER = 'VEDTAK_AVSLAG_SKOLEPENGER',
     VEDTAK_OPPHØR_BARNETILSYN = 'VEDTAK_OPPHØR_BARNETILSYN',
     VEDTAK_OPPHØR_SKOLEPENGER = 'VEDTAK_OPPHØR_SKOLEPENGER',
+    VEDTAK_UTESTENGELSE = 'VEDTAK_UTESTENGELSE',
 }
 
 export const BrevtyperTilOverskrift: Record<FrittståendeBrevtype | FritekstBrevtype, string> = {
@@ -153,6 +158,10 @@ export const BrevtyperTilOverskrift: Record<FrittståendeBrevtype | FritekstBrev
     BREV_OM_FORLENGET_SVARTID: 'Saksbehandlingen vil ta lenger tid',
     BREV_OM_FORLENGET_SVARTID_KLAGE: 'Saksbehandlingen vil ta lenger tid',
     INFORMASJONSBREV_TRUKKET_SØKNAD: 'Saken din om [stønad] er avsluttet',
+    VARSEL_UTESTENGELSE:
+        'Vi vurderer å ta fra deg retten til stønad til enslig mor eller far i en periode',
+    VEDTAK_UTESTENGELSE:
+        'Vi har tatt fra deg retten til stønad til enslig mor eller far i en periode',
 };
 
 export const BrevtyperTilSelectNavn: Record<
@@ -181,6 +190,8 @@ export const BrevtyperTilSelectNavn: Record<
     BREV_OM_FORLENGET_SVARTID: 'Brev om forlenget svartid',
     BREV_OM_FORLENGET_SVARTID_KLAGE: 'Brev om forlenget svartid - klage',
     INFORMASJONSBREV_TRUKKET_SØKNAD: 'Informasjonsbrev - bruker har trukket søknad',
+    VARSEL_UTESTENGELSE: 'Varsel om utestengelse',
+    VEDTAK_UTESTENGELSE: 'Vedtak om utestengelse',
 };
 
 export const stønadstypeTilBrevtyper: Record<Stønadstype, FritekstBrevtype[]> = {
@@ -190,16 +201,19 @@ export const stønadstypeTilBrevtyper: Record<Stønadstype, FritekstBrevtype[]> 
         FritekstBrevtype.VEDTAK_AVSLAG,
         FritekstBrevtype.VEDTAK_OPPHØR,
         FritekstBrevtype.VEDTAK_REVURDERING,
+        FritekstBrevtype.VEDTAK_UTESTENGELSE,
     ],
     BARNETILSYN: [
         FritekstBrevtype.VEDTAK_INNVILGELSE_BARNETILSYN,
         FritekstBrevtype.VEDTAK_AVSLAG_BARNETILSYN,
         FritekstBrevtype.VEDTAK_OPPHØR_BARNETILSYN,
+        FritekstBrevtype.VEDTAK_UTESTENGELSE,
     ],
     SKOLEPENGER: [
         FritekstBrevtype.VEDTAK_INNVILGELSE_SKOLEPENGER,
         FritekstBrevtype.VEDTAK_AVSLAG_SKOLEPENGER,
         FritekstBrevtype.VEDTAK_OPPHØR_SKOLEPENGER,
+        FritekstBrevtype.VEDTAK_UTESTENGELSE,
     ],
 };
 
@@ -228,6 +242,8 @@ export const BrevtyperTilAvsnitt: Record<FrittståendeBrevtype | FritekstBrevtyp
         BREV_OM_FORLENGET_SVARTID: initielleAvsnittForlengetSvartid,
         BREV_OM_FORLENGET_SVARTID_KLAGE: initielleAvsnittForlengetSvartidKlage,
         INFORMASJONSBREV_TRUKKET_SØKNAD: initielleAvsnittTrukketSøknad,
+        VARSEL_UTESTENGELSE: initielleAvsnittVarselUtestengelse,
+        VEDTAK_UTESTENGELSE: initielleAvsnittVedtaklUtestengelse,
     };
 
 export enum FritekstBrevContext {

--- a/src/frontend/Komponenter/Behandling/Brev/BrevTyperTekst.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevTyperTekst.ts
@@ -405,3 +405,43 @@ export const initielleAvsnittTrukketSøknad: AvsnittMedId[] = [
         id: uuidv4(),
     },
 ];
+
+export const initielleAvsnittVedtaklUtestengelse: AvsnittMedId[] = [
+    {
+        deloverskrift: 'Du har rett til å klage',
+        innhold:
+            'Hvis du vil klage, må du gjøre dette innen 6 uker fra den datoen du fikk dette vedtaket. Du finner skjema og informasjon på klage.nav.no/nb/familie/enslig-mor-eller-far.',
+        id: uuidv4(),
+    },
+    {
+        deloverskrift: 'Du har rett til innsyn',
+        innhold: 'På nav.no/minside kan du se dokumentene i saken din.',
+        id: uuidv4(),
+    },
+    {
+        deloverskrift: 'Har du spørsmål?',
+        innhold:
+            'Du finner informasjon som kan være nyttig for deg på nav.no/alene-med-barn. Du kan også kontakte oss på nav.no/kontakt.',
+        id: uuidv4(),
+    },
+];
+
+export const initielleAvsnittVarselUtestengelse: AvsnittMedId[] = [
+    {
+        deloverskrift: 'Slik uttaler du deg',
+        innhold:
+            'Du kan sende uttalelsen din ved å skrive en beskjed til oss på nav.no/skriv-til-oss.',
+        id: uuidv4(),
+    },
+    {
+        deloverskrift: 'Saksbehandlingstid',
+        innhold: 'Saksbehandlingstidene finner du på nav.no/saksbehandlingstider.',
+        id: uuidv4(),
+    },
+    {
+        deloverskrift: 'Har du spørsmål?',
+        innhold:
+            'Du finner informasjon som kan være nyttig for deg på nav.no/alene-med-barn. Du kan også kontakte oss på nav.no/kontakt.',
+        id: uuidv4(),
+    },
+];


### PR DESCRIPTION
Skal legge til nye brev for bruk ved utestengelse. Vedtaksbrevet skal kunne sendes både fra en behandling og fra den frittstående brevutsenderen. Varselbrevet skal bare finnes i frittstående brevutsender.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10009)

### Vedtaksbrev i behandlingsflyt
![image](https://user-images.githubusercontent.com/21220467/217475547-ab4ea860-4917-4a26-9b55-c8e71830297c.png)

### Varselbrev frittstående brev
![image](https://user-images.githubusercontent.com/21220467/217475791-c878318f-3cac-49e9-8a1f-df14a56be88b.png)


### Vedtaksbrev frittstående brev
![image](https://user-images.githubusercontent.com/21220467/217475936-4ba768ab-4d05-4a43-88cb-eac971df6b7a.png)
