### PR TITLE
Skal vise annen forelder sin bostedsadresse på aleneomsorg

### DIFF
--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/AnnenForelderOpplysninger.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/AnnenForelderOpplysninger.tsx
@@ -70,22 +70,20 @@ const AnnenForelderOpplysninger: FC<Props> = ({ forelderRegister, søknadsgrunnl
                 />
             )}
 
-            {!visForelderSøknadInfo &&
-                forelderRegister &&
-                harNavnFødselsdatoEllerFnr(forelderRegister) && (
-                    <Informasjonsrad
-                        ikon={VilkårInfoIkon.REGISTER}
-                        label="Annen forelder"
-                        verdiSomString={false}
-                        verdi={
-                            forelderRegister ? (
-                                <AnnenForelderNavnOgFnr forelder={forelderRegister} />
-                            ) : (
-                                <BodyShortSmall>-</BodyShortSmall>
-                            )
-                        }
-                    />
-                )}
+            {!visForelderSøknadInfo && forelderRegister && (
+                <Informasjonsrad
+                    ikon={VilkårInfoIkon.REGISTER}
+                    label="Annen forelder"
+                    verdiSomString={false}
+                    verdi={
+                        forelderRegister ? (
+                            <AnnenForelderNavnOgFnr forelder={forelderRegister} />
+                        ) : (
+                            <BodyShortSmall>-</BodyShortSmall>
+                        )
+                    }
+                />
+            )}
 
             {forelderRegister?.dødsfall && (
                 <Informasjonsrad
@@ -106,19 +104,27 @@ const AnnenForelderOpplysninger: FC<Props> = ({ forelderRegister, søknadsgrunnl
                         />
                     )}
 
-                    {!visForelderSøknadInfo &&
-                        forelderRegister &&
-                        harNavnFødselsdatoEllerFnr(forelderRegister) && (
-                            <Informasjonsrad
-                                ikon={VilkårInfoIkon.REGISTER}
-                                label="Annen forelder bor i"
-                                verdi={
-                                    forelderRegister?.bosattINorge
-                                        ? 'Norge'
-                                        : forelderRegister.land || '-'
-                                }
-                            />
-                        )}
+                    {!visForelderSøknadInfo && forelderRegister && (
+                        <Informasjonsrad
+                            ikon={VilkårInfoIkon.REGISTER}
+                            label="Annen forelder bor i"
+                            verdi={
+                                forelderRegister?.bosattINorge
+                                    ? 'Norge'
+                                    : forelderRegister.land || '-'
+                            }
+                        />
+                    )}
+                    {forelderRegister && (
+                        <Informasjonsrad
+                            ikon={VilkårInfoIkon.REGISTER}
+                            label="Annen forelders adresse"
+                            verdi={
+                                forelderRegister?.visningsadresse ||
+                                'Mangler gjeldende bostedsadresse'
+                            }
+                        />
+                    )}
                 </>
             )}
 

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/typer.ts
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/typer.ts
@@ -62,6 +62,7 @@ export interface IAnnenForelder {
     fødselsdato?: string;
     bosattINorge?: boolean;
     land?: string;
+    visningsadresse?: string;
     dødsfall?: string;
     tidligereVedtaksperioder?: ITidligereVedtaksperioder;
     avstandTilSøker: IAvstandTilSøker;


### PR DESCRIPTION
* Fjernet sjekk av harNavnFødselsdatoEllerFnr på forelderRegister då den informasjonen burde finnes hvis forelderRegister finnes

En del av https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10864

<img width="488" alt="image" src="https://user-images.githubusercontent.com/937168/217498093-3cb54934-04a6-437a-bfbe-cea9c62f6114.png">
