### PR TITLE
Skal ikke kunne opprette nye fritekstbrev

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
@@ -133,10 +133,12 @@ const Brevmeny: React.FC<BrevmenyProps> = (props) => {
                                     {navn.visningsnavn}
                                 </option>
                             ))}
-                        <option value={fritekstmal} key={fritekstmal}>
-                            {' '}
-                            Fritekstbrev
-                        </option>
+                        {brevMal === fritekstmal && (
+                            <option value={fritekstmal} key={fritekstmal}>
+                                {' '}
+                                Fritekstbrev
+                            </option>
+                        )}
                     </Select>
                 )}
             </DataViewer>


### PR DESCRIPTION
Vi ønsker fremover kun å bruke sanity-brev, og skal derfor fase ut fritekstbrev ([favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12119)). Derfor ønsker vi å skjule valget om fritekstbrev dersom man ikke har en mellomlagret versjon av dette.
Dersom man har et mellomlagret fritesktbrev vil valget fortsatt vises

Venter mer å merge denne til det er avklart med Mirja/funksjonelle.