### PR TITLE
horisontal scrollbar skal alltid vises under utgiftsperioderad for ba…

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtgiftsperiodeValg.tsx
@@ -25,6 +25,7 @@ import { erOpphørEllerSanksjon, tomUtgiftsperiodeRad } from './utils';
 import PeriodetypeSelect from './PeriodetypeSelect';
 import AktivitetSelect from './AktivitetSelect';
 import { Sanksjonsmodal, SlettSanksjonsperiodeModal } from '../Felles/SlettSanksjonsperiodeModal';
+import { AGrayalpha300, AGrayalpha600, AWhite } from '@navikt/ds-tokens/dist/tokens';
 
 const UtgiftsperiodeRad = styled.div<{ lesevisning?: boolean; erHeader?: boolean }>`
     display: grid;
@@ -55,6 +56,25 @@ const IkonKnappWrapper = styled.div`
 
 const HorizontalScroll = styled.div<{ åpenHøyremeny: boolean }>`
     @media screen and (max-width: ${(p) => (p.åpenHøyremeny ? '1770px' : '1470px')}) {
+        // Noen mac innstillinger fjerner scroll-baren fra nettsiden. Denne stylingen gjør slik at baren alltid vises
+        // dersom det er behov for horisontal scrolling. Kun støttet i chrome.
+        ::-webkit-scrollbar {
+            -webkit-appearance: none;
+        }
+        ::-webkit-scrollbar:horizontal {
+            height: 11px;
+        }
+        ::-webkit-scrollbar-thumb {
+            border-radius: 8px;
+            border: 2px solid ${AWhite};
+            background-color: ${AGrayalpha300};
+        }
+        ::-webkit-scrollbar-thumb:hover {
+            background-color: ${AGrayalpha600};
+        }
+        ::-webkit-scrollbar-track {
+            background-color: ${AWhite};
+        }
         overflow-x: scroll;
         overflow-y: hidden;
         white-space: nowrap;


### PR DESCRIPTION
…rnetilsyn, dersom skjermen er smal

Etter demo på fredag kom det frem at horisontal scrollbar ikke alltid opptrer selv om skjermen er small. Grunnen til dette er egne innstillinger på macen som i noen tilfeller skjuler scrollbars i nettleseren. Dette er en fix som sørger for at scrollbaren alltid er synlig dersom skjermen er small nok. Fixen støttes kun i Chrome.

Baren ser slik ut i Chrome:
![Skjermbilde 2023-02-13 kl  13 15 32](https://user-images.githubusercontent.com/32769446/218455761-d52e552a-0370-41f6-8eac-cafab2da98e9.png)

I andre nettlesere har den standardvisning, vist her med Firefox:
![Skjermbilde 2023-02-13 kl  13 15 24](https://user-images.githubusercontent.com/32769446/218455858-fcd41dbf-2c9c-4c5a-8f0a-29ba118852ab.png)

