### PR TITLE
Adressehistorikk kolonnetitler fom tom hjelpetekst

### DIFF
--- a/src/frontend/Felles/Personopplysninger/Adressehistorikk.tsx
+++ b/src/frontend/Felles/Personopplysninger/Adressehistorikk.tsx
@@ -9,6 +9,7 @@ import { formaterNullableIsoDato } from '../../App/utils/formatter';
 import { ModalWrapper } from '../Modal/ModalWrapper';
 import UtvidPanel from '../UtvidPanel/UtvidPanel';
 import { Button, HelpText, Label } from '@navikt/ds-react';
+import { BodyLongSmall } from '../Visningskomponenter/Tekster';
 
 const StyledFlexDiv = styled.div`
     display: flex;
@@ -18,6 +19,10 @@ const StyledFlexDiv = styled.div`
 const Knapp = styled(Button)`
     padding-left: 1.25rem;
     padding-right: 1.25rem;
+`;
+
+const FetTekst = styled.span`
+    font-weight: bold;
 `;
 
 const MAX_LENGDE_ADRESSER = 5;
@@ -80,9 +85,25 @@ const Kolonnetittel: React.FC<{ text: string; width: number }> = ({ text, width 
 
 const TittelbeskrivelseBostedsadresser: React.ReactElement = (
     <HelpText title="Gjeldende" placement={'right'}>
-        En person skal til enhver tid ha kun en folkeregistrert bostedsadresse. I EF Sak er denne
-        adressen markert med "(gjeldende)". Vær oppmerksom på at det i noen tilfeller ikke vil være
-        adressen med den nyeste fra-datoen som er gjeldende.
+        <BodyLongSmall>
+            <FetTekst>Gjeldende adresse:</FetTekst>
+            En person skal til enhver tid ha kun én folkeregistrert bostedsadresse. I EF Sak er
+            denne adressen markert med "(gjeldende)". Vær oppmerksom på at det i noen tilfeller ikke
+            vil være adressen med den nyeste fra-datoen som er gjeldende
+        </BodyLongSmall>
+        <BodyLongSmall>
+            <FetTekst>Angitt flyttedato:</FetTekst>Datoen personen selv har oppgitt for flytting til
+            ny bolig
+        </BodyLongSmall>
+        <BodyLongSmall>
+            <FetTekst>Fra og med (FOM):</FetTekst>
+            Folkeregisterets vedtaksdato for gyldighet på bostedsregistreringen
+        </BodyLongSmall>
+        <BodyLongSmall>
+            <FetTekst>Til og med (TOM):</FetTekst>
+            Folkeregisterets opphørsdato (dersom den er kjent). Personen er ikke registrert bosatt
+            på adressen iht Folkeregisteret
+        </BodyLongSmall>
     </HelpText>
 );
 
@@ -115,8 +136,8 @@ const Adresser: React.FC<{ adresser: IAdresse[]; fagsakPersonId: string; type?: 
                                 }
                                 width={15}
                             />
-                            <Kolonnetittel text={'Fra'} width={15} />
-                            <Kolonnetittel text={'Til'} width={20} />
+                            <Kolonnetittel text={'FOM'} width={15} />
+                            <Kolonnetittel text={'TOM'} width={20} />
                         </tr>
                     </thead>
                     <Innhold adresser={adresser} fagsakPersonId={fagsakPersonId} />

--- a/src/frontend/Felles/Personopplysninger/Adressehistorikk.tsx
+++ b/src/frontend/Felles/Personopplysninger/Adressehistorikk.tsx
@@ -84,7 +84,7 @@ const Kolonnetittel: React.FC<{ text: string; width: number }> = ({ text, width 
 );
 
 const TittelbeskrivelseBostedsadresser: React.ReactElement = (
-    <HelpText title="Gjeldende" placement={'right'}>
+    <HelpText title="Gjeldende og kolonner" placement={'right'}>
         <BodyLongSmall>
             <FetTekst>Gjeldende adresse:</FetTekst>
             En person skal til enhver tid ha kun én folkeregistrert bostedsadresse. I EF Sak er
@@ -96,11 +96,11 @@ const TittelbeskrivelseBostedsadresser: React.ReactElement = (
             ny bolig
         </BodyLongSmall>
         <BodyLongSmall>
-            <FetTekst>Fra og med (FOM):</FetTekst>
+            <FetTekst>Fra og med:</FetTekst>
             Folkeregisterets vedtaksdato for gyldighet på bostedsregistreringen
         </BodyLongSmall>
         <BodyLongSmall>
-            <FetTekst>Til og med (TOM):</FetTekst>
+            <FetTekst>Til og med:</FetTekst>
             Folkeregisterets opphørsdato (dersom den er kjent). Personen er ikke registrert bosatt
             på adressen iht Folkeregisteret
         </BodyLongSmall>
@@ -136,8 +136,8 @@ const Adresser: React.FC<{ adresser: IAdresse[]; fagsakPersonId: string; type?: 
                                 }
                                 width={15}
                             />
-                            <Kolonnetittel text={'FOM'} width={15} />
-                            <Kolonnetittel text={'TOM'} width={20} />
+                            <Kolonnetittel text={'Fra og med'} width={15} />
+                            <Kolonnetittel text={'Til og med'} width={20} />
                         </tr>
                     </thead>
                     <Innhold adresser={adresser} fagsakPersonId={fagsakPersonId} />


### PR DESCRIPTION
Det var også ønskelig å endre kolonnetitler til å være mer lik titlene i gosys.
Har også oppdatert hjelpeteksten. 

Korrigering av https://github.com/navikt/familie-ef-sak-frontend/pull/2107
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-11467

<img width="1714" alt="image" src="https://user-images.githubusercontent.com/937168/220190886-ff5c2388-781a-4bd0-9cd5-aab6b8822d21.png">

<img width="863" alt="image" src="https://user-images.githubusercontent.com/937168/220190917-c5654ab7-08b2-4eb7-ada4-083b2b85a0a1.png">
