### PR TITLE
Bugfix. Fjerner ! som skjuler komponent i samlivinfo ved motsatt situasjon

### DIFF
--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Samliv/SamlivInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Samliv/SamlivInfo.tsx
@@ -30,7 +30,7 @@ const SamlivInfo: FC<Props> = ({
 
     return (
         <InformasjonContainer>
-            {!skalViseSøknadsdata &&
+            {skalViseSøknadsdata &&
                 sivilstand.søknadsgrunnlag &&
                 bosituasjon &&
                 sivilstandsplaner && (


### PR DESCRIPTION
Har sneket med seg et utropstegn i en tidligere merge som gjør at informasjon av bor alene hvis vises i feil situasjon. 