### PR TITLE
skal utbedre gui for vedtak og beregning for barnetilsyn

### DIFF
--- a/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
@@ -45,6 +45,8 @@ const HøyreMenyWrapper = styled.div<HøyreMenyWrapperProps>`
     min-width: ${(p) => (p.åpenHøyremeny ? '20rem' : '1.5rem')};
 
     transition: all 0.25s;
+
+    z-index: 10;
 `;
 
 const InnholdWrapper = styled.div<InnholdWrapperProps>`

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtgiftsperiodeValg.tsx
@@ -30,7 +30,7 @@ const UtgiftsperiodeRad = styled.div<{ lesevisning?: boolean; erHeader?: boolean
     grid-template-columns: ${(props) =>
         props.lesevisning
             ? '8rem 8rem 10rem 10rem 12rem 4rem 4rem'
-            : '10rem 10rem 14rem 14rem 25rem 2rem 4rem 3rem 3rem'};
+            : '10rem 10rem 12.5rem 12.5rem 25rem 2rem 4rem 3rem 3rem'};
     grid-gap: ${(props) => (props.lesevisning ? '0.5rem' : '1rem')};
     padding-bottom: ${(props) => (props.erHeader ? '0.5rem' : 0)};
 `;
@@ -52,6 +52,14 @@ const IkonKnappWrapper = styled.div`
     display: block;
 `;
 
+const HorizontalScroll = styled.div<{ åpenHøyremeny: boolean }>`
+    @media screen and (max-width: ${(p) => (p.åpenHøyremeny ? '1770px' : '1470px')}) {
+        overflow-x: scroll;
+        overflow-y: hidden;
+        white-space: nowrap;
+    }
+`;
+
 interface Props {
     utgiftsperioder: ListState<IUtgiftsperiode>;
     valideringsfeil?: FormErrors<InnvilgeVedtakForm>['utgiftsperioder'];
@@ -67,7 +75,7 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
     barn,
     låsFraDatoFørsteRad,
 }) => {
-    const { behandlingErRedigerbar } = useBehandling();
+    const { behandlingErRedigerbar, åpenHøyremeny } = useBehandling();
     const { settIkkePersistertKomponent } = useApp();
 
     const oppdaterUtgiftsperiode = (
@@ -125,7 +133,7 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
     };
 
     return (
-        <>
+        <HorizontalScroll åpenHøyremeny={åpenHøyremeny}>
             <UtgiftsperiodeRad lesevisning={!behandlingErRedigerbar} erHeader>
                 <Label>Periodetype</Label>
                 <Label>Aktivitet</Label>
@@ -248,6 +256,16 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
                                 hideLabel
                             />
                         )}
+                        {behandlingErRedigerbar && (
+                            <IkonKnappWrapper>
+                                <Tooltip content="Legg til rad under" placement="right">
+                                    <LeggTilKnapp
+                                        onClick={() => leggTilTomRadUnder(index)}
+                                        ikontekst={'Legg til ny rad'}
+                                    />
+                                </Tooltip>
+                            </IkonKnappWrapper>
+                        )}
                         {skalViseFjernKnapp ? (
                             <IkonKnappWrapper>
                                 <FjernKnapp
@@ -268,16 +286,6 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
                         ) : (
                             <div />
                         )}
-                        {behandlingErRedigerbar && (
-                            <IkonKnappWrapper>
-                                <Tooltip content="Legg til rad under" placement="right">
-                                    <LeggTilKnapp
-                                        onClick={() => leggTilTomRadUnder(index)}
-                                        ikontekst={'Legg til ny rad'}
-                                    />
-                                </Tooltip>
-                            </IkonKnappWrapper>
-                        )}
                     </UtgiftsperiodeRad>
                 );
             })}
@@ -289,7 +297,7 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
                     />
                 )}
             </ContainerMedLuftUnder>
-        </>
+        </HorizontalScroll>
     );
 };
 


### PR DESCRIPTION
Har utbedret gui for vedtak og beregningsfanen for barnetilsyn, [favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10984)

Det som er gjort er:
- Jevnet ut space mellom alle komponentene for utgiftsperioderad
- Endret rekkefølge på legg til rad knapp og slett knapp for utgiftsperioderad
- Sørget for at komponentene i utgiftsperioderad opptrer "bak" høyremenyen når disse elementene overlapper
- Lagt til en horisontal scroll på utgiftsperioderad når skjermen blir for smal til å vise hele raden

Disse gjøremålene er visualisert under:
![image](https://user-images.githubusercontent.com/32769446/217481955-8cb17914-58ec-46f2-b9a5-c138cdb62451.png)

Slik ser det nå ut:
Vanlig tilstand:
![Skjermbilde 2023-02-08 kl  09 57 54](https://user-images.githubusercontent.com/32769446/217482497-7c3529be-b087-4b4c-8622-9a830bf7c4da.png)

Med scrollbar:
![Skjermbilde 2023-02-08 kl  09 58 27](https://user-images.githubusercontent.com/32769446/217482644-3dbf56c6-b1c7-4f34-bf78-44f57652f9b6.png)


