### PR TITLE
Skal ikke hente beløpsperioder ved sanksjon

### DIFF
--- a/src/frontend/App/hooks/useHentBeløpsperioder.ts
+++ b/src/frontend/App/hooks/useHentBeløpsperioder.ts
@@ -37,7 +37,8 @@ export const useHentBeløpsperioder = (
         (vedtaksresultat: EBehandlingResultat | undefined) => {
             if (
                 harVedtaksresultatMedTilkjentYtelse(vedtaksresultat) &&
-                vedtaksresultat != EBehandlingResultat.OPPHØRT
+                vedtaksresultat != EBehandlingResultat.OPPHØRT &&
+                vedtaksresultat != EBehandlingResultat.SANKSJONERE
             ) {
                 const behandlingConfig: AxiosRequestConfig = {
                     method: 'GET',


### PR DESCRIPTION
Dersom vedtaksresultat er SANKSJONERE vil beløpsperioder aldri bli brukt i frontend/brev

Gjør dette for å løse https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-10031
(kan gi sanksjon 1 måned for barnetilsyn, uten påfølgende brevfeil)
![image](https://user-images.githubusercontent.com/21220467/221171588-558542e0-ab20-4adf-ae8d-96523ccfe81d.png)
