### PR TITLE
Legg til pensjonsgivende inntekt fra Svalbard i inntektstabell

### DIFF
--- a/src/frontend/App/typer/personinntekt.ts
+++ b/src/frontend/App/typer/personinntekt.ts
@@ -2,4 +2,8 @@ export interface PensjonsgivendeInntekt {
     inntektsår: string;
     næring: number;
     person: number;
+    svalbard?: {
+        næring: number;
+        person: number;
+    };
 }

--- a/src/frontend/Komponenter/Personoversikt/InntektForPerson.tsx
+++ b/src/frontend/Komponenter/Personoversikt/InntektForPerson.tsx
@@ -47,6 +47,11 @@ const PensjonsgivendeInntektTabell: React.FC<{
                 if (!pensjonsgivendeInntekter.length) {
                     return null;
                 }
+
+                const harInntektFraSvalbard = pensjonsgivendeInntekter.some(
+                    (pensjonsgivendeInntekt) => pensjonsgivendeInntekt.svalbard
+                );
+
                 return (
                     <Container>
                         <Table size="small">
@@ -58,6 +63,16 @@ const PensjonsgivendeInntektTabell: React.FC<{
                                     </Table.HeaderCell>
                                     <HøyrestiltHeaderCell>Arbeidstaker</HøyrestiltHeaderCell>
                                     <HøyrestiltHeaderCell>Næring</HøyrestiltHeaderCell>
+                                    {harInntektFraSvalbard && (
+                                        <>
+                                            <HøyrestiltHeaderCell>
+                                                Svalbard arbeidstaker
+                                            </HøyrestiltHeaderCell>
+                                            <HøyrestiltHeaderCell>
+                                                Svalbard næring
+                                            </HøyrestiltHeaderCell>
+                                        </>
+                                    )}
                                 </Table.Row>
                             </Table.Header>
                             <Table.Body>
@@ -83,6 +98,20 @@ const PensjonsgivendeInntektTabell: React.FC<{
                                                     pensjonsgivendeInntekt.næring
                                                 )}
                                             </HøyrestiltDataCell>
+                                            {harInntektFraSvalbard && (
+                                                <>
+                                                    <HøyrestiltDataCell>
+                                                        {formaterTallMedTusenSkille(
+                                                            pensjonsgivendeInntekt.svalbard?.person
+                                                        )}
+                                                    </HøyrestiltDataCell>
+                                                    <HøyrestiltDataCell>
+                                                        {formaterTallMedTusenSkille(
+                                                            pensjonsgivendeInntekt.svalbard?.næring
+                                                        )}
+                                                    </HøyrestiltDataCell>
+                                                </>
+                                            )}
                                         </Table.Row>
                                     );
                                 })}

--- a/src/frontend/Komponenter/Personoversikt/InntektForPerson.tsx
+++ b/src/frontend/Komponenter/Personoversikt/InntektForPerson.tsx
@@ -75,12 +75,12 @@ const PensjonsgivendeInntektTabell: React.FC<{
                                             </HøyrestiltDataCell>
                                             <HøyrestiltDataCell>
                                                 {formaterTallMedTusenSkille(
-                                                    pensjonsgivendeInntekt.næring
+                                                    pensjonsgivendeInntekt.person
                                                 )}
                                             </HøyrestiltDataCell>
                                             <HøyrestiltDataCell>
                                                 {formaterTallMedTusenSkille(
-                                                    pensjonsgivendeInntekt.person
+                                                    pensjonsgivendeInntekt.næring
                                                 )}
                                             </HøyrestiltDataCell>
                                         </Table.Row>


### PR DESCRIPTION
### Hva er gjort? ✨
Knyttet til [denne oppgaven](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-8724) på favro og [PR-2142 i ef-sak](https://github.com/navikt/familie-ef-sak/pull/2142)
- Det legges til ekstra kolonner i tabellen dersom en person har enten person- eller næringsinntekt fra Svalbard et år.
- Bugfix som ble oppdaget underveis: person og næring var i feil kolonne vs. headeren.

### Bilder 🎨
Med inntekt fra Svalbard (kun næring fordi vi får ikke hentet ut personinntekt enda, men det sendes med 0 fra backend):
![image](https://user-images.githubusercontent.com/46678893/227220271-0127e1d9-6c26-4acd-9f73-e8df6f31cc5a.png)


Uten inntekt fra Svalbard (folk flest): 
![image](https://user-images.githubusercontent.com/46678893/227219984-33c4154c-03e8-4aab-af00-d9ee4ed85f99.png)
