### PR TITLE
Refaktorering. Skal ikke spreade props sendt til brevmenyvisning

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
@@ -3,7 +3,6 @@ import { BrevStruktur, Brevtype, DokumentNavn, IMellomlagretBrevFritekst } from 
 import { byggTomRessurs, Ressurs, RessursStatus } from '../../../App/typer/ressurs';
 import { useApp } from '../../../App/context/AppContext';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
-import { IPersonopplysninger } from '../../../App/typer/personopplysninger';
 import BrevmenyVisning from './BrevmenyVisning';
 import styled from 'styled-components';
 import {
@@ -18,6 +17,7 @@ import { useHentBeløpsperioder } from '../../../App/hooks/useHentBeløpsperiode
 import { Stønadstype } from '../../../App/typer/behandlingstema';
 import { Select } from '@navikt/ds-react';
 import { EBehandlingResultat } from '../../../App/typer/vedtak';
+import { IPersonopplysninger } from '../../../App/typer/personopplysninger';
 
 export interface BrevmenyProps {
     oppdaterBrevRessurs: (brevRessurs: Ressurs<string>) => void;
@@ -39,7 +39,14 @@ const datasett = 'ef-brev';
 const fritekstmal = 'Fritekstbrev';
 
 const Brevmeny: React.FC<BrevmenyProps> = (props) => {
-    const { behandling, vedtaksresultat, behandlingId } = props;
+    const {
+        oppdaterBrevRessurs,
+        behandling,
+        vedtaksresultat,
+        behandlingId,
+        personopplysninger,
+        settKanSendesTilBeslutter,
+    } = props;
     const { axiosRequest } = useApp();
     const { hentBeløpsperioder, beløpsperioder } = useHentBeløpsperioder(
         behandling.id,
@@ -138,7 +145,7 @@ const Brevmeny: React.FC<BrevmenyProps> = (props) => {
                     {({ mellomlagretBrev }) => (
                         <FritekstBrev
                             behandlingId={behandlingId}
-                            oppdaterBrevressurs={props.oppdaterBrevRessurs}
+                            oppdaterBrevressurs={oppdaterBrevRessurs}
                             mellomlagretFritekstbrev={mellomlagretBrev as IMellomlagretBrevFritekst}
                         />
                     )}
@@ -154,7 +161,8 @@ const Brevmeny: React.FC<BrevmenyProps> = (props) => {
                     {({ brevStruktur, mellomlagretBrev, beløpsperioder }) =>
                         brevMal ? (
                             <BrevmenyVisning
-                                {...props}
+                                behandlingId={behandlingId}
+                                oppdaterBrevRessurs={oppdaterBrevRessurs}
                                 behandling={behandling}
                                 brevStruktur={brevStruktur}
                                 beløpsperioder={beløpsperioder}
@@ -163,6 +171,8 @@ const Brevmeny: React.FC<BrevmenyProps> = (props) => {
                                     (mellomlagretBrev as IMellomlagretBrevResponse)?.brevverdier
                                 }
                                 stønadstype={behandling.stønadstype}
+                                personopplysninger={personopplysninger}
+                                settKanSendesTilBeslutter={settKanSendesTilBeslutter}
                             />
                         ) : null
                     }

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
@@ -26,7 +26,6 @@ import {
 import { Ressurs } from '../../../App/typer/ressurs';
 import { useApp } from '../../../App/context/AppContext';
 import styled from 'styled-components';
-import { BrevmenyProps } from './Brevmeny';
 import { apiLoggFeil } from '../../../App/api/axios';
 import { IBrevverdier, useMellomlagringBrev } from '../../../App/hooks/useMellomlagringBrev';
 import { useDebouncedCallback } from 'use-debounce';
@@ -37,6 +36,8 @@ import { delmalTilUtregningstabellOS } from './UtregningstabellOvergangsstønad'
 import { delmalTilUtregningstabellBT } from './UtregningstabellBarnetilsyn';
 import { useVerdierForBrev } from '../../../App/hooks/useVerdierForBrev';
 import { Fritekstområde } from './Fritekstområde';
+import { IPersonopplysninger } from '../../../App/typer/personopplysninger';
+import { Behandling } from '../../../App/typer/fagsak';
 
 const BrevFelter = styled.div`
     display: flex;
@@ -54,12 +55,17 @@ const BrevMenyDelmalWrapper = styled.div<{ førsteElement?: boolean }>`
     margin-top: ${(props) => (props.førsteElement ? '0' : '1rem')};
 `;
 
-export interface BrevmenyVisningProps extends BrevmenyProps {
+export interface BrevmenyVisningProps {
     brevStruktur: BrevStruktur;
     beløpsperioder?: IBeløpsperiode[] | IBeregningsperiodeBarnetilsyn[];
     mellomlagretBrevVerdier?: string;
     brevMal: string;
     stønadstype: Stønadstype;
+    personopplysninger: IPersonopplysninger;
+    settKanSendesTilBeslutter: (kanSendesTilBeslutter: boolean) => void;
+    oppdaterBrevRessurs: (brevRessurs: Ressurs<string>) => void;
+    behandlingId: string;
+    behandling: Behandling;
 }
 
 const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({


### PR DESCRIPTION
Dette er en ren refaktorering som ikke skal medføre endringen i funksjonaliteten. Gjør dette som forberedelser til å implementere sanitybrev i den frittstående brevutsenderen. Spreading av props gjør det er vanskelig å se hvilke props som faktisk brukes, og dermed vanskeligere å få oversikt. 