### PR TITLE
Splittet innvilge vedtak for overgangsstønad

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeBarnetilsyn.tsx
@@ -34,6 +34,7 @@ export const InnvilgeBarnetilsyn: FC<{
 
     const hentVedtakshistorikk = useCallback(
         (revurderesFra: string) => {
+            settVedtakshistorikk(undefined);
             axiosRequest<IvedtakForBarnetilsyn, void>({
                 method: 'GET',
                 url: `/familie-ef-sak/api/vedtak/${behandling.id}/historikk/${revurderesFra}`,

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
@@ -13,7 +13,7 @@ import MånedÅrVelger from '../../../../../Felles/Input/MånedÅr/MånedÅrVelg
 import LeggTilKnapp from '../../../../../Felles/Knapper/LeggTilKnapp';
 import { ListState } from '../../../../../App/hooks/felles/useListState';
 import { FormErrors } from '../../../../../App/hooks/felles/useFormState';
-import { InnvilgeVedtakForm } from './InnvilgeVedtak';
+import { InnvilgeVedtakForm } from './Vedtaksform';
 import { VEDTAK_OG_BEREGNING } from '../../Felles/konstanter';
 import { useApp } from '../../../../../App/context/AppContext';
 import { FieldState } from '../../../../../App/hooks/felles/useFieldState';

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeOvergangsstønad.tsx
@@ -8,7 +8,7 @@ import { VEDTAK_OG_BEREGNING } from '../../Felles/konstanter';
 import { revurdererFraPeriodeUtenStønad } from './revurderFraUtils';
 import { RevurderesFraOgMed } from '../../Felles/RevurderesFraOgMed';
 import { IVilkår } from '../../../Inngangsvilkår/vilkår';
-import { InnvilgeVedtak } from './InnvilgeVedtak';
+import { Vedtaksform } from './Vedtaksform';
 import { oppdaterVedtakMedEndretKey } from './utils';
 
 export const InnvilgeOvergangsstønad: React.FC<{
@@ -65,7 +65,7 @@ export const InnvilgeOvergangsstønad: React.FC<{
                 />
             ) : null}
             {(vedtak || !behandling.forrigeBehandlingId) && (
-                <InnvilgeVedtak behandling={behandling} lagretVedtak={vedtak} vilkår={vilkår} />
+                <Vedtaksform behandling={behandling} lagretVedtak={vedtak} vilkår={vilkår} />
             )}
         </>
     );

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeOvergangsstønad.tsx
@@ -1,0 +1,72 @@
+import React, { useCallback, useState } from 'react';
+import { IInnvilgeVedtakForOvergangsstønad } from '../../../../../App/typer/vedtak';
+import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../../../App/typer/ressurs';
+import { useBehandling } from '../../../../../App/context/BehandlingContext';
+import { useApp } from '../../../../../App/context/AppContext';
+import { Behandling } from '../../../../../App/typer/fagsak';
+import { VEDTAK_OG_BEREGNING } from '../../Felles/konstanter';
+import { revurdererFraPeriodeUtenStønad } from './revurderFraUtils';
+import { RevurderesFraOgMed } from '../../Felles/RevurderesFraOgMed';
+import { IVilkår } from '../../../Inngangsvilkår/vilkår';
+import { InnvilgeVedtak } from './InnvilgeVedtak';
+import { oppdaterVedtakMedEndretKey } from './utils';
+
+export const InnvilgeOvergangsstønad: React.FC<{
+    behandling: Behandling;
+    lagretVedtak?: IInnvilgeVedtakForOvergangsstønad;
+    vilkår: IVilkår;
+}> = ({ behandling, lagretVedtak, vilkår }) => {
+    const { behandlingErRedigerbar } = useBehandling();
+    const { axiosRequest, settIkkePersistertKomponent } = useApp();
+    const [vedtak, settVedtak] = useState<IInnvilgeVedtakForOvergangsstønad | undefined>(
+        oppdaterVedtakMedEndretKey(lagretVedtak)
+    );
+    const [revurderesFra, settRevurderesFra] = useState(
+        behandling.forrigeBehandlingId && lagretVedtak?.perioder.length
+            ? lagretVedtak.perioder[0].årMånedFra
+            : undefined
+    );
+    const [revurderesFraOgMedFeilmelding, settRevurderesFraOgMedFeilmelding] = useState<
+        string | null
+    >(null);
+
+    const hentVedtakshistorikk = useCallback(
+        (revurderesFra: string) => {
+            settVedtak(undefined);
+            axiosRequest<IInnvilgeVedtakForOvergangsstønad, void>({
+                method: 'GET',
+                url: `/familie-ef-sak/api/vedtak/fagsak/${behandling.fagsakId}/historikk/${revurderesFra}`,
+            }).then((res: RessursSuksess<IInnvilgeVedtakForOvergangsstønad> | RessursFeilet) => {
+                if (res.status === RessursStatus.SUKSESS) {
+                    settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
+                    settVedtak(oppdaterVedtakMedEndretKey(res.data));
+                } else {
+                    settRevurderesFraOgMedFeilmelding(res.frontendFeilmelding);
+                }
+            });
+        },
+        // eslint-disable-next-line
+        [axiosRequest, behandling]
+    );
+
+    return (
+        <>
+            {behandling.forrigeBehandlingId && behandlingErRedigerbar ? (
+                <RevurderesFraOgMed
+                    settRevurderesFra={settRevurderesFra}
+                    hentVedtakshistorikk={hentVedtakshistorikk}
+                    revurderesFra={revurderesFra}
+                    feilmelding={revurderesFraOgMedFeilmelding}
+                    revurdererFraPeriodeUtenStønad={revurdererFraPeriodeUtenStønad(
+                        vedtak,
+                        revurderesFra
+                    )}
+                    stønadstype={behandling.stønadstype}
+                />
+            ) : null}
+            {(vedtak || !behandling.forrigeBehandlingId) && (
+                <InnvilgeVedtak behandling={behandling} lagretVedtak={vedtak} vilkår={vilkår} />
+            )}
+        </>
+    );
+};

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import VedtaksperiodeValg, { tomVedtaksperiodeRad } from './VedtaksperiodeValg';
 import InntektsperiodeValg, { tomInntektsperiodeRad } from './InntektsperiodeValg';
 import { Behandlingstype } from '../../../../../App/typer/behandlingstype';
@@ -9,17 +9,10 @@ import {
     IBeregningsrequest,
     IInntektsperiode,
     IInnvilgeVedtakForOvergangsstønad,
-    IVedtakForOvergangsstønad,
     IVedtaksperiode,
     IVedtakType,
 } from '../../../../../App/typer/vedtak';
-import {
-    byggTomRessurs,
-    Ressurs,
-    RessursFeilet,
-    RessursStatus,
-    RessursSuksess,
-} from '../../../../../App/typer/ressurs';
+import { byggTomRessurs, Ressurs, RessursStatus } from '../../../../../App/typer/ressurs';
 import { useBehandling } from '../../../../../App/context/BehandlingContext';
 import { useApp } from '../../../../../App/context/AppContext';
 import { Behandling } from '../../../../../App/typer/fagsak';
@@ -30,18 +23,10 @@ import Utregningstabell from './Utregningstabell';
 import useFormState, { FormState } from '../../../../../App/hooks/felles/useFormState';
 import { validerInnvilgetVedtakForm, validerVedtaksperioder } from '../vedtaksvalidering';
 import AlertStripeFeilPreWrap from '../../../../../Felles/Visningskomponenter/AlertStripeFeilPreWrap';
-import { VEDTAK_OG_BEREGNING } from '../../Felles/konstanter';
 import styled from 'styled-components';
 import { Button } from '@navikt/ds-react';
-import {
-    fyllHullMedOpphør,
-    revurdererFraPeriodeUtenStønad,
-    revurderFraInitPeriode,
-} from './revurderFraUtils';
-import { RevurderesFraOgMed } from '../../Felles/RevurderesFraOgMed';
 import { IVilkår } from '../../../Inngangsvilkår/vilkår';
 import { utledYngsteBarnFødselsdato } from './fødselsdatoUtils';
-import { oppdaterVedtakMedEndretKey } from './utils';
 import { useRedirectEtterLagring } from '../../../../../App/hooks/felles/useRedirectEtterLagring';
 import HovedKnapp from '../../../../../Felles/Knapper/HovedKnapp';
 
@@ -61,17 +46,10 @@ const Beregningstabell = styled(Utregningstabell)`
 `;
 export const InnvilgeVedtak: React.FC<{
     behandling: Behandling;
-    lagretVedtak?: IVedtakForOvergangsstønad;
+    lagretVedtak?: IInnvilgeVedtakForOvergangsstønad;
+    revurderesFra?: string;
     vilkår: IVilkår;
-}> = ({ behandling, lagretVedtak, vilkår }) => {
-    const lagretInnvilgetVedtak = useMemo(
-        () =>
-            lagretVedtak?._type === IVedtakType.InnvilgelseOvergangsstønad
-                ? oppdaterVedtakMedEndretKey(lagretVedtak as IInnvilgeVedtakForOvergangsstønad)
-                : undefined,
-        [lagretVedtak]
-    );
-
+}> = ({ behandling, lagretVedtak, revurderesFra, vilkår }) => {
     const { hentBehandling, behandlingErRedigerbar } = useBehandling();
     const { axiosRequest, nullstillIkkePersisterteKomponenter, settIkkePersistertKomponent } =
         useApp();
@@ -80,29 +58,18 @@ export const InnvilgeVedtak: React.FC<{
     const [beregnetStønad, settBeregnetStønad] = useState<Ressurs<IBeløpsperiode[]>>(
         byggTomRessurs()
     );
-    const [vedtakshistorikk, settVedtakshistorikk] = useState<IInnvilgeVedtakForOvergangsstønad>();
-    const [revurderesFra, settRevurderesFra] = useState(
-        behandling.forrigeBehandlingId && lagretInnvilgetVedtak?.perioder.length
-            ? lagretInnvilgetVedtak.perioder[0].årMånedFra
-            : undefined
-    );
-    const [revurderesFraOgMedFeilmelding, settRevurderesFraOgMedFeilmelding] = useState<
-        string | null
-    >(null);
 
     const [feilmelding, settFeilmelding] = useState<string>();
 
     const formState = useFormState<InnvilgeVedtakForm>(
         {
-            periodeBegrunnelse: lagretInnvilgetVedtak?.periodeBegrunnelse || '',
-            inntektBegrunnelse: lagretInnvilgetVedtak?.inntektBegrunnelse || '',
-            perioder: lagretInnvilgetVedtak
-                ? lagretInnvilgetVedtak.perioder
-                : [tomVedtaksperiodeRad()],
-            inntekter: lagretInnvilgetVedtak?.inntekter
-                ? lagretInnvilgetVedtak?.inntekter
+            periodeBegrunnelse: lagretVedtak?.periodeBegrunnelse || '',
+            inntektBegrunnelse: lagretVedtak?.inntektBegrunnelse || '',
+            perioder: lagretVedtak ? lagretVedtak.perioder : [tomVedtaksperiodeRad()],
+            inntekter: lagretVedtak?.inntekter
+                ? lagretVedtak?.inntekter
                 : [tomInntektsperiodeRad()],
-            samordningsfradragType: lagretInnvilgetVedtak?.samordningsfradragType || '',
+            samordningsfradragType: lagretVedtak?.samordningsfradragType || '',
             yngsteBarnFødselsdato: utledYngsteBarnFødselsdato(vilkår) || '',
         },
         validerInnvilgetVedtakForm
@@ -117,26 +84,6 @@ export const InnvilgeVedtak: React.FC<{
     const vedtaksperioder = vedtaksperiodeState.value;
 
     const låsVedtaksperiodeRad = !!revurderesFra;
-
-    useEffect(() => {
-        if (!revurderesFra || !vedtakshistorikk) {
-            return;
-        }
-
-        vedtaksperiodeState.setValue([
-            ...revurderFraInitPeriode(vedtakshistorikk, revurderesFra, tomVedtaksperiodeRad),
-            ...vedtakshistorikk.perioder.reduce(fyllHullMedOpphør, [] as IVedtaksperiode[]),
-        ]);
-
-        inntektsperiodeState.setValue([
-            ...revurderFraInitPeriode(vedtakshistorikk, revurderesFra, tomInntektsperiodeRad),
-            ...vedtakshistorikk.inntekter,
-        ]);
-
-        formState.setErrors((prevState) => ({ ...prevState, perioder: [], inntekter: [] }));
-
-        // eslint-disable-next-line
-    }, [vedtakshistorikk]);
 
     useEffect(() => {
         const førsteInnvilgedeVedtaksperiode =
@@ -165,9 +112,6 @@ export const InnvilgeVedtak: React.FC<{
         (rad) => rad.samordningsfradrag
     );
 
-    const skalViseVedtaksperiodeOgInntekt =
-        !behandling.forrigeBehandlingId || revurderesFra || !behandlingErRedigerbar;
-
     const hentLagretBeløpForYtelse = useCallback(() => {
         axiosRequest<IBeløpsperiode[], void>({
             method: 'GET',
@@ -176,10 +120,10 @@ export const InnvilgeVedtak: React.FC<{
     }, [axiosRequest, behandling]);
 
     useEffect(() => {
-        if (!behandlingErRedigerbar && lagretInnvilgetVedtak) {
+        if (!behandlingErRedigerbar && lagretVedtak) {
             hentLagretBeløpForYtelse();
         }
-    }, [behandlingErRedigerbar, lagretInnvilgetVedtak, hentLagretBeløpForYtelse, behandling]);
+    }, [behandlingErRedigerbar, lagretVedtak, hentLagretBeløpForYtelse]);
 
     const beregnPerioder = () => {
         if (formState.customValidate(validerVedtaksperioder)) {
@@ -197,24 +141,6 @@ export const InnvilgeVedtak: React.FC<{
             }).then((res: Ressurs<IBeløpsperiode[]>) => settBeregnetStønad(res));
         }
     };
-
-    const hentVedtakshistorikk = useCallback(
-        (revurderesFra: string) => {
-            axiosRequest<IInnvilgeVedtakForOvergangsstønad, void>({
-                method: 'GET',
-                url: `/familie-ef-sak/api/vedtak/fagsak/${behandling.fagsakId}/historikk/${revurderesFra}`,
-            }).then((res: RessursSuksess<IInnvilgeVedtakForOvergangsstønad> | RessursFeilet) => {
-                if (res.status === RessursStatus.SUKSESS) {
-                    settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
-                    settVedtakshistorikk(oppdaterVedtakMedEndretKey(res.data));
-                } else {
-                    settRevurderesFraOgMedFeilmelding(res.frontendFeilmelding);
-                }
-            });
-        },
-        // eslint-disable-next-line
-        [axiosRequest, behandling]
-    );
 
     const håndterVedtaksresultat = () => {
         return (res: Ressurs<string>) => {
@@ -267,55 +193,31 @@ export const InnvilgeVedtak: React.FC<{
 
     return (
         <Form onSubmit={formState.onSubmit(handleSubmit)}>
-            {behandling.forrigeBehandlingId && behandlingErRedigerbar ? (
-                <RevurderesFraOgMed
-                    settRevurderesFra={settRevurderesFra}
-                    hentVedtakshistorikk={hentVedtakshistorikk}
-                    revurderesFra={revurderesFra}
-                    feilmelding={revurderesFraOgMedFeilmelding}
-                    revurdererFraPeriodeUtenStønad={revurdererFraPeriodeUtenStønad(
-                        vedtakshistorikk,
-                        revurderesFra
-                    )}
-                    stønadstype={behandling.stønadstype}
-                />
-            ) : null}
-            {skalViseVedtaksperiodeOgInntekt && (
-                <>
-                    <VedtaksperiodeValg
-                        errorState={formState.errors}
-                        periodeBegrunnelseState={periodeBegrunnelse}
-                        låsVedtaksperiodeRad={låsVedtaksperiodeRad}
-                        setValideringsFeil={formState.setErrors}
-                        vedtaksperiodeListe={vedtaksperiodeState}
-                    />
-                    <InntektsperiodeValg
-                        errorState={formState.errors}
-                        inntektBegrunnelseState={inntektBegrunnelse}
-                        inntektsperiodeListe={inntektsperiodeState}
-                        samordningsfradragstype={typeSamordningsfradag}
-                        setValideringsFeil={formState.setErrors}
-                        skalVelgeSamordningstype={skalVelgeSamordningstype}
-                    />
-                    {behandlingErRedigerbar && (
-                        <div>
-                            <Button onClick={beregnPerioder} variant={'secondary'} type={'button'}>
-                                Beregn
-                            </Button>
-                            {feilmelding && (
-                                <AlertStripeFeilPreWrap>{feilmelding}</AlertStripeFeilPreWrap>
-                            )}
-                        </div>
-                    )}
-                    <Beregningstabell beregnetStønad={beregnetStønad} />
-                    {behandlingErRedigerbar && (
-                        <HovedKnapp
-                            disabled={laster || !!revurderesFraOgMedFeilmelding}
-                            knappetekst="Lagre vedtak"
-                        />
-                    )}
-                </>
+            <VedtaksperiodeValg
+                errorState={formState.errors}
+                periodeBegrunnelseState={periodeBegrunnelse}
+                låsVedtaksperiodeRad={låsVedtaksperiodeRad}
+                setValideringsFeil={formState.setErrors}
+                vedtaksperiodeListe={vedtaksperiodeState}
+            />
+            <InntektsperiodeValg
+                errorState={formState.errors}
+                inntektBegrunnelseState={inntektBegrunnelse}
+                inntektsperiodeListe={inntektsperiodeState}
+                samordningsfradragstype={typeSamordningsfradag}
+                setValideringsFeil={formState.setErrors}
+                skalVelgeSamordningstype={skalVelgeSamordningstype}
+            />
+            {behandlingErRedigerbar && (
+                <div>
+                    <Button onClick={beregnPerioder} variant={'secondary'} type={'button'}>
+                        Beregn
+                    </Button>
+                    {feilmelding && <AlertStripeFeilPreWrap>{feilmelding}</AlertStripeFeilPreWrap>}
+                </div>
             )}
+            <Beregningstabell beregnetStønad={beregnetStønad} />
+            {behandlingErRedigerbar && <HovedKnapp disabled={laster} knappetekst="Lagre vedtak" />}
         </Form>
     );
 };

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/Vedtaksform.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/Vedtaksform.tsx
@@ -44,7 +44,7 @@ const Form = styled.form`
 const Beregningstabell = styled(Utregningstabell)`
     margin-left: 1rem;
 `;
-export const InnvilgeVedtak: React.FC<{
+export const Vedtaksform: React.FC<{
     behandling: Behandling;
     lagretVedtak?: IInnvilgeVedtakForOvergangsstønad;
     revurderesFra?: string;

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/VedtaksperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/VedtaksperiodeValg.tsx
@@ -13,7 +13,7 @@ import VedtakperiodeSelect from './VedtakperiodeSelect';
 import LeggTilKnapp from '../../../../../Felles/Knapper/LeggTilKnapp';
 import { ListState } from '../../../../../App/hooks/felles/useListState';
 import { FormErrors } from '../../../../../App/hooks/felles/useFormState';
-import { InnvilgeVedtakForm } from './InnvilgeVedtak';
+import { InnvilgeVedtakForm } from './Vedtaksform';
 import { VEDTAK_OG_BEREGNING } from '../../Felles/konstanter';
 import { useApp } from '../../../../../App/context/AppContext';
 import { kalkulerAntallMåneder } from '../../../../../App/utils/dato';

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/VedtaksresultatSwitch.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/VedtaksresultatSwitch.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
-import { EBehandlingResultat, IVedtakForOvergangsstønad } from '../../../../App/typer/vedtak';
+import {
+    EBehandlingResultat,
+    IVedtakForOvergangsstønad,
+    IVedtakType,
+} from '../../../../App/typer/vedtak';
 import { Behandling } from '../../../../App/typer/fagsak';
-import { InnvilgeVedtak } from './InnvilgeVedtak/InnvilgeVedtak';
+import { InnvilgeOvergangsstønad } from './InnvilgeVedtak/InnvilgeOvergangsstønad';
 import { AvslåVedtak } from './AvslåVedtak/AvslåVedtak';
 import { Opphør } from './Opphør/Opphør';
 import { IVilkår } from '../../Inngangsvilkår/vilkår';
@@ -36,9 +40,13 @@ const VedtaksresultatSwitch: React.FC<Props> = ({
             );
         case EBehandlingResultat.INNVILGE:
             return (
-                <InnvilgeVedtak
+                <InnvilgeOvergangsstønad
                     behandling={behandling}
-                    lagretVedtak={lagretVedtak}
+                    lagretVedtak={
+                        lagretVedtak?._type === IVedtakType.InnvilgelseOvergangsstønad
+                            ? lagretVedtak
+                            : undefined
+                    }
                     vilkår={vilkår}
                 />
             );

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
@@ -13,7 +13,7 @@ import {
     tilDato,
     tilÅrMåned,
 } from '../../../../App/utils/dato';
-import { InnvilgeVedtakForm } from './InnvilgeVedtak/InnvilgeVedtak';
+import { InnvilgeVedtakForm } from './InnvilgeVedtak/Vedtaksform';
 import { FormErrors } from '../../../../App/hooks/felles/useFormState';
 import { SanksjonereVedtakForm } from '../../Sanksjon/Sanksjonsfastsettelse';
 


### PR DESCRIPTION
* Setter håndtering av tidligere vedtak og henting en nivå opp fra selve periodehformen, der selve vedtaket settes til undefined hvis man endrer revurder fra for o få en rendering uten InnvilgeVedtak sånn at statet i den komponenten blir helt nullstillt, sånn at man unngår sideeffekter

Dette ble funnet koblet til i https://github.com/navikt/familie-ef-sak-frontend/pull/2210/files#diff-e73a1c8eaf71528736a99938ed315588feb7b23864d8e7e849bd8810fc607104R117
Det som skjer er at man i en revurdering renderer `InnvilgeVedtak` (master) når man har valgt "revurderesFra", selv om man ikke rukket å hentet vedtakshistorikken, sånn at når man sen har hentet vedtakshistorikken har man allerede initiert statet. 

Det er egentlige typ fikset for barnetilsyn allerede, fordi når jeg la inn revurder fra der så prøvde jeg å forbedre statehåndteringen der :) 