### PR TITLE
Disable automatiske flettefelt og legg til beskrivelse

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
@@ -19,7 +19,7 @@ const DelmalValg = styled.div`
     gap: 0.5rem;
 `;
 
-const StyledInnhold = styled(Accordion.Content)`
+const AccordionInnhold = styled(Accordion.Content)`
     display: flex;
     flex-direction: column;
     gap: 1rem;
@@ -102,7 +102,7 @@ export const BrevMenyDelmal: React.FC<Props> = ({
                         {delmal?.delmalNavn}
                     </Accordion.Header>
                     {ekspanderbartPanelÅpen && (
-                        <StyledInnhold style={{ border: 'none', padding: '1rem' }}>
+                        <AccordionInnhold>
                             {delmalValgfelt &&
                                 delmalValgfelt.map((valgFelt, index) => (
                                     <ValgfeltSelect
@@ -134,7 +134,7 @@ export const BrevMenyDelmal: React.FC<Props> = ({
                                         key={flettefelt._ref}
                                     />
                                 ))}
-                        </StyledInnhold>
+                        </AccordionInnhold>
                     )}
                 </Accordion.Item>
             </Accordion>

--- a/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
@@ -19,6 +19,14 @@ const DelmalValg = styled.div`
     gap: 0.5rem;
 `;
 
+const StyledInnhold = styled(Accordion.Content)`
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    border: none;
+    padding: 1rem;
+`;
+
 interface Props {
     delmal: Delmal;
     dokument: BrevStruktur;
@@ -94,7 +102,7 @@ export const BrevMenyDelmal: React.FC<Props> = ({
                         {delmal?.delmalNavn}
                     </Accordion.Header>
                     {ekspanderbartPanelÅpen && (
-                        <Accordion.Content style={{ border: 'none', padding: '1rem' }}>
+                        <StyledInnhold style={{ border: 'none', padding: '1rem' }}>
                             {delmalValgfelt &&
                                 delmalValgfelt.map((valgFelt, index) => (
                                     <ValgfeltSelect
@@ -126,7 +134,7 @@ export const BrevMenyDelmal: React.FC<Props> = ({
                                         key={flettefelt._ref}
                                     />
                                 ))}
-                        </Accordion.Content>
+                        </StyledInnhold>
                     )}
                 </Accordion.Item>
             </Accordion>

--- a/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
@@ -50,6 +50,7 @@ export interface Flettefeltreferanse {
 
 export interface FlettefeltMedVerdi extends Flettefeltreferanse {
     verdi: string | null;
+    automatiskUtfylt: boolean;
 }
 
 export interface Valgmulighet {

--- a/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
@@ -42,6 +42,7 @@ interface Flettefelt {
     erFritektsfelt?: boolean;
     feltVisningsnavn?: string;
     _id: string;
+    beskrivelse?: string;
 }
 
 export interface Flettefeltreferanse {
@@ -66,6 +67,7 @@ export interface ValgFelt {
     valgMuligheter: Valgmulighet[];
     valgfeltVisningsnavn: string;
     valgFeltApiNavn: string;
+    valgfeltBeskrivelse?: string;
 }
 
 export interface Delmal {

--- a/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
@@ -51,7 +51,7 @@ export interface Flettefeltreferanse {
 
 export interface FlettefeltMedVerdi extends Flettefeltreferanse {
     verdi: string | null;
-    automatiskUtfylt: boolean;
+    automatiskUtfylt?: boolean;
 }
 
 export interface Valgmulighet {

--- a/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
@@ -73,6 +73,7 @@ export const initFlettefelterMedVerdi = (
         verdi:
             flettefeltStore[flettefeltReferanse.felt] ||
             hentVerdiFraMellomlagerEllerNull(flettefeltFraMellomlager, flettefeltReferanse._id),
+        automatiskUtfylt: !!flettefeltStore[flettefeltReferanse.felt],
     }));
 
 export const initValgteFelt = (

--- a/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
@@ -17,16 +17,22 @@ const lagTomtAvsnitt = (): AvsnittMedId => ({
     id: uuidv4(),
 });
 
-export const finnFlettefeltVisningsnavnFraRef = (dokument: BrevStruktur, ref: string): string => {
-    const flettefeltNavnFraRef = dokument?.flettefelter?.flettefeltReferanse?.find(
+export const finnFlettefeltNavnOgBeskrivelseFraRef = (
+    dokument: BrevStruktur,
+    ref: string
+): { flettefeltNavn: string; flettefeltBeskrivelse?: string } => {
+    const flettefeltFraRef = dokument?.flettefelter?.flettefeltReferanse?.find(
         (felt) => felt._id === ref
     );
 
-    if (!flettefeltNavnFraRef) return '';
+    if (!flettefeltFraRef) return { flettefeltNavn: '' };
 
-    return flettefeltNavnFraRef.feltVisningsnavn
-        ? flettefeltNavnFraRef.feltVisningsnavn
-        : flettefeltNavnFraRef.felt;
+    return {
+        flettefeltNavn: flettefeltFraRef.feltVisningsnavn
+            ? flettefeltFraRef.feltVisningsnavn
+            : flettefeltFraRef.felt,
+        flettefeltBeskrivelse: flettefeltFraRef.beskrivelse,
+    };
 };
 
 export const finnFletteFeltApinavnFraRef = (dokument: BrevStruktur, ref: string): string => {

--- a/src/frontend/Komponenter/Behandling/Brev/Flettefelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Flettefelt.tsx
@@ -27,6 +27,8 @@ export const Flettefelt: React.FC<Props> = ({
     flettefelter,
     handleFlettefeltInput,
 }) => {
+    const flettefeltMedVerdi = flettefelter?.find((felt) => felt._ref === flettefelt._ref);
+
     if (erFlettefeltFritektsfelt(dokument, flettefelt._ref)) {
         return (
             <Textarea
@@ -34,7 +36,7 @@ export const Flettefelt: React.FC<Props> = ({
                 onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
                     handleFlettefeltInput(e.target.value, flettefelt);
                 }}
-                value={flettefelter?.find((felt) => felt._ref === flettefelt._ref)?.verdi || ''}
+                value={flettefeltMedVerdi?.verdi || ''}
                 maxLength={0}
             />
         );
@@ -46,7 +48,8 @@ export const Flettefelt: React.FC<Props> = ({
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                     handleFlettefeltInput(e.target.value, flettefelt);
                 }}
-                value={flettefelter?.find((felt) => felt._ref === flettefelt._ref)?.verdi || ''}
+                value={flettefeltMedVerdi?.verdi || ''}
+                disabled={flettefeltMedVerdi?.automatiskUtfylt}
             />
         );
     }

--- a/src/frontend/Komponenter/Behandling/Brev/Flettefelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Flettefelt.tsx
@@ -1,8 +1,8 @@
-import { erFlettefeltFritektsfelt, finnFlettefeltVisningsnavnFraRef } from './BrevUtils';
+import { erFlettefeltFritektsfelt, finnFlettefeltNavnOgBeskrivelseFraRef } from './BrevUtils';
 import React from 'react';
 import { BrevStruktur, FlettefeltMedVerdi, Flettefeltreferanse } from './BrevTyper';
 import styled from 'styled-components';
-import { BodyShort, Label, Textarea, TextField } from '@navikt/ds-react';
+import { BodyShort, HelpText, Label, Textarea, TextField } from '@navikt/ds-react';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const StyledInput = styled(({ fetLabel, ...props }) => <TextField autoComplete="off" {...props} />)`
@@ -10,6 +10,11 @@ const StyledInput = styled(({ fetLabel, ...props }) => <TextField autoComplete="
     .skjemaelement__label {
         font-weight: ${(fetLabel) => (fetLabel ? 600 : 300)};
     }
+`;
+
+const TekstMedHjelpetekstWrapper = styled.div`
+    display: flex;
+    gap: 1rem;
 `;
 
 interface Props {
@@ -28,11 +33,15 @@ export const Flettefelt: React.FC<Props> = ({
     handleFlettefeltInput,
 }) => {
     const flettefeltMedVerdi = flettefelter?.find((felt) => felt._ref === flettefelt._ref);
+    const { flettefeltNavn, flettefeltBeskrivelse } = finnFlettefeltNavnOgBeskrivelseFraRef(
+        dokument,
+        flettefelt._ref
+    );
 
     if (erFlettefeltFritektsfelt(dokument, flettefelt._ref)) {
         return (
             <Textarea
-                label={finnFlettefeltVisningsnavnFraRef(dokument, flettefelt._ref)}
+                label={flettefeltNavn}
                 onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
                     handleFlettefeltInput(e.target.value, flettefelt);
                 }}
@@ -43,13 +52,17 @@ export const Flettefelt: React.FC<Props> = ({
     } else {
         return flettefeltMedVerdi?.automatiskUtfylt ? (
             <div>
-                <Label>{finnFlettefeltVisningsnavnFraRef(dokument, flettefelt._ref)}</Label>
-                <BodyShort>{flettefeltMedVerdi.verdi}</BodyShort>
+                <Label>{flettefeltNavn}</Label>
+                <TekstMedHjelpetekstWrapper>
+                    <BodyShort>{flettefeltMedVerdi.verdi}</BodyShort>
+                    {flettefeltBeskrivelse && <HelpText>{flettefeltBeskrivelse}</HelpText>}
+                </TekstMedHjelpetekstWrapper>
             </div>
         ) : (
             <StyledInput
                 fetLabel={fetLabel}
-                label={finnFlettefeltVisningsnavnFraRef(dokument, flettefelt._ref)}
+                description={flettefeltBeskrivelse}
+                label={flettefeltNavn}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
                     handleFlettefeltInput(e.target.value, flettefelt);
                 }}

--- a/src/frontend/Komponenter/Behandling/Brev/Flettefelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Flettefelt.tsx
@@ -2,7 +2,7 @@ import { erFlettefeltFritektsfelt, finnFlettefeltVisningsnavnFraRef } from './Br
 import React from 'react';
 import { BrevStruktur, FlettefeltMedVerdi, Flettefeltreferanse } from './BrevTyper';
 import styled from 'styled-components';
-import { Textarea, TextField } from '@navikt/ds-react';
+import { BodyShort, Label, Textarea, TextField } from '@navikt/ds-react';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const StyledInput = styled(({ fetLabel, ...props }) => <TextField autoComplete="off" {...props} />)`
@@ -41,7 +41,12 @@ export const Flettefelt: React.FC<Props> = ({
             />
         );
     } else {
-        return (
+        return flettefeltMedVerdi?.automatiskUtfylt ? (
+            <div>
+                <Label>{finnFlettefeltVisningsnavnFraRef(dokument, flettefelt._ref)}</Label>
+                <BodyShort>{flettefeltMedVerdi.verdi}</BodyShort>
+            </div>
+        ) : (
             <StyledInput
                 fetLabel={fetLabel}
                 label={finnFlettefeltVisningsnavnFraRef(dokument, flettefelt._ref)}

--- a/src/frontend/Komponenter/Behandling/Brev/Flettefelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Flettefelt.tsx
@@ -67,7 +67,6 @@ export const Flettefelt: React.FC<Props> = ({
                     handleFlettefeltInput(e.target.value, flettefelt);
                 }}
                 value={flettefeltMedVerdi?.verdi || ''}
-                disabled={flettefeltMedVerdi?.automatiskUtfylt}
             />
         );
     }

--- a/src/frontend/Komponenter/Behandling/Brev/ValgfeltSelect.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/ValgfeltSelect.tsx
@@ -13,7 +13,9 @@ import styled from 'styled-components';
 import { Checkbox, Label, Select } from '@navikt/ds-react';
 
 const StyledValgfeltSelect = styled.div`
-    padding-bottom: 0.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
 `;
 
 interface Props {

--- a/src/frontend/Komponenter/Behandling/Brev/ValgfeltSelect.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/ValgfeltSelect.tsx
@@ -75,6 +75,7 @@ export const ValgfeltSelect: React.FC<Props> = ({
                     onChange={(e) =>
                         doSettValgteFelt(valgFelt.valgFeltApiNavn, e.target.value, delmal)
                     }
+                    description={valgFelt.valgfeltBeskrivelse}
                 >
                     <option value="">Ikke valgt</option>
                     {valgFelt.valgMuligheter.map((valgMulighet: Valgmulighet) => (

--- a/src/frontend/Komponenter/Behandling/Brev/ValgfeltSelect.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/ValgfeltSelect.tsx
@@ -12,7 +12,7 @@ import { Flettefelt } from './Flettefelt';
 import styled from 'styled-components';
 import { Checkbox, Label, Select } from '@navikt/ds-react';
 
-const StyledValgfeltSelect = styled.div`
+const Container = styled.div`
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
@@ -67,7 +67,7 @@ export const ValgfeltSelect: React.FC<Props> = ({
     };
 
     return (
-        <StyledValgfeltSelect>
+        <Container>
             {valgFelt.valgMuligheter.length > 1 ? (
                 <Select
                     label={valgFelt.valgfeltVisningsnavn}
@@ -132,6 +132,6 @@ export const ValgfeltSelect: React.FC<Props> = ({
                         })
                     );
                 })}
-        </StyledValgfeltSelect>
+        </Container>
     );
 };


### PR DESCRIPTION
### Oppsummering av hva som er gjort 🚀

- Alle automatiske verdier vises nå kun i leservisning (SB har ikke mulighet til å endre de)
- Valgfelt og flettefelt kan ha en beskrivelse eller hjelpetekst dersom det er lagt inn i Sanity (se. PR i [familie-brev](https://github.com/navikt/familie-brev/pull/426) og [familie-sanity-brev](https://github.com/navikt/familie-sanity-brev/pull/364))

### Hvorfor er dette nødvendig? ✨
Automatiske verdier overstyrer mellomlagring hver gang SB går frem og tilbake mellom faner. Dette kan gjøre at noen tror de har endret en verdi, men denne verdien er endret tilbake av systemet. Vi prøver oss derfor på en løsning hvor SB ikke har mulighet til å endre de automatiske verdiene at all. Hvis det viser seg at dette er noe flere har behov for kan vi raskt legge inn ekstra felter i Sanity som ikke bruker de automatiske verdiene. Dette er et resultat etter diskusjon med Eirik, Lars og Mirja. 

Beskrivelse er lagt inn for å kunne gi bruker litt mer informasjon om hvor de automatiske verdiene er hentet fra. Det er lagt til på både flettefelt og valgfelt for å unngå bruk av paranteser med masse informasjon. 

### Greit å vite  🤓
Beskrivelse brukes kun dersom det er nødvendig, og om det ikke settes en beskrivelse har det ingen betydning for systemet. 

### Bilder 🎨
Valgfelt med beskrivelse og automatisk flettefelt med hjelpetekst (beskrivelse):
<img width="600" alt="image" src="https://user-images.githubusercontent.com/46678893/221797251-eb8cf13d-f718-47ea-8216-0471d8cb64bf.png">

For ikke-automatiske flettefelt vises beskrivelse som description på input: 
<img width="600" alt="image" src="https://user-images.githubusercontent.com/46678893/221797596-22dae055-5a9e-42b9-b48c-020d6f4ad57f.png">
