### PR TITLE
Skal vise at oppgave gjelder "Klage - Tilbakekreving" i oppgavebenk

### DIFF
--- a/src/frontend/App/typer/behandlingstema.ts
+++ b/src/frontend/App/typer/behandlingstema.ts
@@ -1,12 +1,18 @@
-export type Behandlingstema = 'ab0177' | 'ab0028' | 'ab0071';
+export type BehandlingstemaStønadstype = 'ab0177' | 'ab0028' | 'ab0071';
+export type Behandlingstema = BehandlingstemaStønadstype | 'ab0007';
 export type OppgavetypeTilbakekreving = 'ae0161';
 export type OppgavetypeKlage = 'ae0058';
 export type OppgaveBehandlingstype = OppgavetypeTilbakekreving | OppgavetypeKlage;
 
-export const behandlingstemaTilTekst: Record<Behandlingstema, string> = {
+export const behandlingstemaStønadstypeTilTekst: Record<BehandlingstemaStønadstype, string> = {
     ab0071: 'Overgangsstønad',
     ab0177: 'Skolepenger',
     ab0028: 'Barnetilsyn',
+};
+
+export const behandlingstemaTilTekst: Record<Behandlingstema, string> = {
+    ...behandlingstemaStønadstypeTilTekst,
+    ab0007: 'Tilbakekreving',
 };
 
 export enum Stønadstype {

--- a/src/frontend/Komponenter/Oppgavebenk/OppgaveFiltrering.tsx
+++ b/src/frontend/Komponenter/Oppgavebenk/OppgaveFiltrering.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { oppgaveTypeTilTekst } from './typer/oppgavetema';
-import { behandlingstemaTilTekst } from '../../App/typer/behandlingstema';
+import { behandlingstemaStønadstypeTilTekst } from '../../App/typer/behandlingstema';
 import { useApp } from '../../App/context/AppContext';
 import CustomSelect from './CustomSelect';
 import { enhetTilTekst, FortroligEnhet, IkkeFortroligEnhet } from './typer/enhet';
@@ -176,7 +176,7 @@ const OppgaveFiltrering: React.FC<IOppgaveFiltrering> = ({
                 <CustomSelect
                     onChange={settOppgave('behandlingstema')}
                     label="Gjelder"
-                    options={behandlingstemaTilTekst}
+                    options={behandlingstemaStønadstypeTilTekst}
                     value={oppgaveRequest.behandlingstema}
                 />
                 <DatoPeriode

--- a/src/frontend/Komponenter/Oppgavebenk/OppgaveRad.tsx
+++ b/src/frontend/Komponenter/Oppgavebenk/OppgaveRad.tsx
@@ -46,7 +46,11 @@ const OppgaveRad: React.FC<Props> = ({ oppgave, mapper, settFeilmelding, hentOpp
         oppgave.behandlingstype &&
         oppgaveBehandlingstypeTilTekst[oppgave.behandlingstype as OppgaveBehandlingstype];
 
-    const typeBehandling = behandlingstype ? behandlingstype : behandlingstema;
+    const typeBehandling = behandlingstype
+        ? behandlingstema
+            ? behandlingstype + ' - ' + behandlingstema
+            : behandlingstype
+        : behandlingstema;
 
     return (
         <>


### PR DESCRIPTION
### Hensikt
Hjelpe saksbehandlere å skille mellom "Klage" og "Klage tilbakekreving" i oppgavebenken ([FAVRO](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12073))

Det skilles nå mellom `BehandlingstemaStønadstype` og `Behandlingstema` for å ikke ta med "Tilbakekreving" i "Gjelder" filtreringen. Denne blir misvisende fordi behandlingstema = ab0007 er egentlig "klage tilbakekreving" og filtreringen vil derfor ikke vise vanlige tilbakekrevingssaker

![image](https://user-images.githubusercontent.com/46678893/224692691-1a5d8a5b-b449-466c-8383-bbb257c2e21d.png)
