### PR TITLE
skal kunne vise frem om en behandling er av EØS-kategori

### DIFF
--- a/src/frontend/App/typer/fagsak.ts
+++ b/src/frontend/App/typer/fagsak.ts
@@ -38,6 +38,7 @@ export interface Behandling {
     type: Behandlingstype;
     steg: Steg;
     status: BehandlingStatus;
+    kategori: BehandlingKategori;
     sistEndret: string;
     opprettet: string;
     resultat: BehandlingResultat;
@@ -75,4 +76,14 @@ export const behandlingResultatTilTekst: Record<
     MEDHOLD: 'Medhold',
     IKKE_MEDHOLD: 'Oversendt til KA',
     IKKE_MEDHOLD_FORMKRAV_AVVIST: 'Ikke medhold, formkrav avvist',
+};
+
+export enum BehandlingKategori {
+    EØS = 'EØS',
+    NASJONAL = 'NASJONAL',
+}
+
+export const kategoriTilTekst: Record<BehandlingKategori, string> = {
+    EØS: 'EØS',
+    NASJONAL: 'Nasjonal',
 };

--- a/src/frontend/Felles/PersonHeader/PersonHeader.tsx
+++ b/src/frontend/Felles/PersonHeader/PersonHeader.tsx
@@ -4,7 +4,7 @@ import VisittKort from '@navikt/familie-visittkort';
 import styled from 'styled-components';
 import PersonStatusVarsel from '../Varsel/PersonStatusVarsel';
 import AdressebeskyttelseVarsel from '../Varsel/AdressebeskyttelseVarsel';
-import { Behandling } from '../../App/typer/fagsak';
+import { Behandling, BehandlingKategori, kategoriTilTekst } from '../../App/typer/fagsak';
 import { Sticky } from '../Visningskomponenter/Sticky';
 import { erEtterDagensDato, nullableDatoTilAlder } from '../../App/utils/dato';
 import { RessursFeilet, RessursStatus, RessursSuksess } from '../../App/typer/ressurs';
@@ -243,6 +243,13 @@ const PersonHeaderComponent: FC<{ data: IPersonopplysninger; behandling?: Behand
                     )}
                 </TagsKnyttetTilPerson>
                 <TagsKnyttetTilBehandling>
+                    {behandling && behandling.kategori === BehandlingKategori.EØS && (
+                        <ElementWrapper>
+                            <Tag variant={'warning-filled'} size={'small'}>
+                                {kategoriTilTekst[behandling.kategori]}
+                            </Tag>
+                        </ElementWrapper>
+                    )}
                     {behandling && (
                         <ElementWrapper>
                             <TagsLitenSkjerm>

--- a/src/frontend/Komponenter/Personoversikt/BehandlingsoversiktTabell.tsx
+++ b/src/frontend/Komponenter/Personoversikt/BehandlingsoversiktTabell.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { Behandling, BehandlingResultat, behandlingResultatTilTekst } from '../../App/typer/fagsak';
+import {
+    Behandling,
+    BehandlingKategori,
+    BehandlingResultat,
+    behandlingResultatTilTekst,
+    kategoriTilTekst,
+} from '../../App/typer/fagsak';
 import {
     TilbakekrevingBehandling,
     TilbakekrevingBehandlingsresultatstype,
@@ -29,7 +35,7 @@ import {
     KlageÅrsak,
 } from '../../App/typer/klage';
 import { WarningColored } from '@navikt/ds-icons';
-import { Tooltip } from '@navikt/ds-react';
+import { Tag, Tooltip } from '@navikt/ds-react';
 import { sorterBehandlinger } from '../../App/utils/behandlingutil';
 
 const StyledTable = styled.table`
@@ -40,6 +46,11 @@ const StyledTable = styled.table`
 
 const AdvarselIkon = styled(WarningColored)`
     margin-left: 1rem;
+`;
+
+const FlexBox = styled.div`
+    display: flex;
+    gap: 0.75rem;
 `;
 
 const TabellData: PartialRecord<keyof Behandling | 'vedtaksdato', string> = {
@@ -57,6 +68,7 @@ interface BehandlingsoversiktTabellBehandling {
     årsak?: Behandlingsårsak | KlageÅrsak;
     henlagtÅrsak?: EHenlagtårsak | KlageHenlagtÅrsak;
     status: string;
+    kategori?: BehandlingKategori;
     vedtaksdato?: string;
     resultat?:
         | BehandlingResultat
@@ -82,6 +94,7 @@ export const BehandlingsoversiktTabell: React.FC<{
                 henlagtÅrsak: behandling.henlagtÅrsak,
                 status: behandling.status,
                 resultat: behandling.resultat,
+                kategori: behandling.kategori,
                 opprettet: behandling.opprettet,
                 vedtaksdato: behandling.vedtaksdato,
                 applikasjon: BehandlingApplikasjon.EF_SAK,
@@ -195,7 +208,12 @@ export const BehandlingsoversiktTabell: React.FC<{
                     return (
                         <tr key={behandling.id}>
                             <td>{formaterIsoDatoTid(behandling.opprettet)}</td>
-                            <td>{formatterEnumVerdi(behandling.type)}</td>
+                            <td>
+                                <BehandlingType
+                                    behandlingType={behandling.type}
+                                    kategori={behandling.kategori}
+                                />
+                            </td>
                             <td>{finnÅrsak(behandling)}</td>
                             <td>{formatterEnumVerdi(behandling.status)}</td>
                             <td>
@@ -239,5 +257,23 @@ export const BehandlingsoversiktTabell: React.FC<{
                 })}
             </tbody>
         </StyledTable>
+    );
+};
+
+const BehandlingType: React.FC<{ behandlingType: string; kategori?: BehandlingKategori }> = ({
+    behandlingType,
+    kategori,
+}) => {
+    if (!kategori || kategori === BehandlingKategori.NASJONAL) {
+        return <>{formatterEnumVerdi(behandlingType)}</>;
+    }
+
+    return (
+        <FlexBox>
+            <span>{formatterEnumVerdi(behandlingType)}</span>
+            <Tag variant={'warning-filled'} size={'small'}>
+                {kategoriTilTekst[kategori]}
+            </Tag>
+        </FlexBox>
     );
 };


### PR DESCRIPTION
Backend:
* https://github.com/navikt/familie-ef-sak/pull/2148

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-11453)

**Hvorfor?**
Dersom en behandling har visse inngangsvilkår satt til oppfylt/ikke oppfylt kan behandlingen anses som å være av kategorien EØS. Kategorien blir satt i backend og sendt med til frontend for visning.

![Skjermbilde 2023-03-28 kl  14 07 35](https://user-images.githubusercontent.com/32769446/228231132-8c73766a-0866-4727-9826-ec7f4ade0054.png)
![Skjermbilde 2023-03-28 kl  14 06 22](https://user-images.githubusercontent.com/32769446/228231136-a210b200-ca2b-4610-837e-4690712c2416.png)
