### PR TITLE
Vis inntekt fra sigrun

### DIFF
--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -12,5 +12,6 @@ export enum ToggleName {
     visAutomatiskUtfylleVilkår = 'familie.ef.sak.frontend-automatisk-utfylle-vilkar', // Miljø-toggle
     visSatsendring = 'familie.ef.sak.frontend-vis-satsendring',
     visEndringerPersonopplysninger = 'familie.ef.sak.frontend.personopplysninger-endringer',
+    visInntektPersonoversikt = 'familie.ef.sak.frontend.vis-inntekt-personoversikt',
     angreSendTilBeslutter = 'familie.ef.sak.frontend-angre-send-til-beslutter',
 }

--- a/src/frontend/App/typer/personinntekt.ts
+++ b/src/frontend/App/typer/personinntekt.ts
@@ -1,0 +1,4 @@
+export interface PensjonsgivendeInntekt {
+    inntektsaar: string;
+    verdi: string;
+}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/Opphør/Opphør.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/Opphør/Opphør.tsx
@@ -94,7 +94,7 @@ export const Opphør: React.FC<{
                             settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
                             årMåned && settOpphørtFra(årMåned);
                         }}
-                        antallÅrTilbake={3}
+                        antallÅrTilbake={4}
                         antallÅrFrem={3}
                         disabled={!behandlingErRedigerbar}
                         årMånedInitiell={opphørtFra}

--- a/src/frontend/Komponenter/Personoversikt/InntektForPerson.tsx
+++ b/src/frontend/Komponenter/Personoversikt/InntektForPerson.tsx
@@ -8,6 +8,15 @@ import { Table } from '@navikt/ds-react';
 import styled from 'styled-components';
 import { Ressurs } from '../../App/typer/ressurs';
 
+const StyledTable = styled.table`
+    width: 70%;
+    padding: 2rem;
+    margin-left: 1rem;
+    td {
+        padding: 0.75rem;
+    }
+`;
+
 export const InntektForPerson: React.FC<{
     fagsakPerson: IFagsakPerson;
 }> = ({ fagsakPerson }) => {
@@ -18,34 +27,38 @@ export const InntektForPerson: React.FC<{
         }),
         [fagsakPerson]
     );
-    const pensjonsgivendeInntekt = useDataHenter<PensjonsgivendeInntekt[], null>(inntektConfig);
+    const pensjonsgivendeInntekter = useDataHenter<PensjonsgivendeInntekt[], null>(inntektConfig);
 
-    return <PensjonsgivendeInntektTabell pensjonsgivendeInntekt={pensjonsgivendeInntekt} />;
+    return <PensjonsgivendeInntektTabell pensjonsgivendeInntekter={pensjonsgivendeInntekter} />;
 };
 
 const PensjonsgivendeInntektTabell: React.FC<{
-    pensjonsgivendeInntekt: Ressurs<PensjonsgivendeInntekt[]>;
-}> = ({ pensjonsgivendeInntekt }) => {
+    pensjonsgivendeInntekter: Ressurs<PensjonsgivendeInntekt[]>;
+}> = ({ pensjonsgivendeInntekter }) => {
     return (
-        <DataViewer response={{ pensjonsgivendeInntekt }}>
-            {({ pensjonsgivendeInntekt }) => {
-                if (!pensjonsgivendeInntekt.length) {
+        <DataViewer response={{ pensjonsgivendeInntekter }}>
+            {({ pensjonsgivendeInntekter }) => {
+                if (!pensjonsgivendeInntekter.length) {
                     return null;
                 }
                 return (
                     <StyledTable>
                         <Table.Header>
                             <Table.Row>
-                                <Table.ColumnHeader>Inntektsår</Table.ColumnHeader>
-                                <Table.ColumnHeader>Pensjonsgivende inntekt</Table.ColumnHeader>
+                                <Table.HeaderCell>Inntektsår</Table.HeaderCell>
+                                <Table.HeaderCell>Pensjonsgivende inntekt</Table.HeaderCell>
                             </Table.Row>
                         </Table.Header>
                         <Table.Body>
-                            {pensjonsgivendeInntekt.map((inntekt) => {
+                            {pensjonsgivendeInntekter.map((pensjonsgivendeInntekt) => {
                                 return (
-                                    <Table.Row key={inntekt.inntektsaar}>
-                                        <Table.DataCell>{inntekt.inntektsaar}</Table.DataCell>
-                                        <Table.DataCell>{inntekt.verdi}</Table.DataCell>
+                                    <Table.Row key={pensjonsgivendeInntekt.inntektsaar}>
+                                        <Table.DataCell>
+                                            {pensjonsgivendeInntekt.inntektsaar}
+                                        </Table.DataCell>
+                                        <Table.DataCell>
+                                            {pensjonsgivendeInntekt.verdi}
+                                        </Table.DataCell>
                                     </Table.Row>
                                 );
                             })}
@@ -56,12 +69,3 @@ const PensjonsgivendeInntektTabell: React.FC<{
         </DataViewer>
     );
 };
-
-const StyledTable = styled.table`
-    width: 70%;
-    padding: 2rem;
-    margin-left: 1rem;
-    td {
-        padding: 0.75rem;
-    }
-`;

--- a/src/frontend/Komponenter/Personoversikt/InntektForPerson.tsx
+++ b/src/frontend/Komponenter/Personoversikt/InntektForPerson.tsx
@@ -1,0 +1,66 @@
+import React, { useMemo } from 'react';
+import { IFagsakPerson } from '../../App/typer/fagsak';
+import { AxiosRequestConfig } from 'axios';
+import { useDataHenter } from '../../App/hooks/felles/useDataHenter';
+import DataViewer from '../../Felles/DataViewer/DataViewer';
+import { PensjonsgivendeInntekt } from '../../App/typer/personinntekt';
+import { Table } from '@navikt/ds-react';
+import styled from 'styled-components';
+import { Ressurs } from '../../App/typer/ressurs';
+
+export const InntektForPerson: React.FC<{
+    fagsakPerson: IFagsakPerson;
+}> = ({ fagsakPerson }) => {
+    const inntektConfig: AxiosRequestConfig = useMemo(
+        () => ({
+            method: 'GET',
+            url: `/familie-ef-sak/api/naeringsinntekt/fagsak-person/${fagsakPerson.id}`,
+        }),
+        [fagsakPerson]
+    );
+    const pensjonsgivendeInntekt = useDataHenter<PensjonsgivendeInntekt[], null>(inntektConfig);
+
+    return <PensjonsgivendeInntektTabell pensjonsgivendeInntekt={pensjonsgivendeInntekt} />;
+};
+
+const PensjonsgivendeInntektTabell: React.FC<{
+    pensjonsgivendeInntekt: Ressurs<PensjonsgivendeInntekt[]>;
+}> = ({ pensjonsgivendeInntekt }) => {
+    return (
+        <DataViewer response={{ pensjonsgivendeInntekt }}>
+            {({ pensjonsgivendeInntekt }) => {
+                if (!pensjonsgivendeInntekt.length) {
+                    return null;
+                }
+                return (
+                    <StyledTable>
+                        <Table.Header>
+                            <Table.Row>
+                                <Table.ColumnHeader>Inntektsår</Table.ColumnHeader>
+                                <Table.ColumnHeader>Pensjonsgivende inntekt</Table.ColumnHeader>
+                            </Table.Row>
+                        </Table.Header>
+                        <Table.Body>
+                            {pensjonsgivendeInntekt.map((inntekt) => {
+                                return (
+                                    <Table.Row key={inntekt.inntektsaar}>
+                                        <Table.DataCell>{inntekt.verdi}</Table.DataCell>
+                                    </Table.Row>
+                                );
+                            })}
+                        </Table.Body>
+                    </StyledTable>
+                );
+            }}
+        </DataViewer>
+    );
+};
+
+const StyledTable = styled.table`
+    width: 70%;
+    padding: 2rem;
+    margin-left: 1rem;
+    td {
+        padding: 0.75rem;
+    }
+`;

--- a/src/frontend/Komponenter/Personoversikt/InntektForPerson.tsx
+++ b/src/frontend/Komponenter/Personoversikt/InntektForPerson.tsx
@@ -44,6 +44,7 @@ const PensjonsgivendeInntektTabell: React.FC<{
                             {pensjonsgivendeInntekt.map((inntekt) => {
                                 return (
                                     <Table.Row key={inntekt.inntektsaar}>
+                                        <Table.DataCell>{inntekt.inntektsaar}</Table.DataCell>
                                         <Table.DataCell>{inntekt.verdi}</Table.DataCell>
                                     </Table.Row>
                                 );

--- a/src/frontend/Komponenter/Personoversikt/Personoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Personoversikt.tsx
@@ -18,6 +18,7 @@ import { useSetValgtFagsakPersonId } from '../../App/hooks/useSetValgtFagsakPers
 import { useSetPersonIdent } from '../../App/hooks/useSetPersonIdent';
 import { useHentFagsakPerson } from '../../App/hooks/useHentFagsakPerson';
 import { Tabs } from '@navikt/ds-react';
+import { InntektForPerson } from './InntektForPerson';
 
 type TabWithRouter = {
     label: string;
@@ -84,6 +85,11 @@ const tabs: TabWithRouter[] = [
                 )
             );
         },
+    },
+    {
+        label: 'Inntekt',
+        path: 'inntekt',
+        komponent: (fagsakPerson) => <InntektForPerson fagsakPerson={fagsakPerson} />,
     },
 ];
 

--- a/src/frontend/Komponenter/Personoversikt/Personoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Personoversikt.tsx
@@ -19,6 +19,8 @@ import { useSetPersonIdent } from '../../App/hooks/useSetPersonIdent';
 import { useHentFagsakPerson } from '../../App/hooks/useHentFagsakPerson';
 import { Tabs } from '@navikt/ds-react';
 import { InntektForPerson } from './InntektForPerson';
+import { ToggleName } from '../../App/context/toggles';
+import { useToggles } from '../../App/context/TogglesContext';
 
 type TabWithRouter = {
     label: string;
@@ -89,7 +91,15 @@ const tabs: TabWithRouter[] = [
     {
         label: 'Inntekt',
         path: 'inntekt',
-        komponent: (fagsakPerson) => <InntektForPerson fagsakPerson={fagsakPerson} />,
+        komponent: (fagsakPerson) => {
+            // eslint-disable-next-line react-hooks/rules-of-hooks
+            const { toggles } = useToggles();
+            return (
+                toggles[ToggleName.visInntektPersonoversikt] && (
+                    <InntektForPerson fagsakPerson={fagsakPerson} />
+                )
+            );
+        },
     },
 ];
 

--- a/src/frontend/Komponenter/Personoversikt/Personoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Personoversikt.tsx
@@ -88,13 +88,6 @@ const tabs: TabWithRouter[] = [
             );
         },
     },
-    {
-        label: 'Inntekt',
-        path: 'inntekt',
-        komponent: (fagsakPerson) => {
-            return <InntektForPerson fagsakPerson={fagsakPerson} />;
-        },
-    },
 ];
 
 const PersonoversiktContent: React.FC<{
@@ -108,7 +101,8 @@ const PersonoversiktContent: React.FC<{
     const path = paths.length ? paths[paths.length - 1] : '';
     useSetPersonIdent(personopplysninger.personIdent);
     const skalInntektVises = toggles[ToggleName.visInntektPersonoversikt];
-    if (skalInntektVises) {
+    if (skalInntektVises && tabs.length === 6) {
+        //Flyttes opp når den ikke trengs featuretogglet lenger
         tabs.push({
             label: 'Inntekt',
             path: 'inntekt',

--- a/src/frontend/Komponenter/Personoversikt/Personoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Personoversikt.tsx
@@ -92,13 +92,7 @@ const tabs: TabWithRouter[] = [
         label: 'Inntekt',
         path: 'inntekt',
         komponent: (fagsakPerson) => {
-            // eslint-disable-next-line react-hooks/rules-of-hooks
-            const { toggles } = useToggles();
-            return (
-                toggles[ToggleName.visInntektPersonoversikt] && (
-                    <InntektForPerson fagsakPerson={fagsakPerson} />
-                )
-            );
+            return <InntektForPerson fagsakPerson={fagsakPerson} />;
         },
     },
 ];
@@ -109,9 +103,20 @@ const PersonoversiktContent: React.FC<{
 }> = ({ fagsakPerson, personopplysninger }) => {
     const navigate = useNavigate();
     const { erSaksbehandler } = useApp();
+    const { toggles } = useToggles();
     const paths = useLocation().pathname.split('/').slice(-1);
     const path = paths.length ? paths[paths.length - 1] : '';
     useSetPersonIdent(personopplysninger.personIdent);
+    const skalInntektVises = toggles[ToggleName.visInntektPersonoversikt];
+    if (skalInntektVises) {
+        tabs.push({
+            label: 'Inntekt',
+            path: 'inntekt',
+            komponent: (fagsakPerson) => {
+                return <InntektForPerson fagsakPerson={fagsakPerson} />;
+            },
+        });
+    }
 
     return (
         <>


### PR DESCRIPTION
Lager det som en ny side i personoversikten. Slik det er laget nå summeres all pensjonsgivende inntekt, inklusiv næringsinntekt. Det er ikke lagt vekt på hvordan dette ser ut, da designet for hvordan dette skal se ut ikke er avklart, i tillegg til at det må avklares og testes hvilken inntekt som skal regnes som person og næring. Featuretoggler dette for enklere testing. Det kommer til å bli endringer på visingen, for å skille på næring og personinntekt blant annet.

Bruker endepunktet fra PR: https://github.com/navikt/familie-ef-sak/pull/2120

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-8724

![Screenshot 2023-03-08 at 16 15 17](https://user-images.githubusercontent.com/42737566/223752664-defe2958-e3a8-4823-8337-3198407d5898.png)

Visningen i bilde over er basert på følgende inntekt: 
![Screenshot 2023-03-08 at 16 18 17](https://user-images.githubusercontent.com/42737566/223752953-1ba8b895-f521-4871-8a88-923dd8d38cd4.png)
