### PR TITLE
Vil unngå visuell støy: skal ikke vise endringsdetaljer (tidligere, n…

### DIFF
--- a/src/frontend/Komponenter/Behandling/Endring/EndringPersonopplysninger.tsx
+++ b/src/frontend/Komponenter/Behandling/Endring/EndringPersonopplysninger.tsx
@@ -27,15 +27,12 @@ const OppdaterGrunnlagKnapp = styled(Button)`
 
 const skalViseDetaljer = (ny: string, tidligere: string) => tidligere != '' || ny != '';
 
-const visEndringsdetaljer = (ny: string, tidligere: string) => (
-    <>
-        {skalViseDetaljer(tidligere, ny) && (
-            <>
-                - <strong>Tidligere:</strong> {tidligere} <strong>Ny:</strong> {ny}
-            </>
-        )}
-    </>
-);
+const visEndringsdetaljer = (ny: string, tidligere: string) =>
+    skalViseDetaljer(tidligere, ny) && (
+        <>
+            - <strong>Tidligere:</strong> {tidligere} <strong>Ny:</strong> {ny}
+        </>
+    );
 
 const PersonEndring: React.FC<{ personendringer: Personendring[] }> = ({ personendringer }) => {
     return (

--- a/src/frontend/Komponenter/Behandling/Endring/EndringPersonopplysninger.tsx
+++ b/src/frontend/Komponenter/Behandling/Endring/EndringPersonopplysninger.tsx
@@ -25,6 +25,18 @@ const OppdaterGrunnlagKnapp = styled(Button)`
     margin: 0 1rem 0 0.5rem;
 `;
 
+const skalViseDetaljer = (ny: string, tidligere: string) => tidligere != '' || ny != '';
+
+const visEndringsdetaljer = (ny: string, tidligere: string) => (
+    <>
+        {skalViseDetaljer(tidligere, ny) && (
+            <>
+                - <strong>Tidligere:</strong> {tidligere} <strong>Ny:</strong> {ny}
+            </>
+        )}
+    </>
+);
+
 const PersonEndring: React.FC<{ personendringer: Personendring[] }> = ({ personendringer }) => {
     return (
         <>
@@ -34,12 +46,14 @@ const PersonEndring: React.FC<{ personendringer: Personendring[] }> = ({ persone
                     <ul>
                         {person.fjernet && <li>Fjernet</li>}
                         {person.ny && <li>Ny</li>}
-                        {person.endringer.map((endring, index) => (
-                            <li key={endring.felt + index}>
-                                {endring.felt} - <strong>Tidligere:</strong> {endring.tidligere}{' '}
-                                <strong>Ny:</strong> {endring.ny}
-                            </li>
-                        ))}
+                        {person.endringer.map((endring, index) => {
+                            return (
+                                <li key={endring.felt + index}>
+                                    {endring.felt}
+                                    {visEndringsdetaljer(endring.tidligere, endring.ny)}
+                                </li>
+                            );
+                        })}
                     </ul>
                 </ul>
             ))}


### PR DESCRIPTION
…y) dersom begge disse er tom streng.

Før: 
![image](https://user-images.githubusercontent.com/53942238/223760412-b45de775-a92c-487e-a7ff-0c4c3a82684e.png)

Nå:

![image](https://user-images.githubusercontent.com/53942238/223759615-9da70989-c7c9-4967-a8aa-fabdd8b29bbd.png)

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-11946


relatert til :
https://github.com/navikt/familie-ef-sak/pull/2119
