### PR TITLE
Legger tilbake key på periode- og inntektsrad for å endre på datovelg…

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
@@ -110,7 +110,7 @@ const InntektsperiodeValg: React.FC<Props> = ({
                         index !== 0 &&
                         (skalViseLeggTilKnapp || index === inntektsperiodeListe.value.length - 1);
                     return (
-                        <>
+                        <React.Fragment key={rad.endretKey}>
                             <MånedÅrVelger
                                 className={'ny-rad'}
                                 disabled={index === 0}
@@ -226,7 +226,7 @@ const InntektsperiodeValg: React.FC<Props> = ({
                             ) : (
                                 <div />
                             )}
-                        </>
+                        </React.Fragment>
                     );
                 })}
             </Grid>

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/VedtaksperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/VedtaksperiodeValg.tsx
@@ -156,7 +156,7 @@ const VedtaksperiodeValg: React.FC<Props> = ({
                     const antallMåneder = kalkulerAntallMåneder(årMånedFra, årMånedTil);
                     const skalViseFjernKnapp = behandlingErRedigerbar && index !== 0;
                     return (
-                        <>
+                        <React.Fragment key={vedtaksperiode.endretKey}>
                             <VedtakperiodeSelect
                                 className={'ny-rad'}
                                 feil={valideringsfeil && valideringsfeil[index]?.periodeType}
@@ -213,7 +213,7 @@ const VedtaksperiodeValg: React.FC<Props> = ({
                             ) : (
                                 <div />
                             )}
-                        </>
+                        </React.Fragment>
                     );
                 })}
             </Grid>


### PR DESCRIPTION
…eren

https://github.com/navikt/familie-ef-sak-frontend/pull/2121 tok bort `key=` som trengs fordi ÅrMånedVelgeren ikke oppdaterer internt state når man "endrer på listen".

https://nav-it.slack.com/archives/G012YEK9YQ1/p1678103265947369