### PR TITLE
Skal vise tidspunkt for opprinnelig behandling når et vilkår er gjenb…

### DIFF
--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/vilkår.ts
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/vilkår.ts
@@ -49,6 +49,12 @@ export interface IVurdering {
     endretAv: string;
     endretTid: string;
     delvilkårsvurderinger: IDelvilkår[];
+    gjenbrukt?: Gjenbrukt;
+}
+
+export interface Gjenbrukt {
+    behandlingId: string;
+    endretTid: string;
 }
 
 export interface IDokumentasjonGrunnlag {

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/vilkår.ts
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/vilkår.ts
@@ -49,12 +49,12 @@ export interface IVurdering {
     endretAv: string;
     endretTid: string;
     delvilkårsvurderinger: IDelvilkår[];
-    gjenbrukt?: Gjenbrukt;
+    opphavsvilkår?: Opphavsvilkår;
 }
 
-export interface Gjenbrukt {
+export interface Opphavsvilkår {
     behandlingId: string;
-    endretTid: string;
+    vurderingstidspunkt: string;
 }
 
 export interface IDokumentasjonGrunnlag {

--- a/src/frontend/Komponenter/Behandling/Vurdering/VisVurdering.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/VisVurdering.tsx
@@ -72,7 +72,9 @@ const VisVurdering: FC<Props> = ({
     tittelTekst,
 }) => {
     const vilkårsresultat = vurdering.resultat;
-    const sistOppdatert = formaterIsoDatoTidMedSekunder(vurdering.endretTid);
+    const sistOppdatert = formaterIsoDatoTidMedSekunder(
+        vurdering.gjenbrukt?.endretTid || vurdering.endretTid
+    );
     const vurderingerBesvartAvSaksbehandler = vurdering.delvilkårsvurderinger.filter(
         (delvilkårsvurdering) =>
             delvilkårsvurdering.resultat === Vilkårsresultat.OPPFYLT ||
@@ -135,12 +137,14 @@ const VisVurdering: FC<Props> = ({
 
             <VertikalStrek />
             <SistOppdatertOgVurderingWrapper>
-                {sistOppdatert &&
-                    (vilkårsresultat === Vilkårsresultat.OPPFYLT ||
-                        vilkårsresultat === Vilkårsresultat.AUTOMATISK_OPPFYLT ||
-                        vilkårsresultat === Vilkårsresultat.IKKE_OPPFYLT) && (
-                        <SistOppdatertTekst>Sist endret dato - {sistOppdatert}</SistOppdatertTekst>
-                    )}
+                {(vilkårsresultat === Vilkårsresultat.OPPFYLT ||
+                    vilkårsresultat === Vilkårsresultat.AUTOMATISK_OPPFYLT ||
+                    vilkårsresultat === Vilkårsresultat.IKKE_OPPFYLT) && (
+                    <SistOppdatertTekst>
+                        Sist endret dato - {sistOppdatert}
+                        {vurdering.gjenbrukt ? ` (gjenbrukt)` : ``}
+                    </SistOppdatertTekst>
+                )}
                 <StyledVilkår>
                     {vurderingerBesvartAvSaksbehandler.map((delvilkårsvurdering) =>
                         delvilkårsvurdering.vurderinger.map((vurdering) => (

--- a/src/frontend/Komponenter/Behandling/Vurdering/VisVurdering.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/VisVurdering.tsx
@@ -73,7 +73,7 @@ const VisVurdering: FC<Props> = ({
 }) => {
     const vilkårsresultat = vurdering.resultat;
     const sistOppdatert = formaterIsoDatoTidMedSekunder(
-        vurdering.gjenbrukt?.endretTid || vurdering.endretTid
+        vurdering.opphavsvilkår?.vurderingstidspunkt || vurdering.endretTid
     );
     const vurderingerBesvartAvSaksbehandler = vurdering.delvilkårsvurderinger.filter(
         (delvilkårsvurdering) =>
@@ -142,7 +142,7 @@ const VisVurdering: FC<Props> = ({
                     vilkårsresultat === Vilkårsresultat.IKKE_OPPFYLT) && (
                     <SistOppdatertTekst>
                         Sist endret dato - {sistOppdatert}
-                        {vurdering.gjenbrukt ? ` (gjenbrukt)` : ``}
+                        {vurdering.opphavsvilkår ? ` (gjenbrukt)` : ``}
                     </SistOppdatertTekst>
                 )}
                 <StyledVilkår>


### PR DESCRIPTION
…rukt

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-9688

Når vi gjenbruker et vilkår, både vid manuell revurdering og ved gjenbruk inngangsvilkår så skal vi ha en peker til den opprinnelige behandlinger som vilkåret ble kopiert fra.

Når man nullstiller eller endrer vilkåret så skal gjenbrukt nullstilles.

