### PR TITLE
Skal nulstille oppgavefelter ved vellykket "Sett på vent"

### DIFF
--- a/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVent.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVent.tsx
@@ -179,12 +179,21 @@ export const SettPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
                 if (respons.status == RessursStatus.SUKSESS) {
                     hentBehandling.rerun();
                     lukkSettPåVent();
+                    nullstillOppgaveFelter();
                     settToast(EToast.BEHANDLING_SATT_PÅ_VENT);
                 } else {
                     settFeilmelding(respons.frontendFeilmelding);
                 }
             })
             .finally(() => settLåsKnapp(false));
+    };
+
+    const nullstillOppgaveFelter = () => {
+        settSaksbehandler('');
+        settBeskrivelse('');
+        settPrioritet(undefined);
+        settFrist(undefined);
+        settMappe(undefined);
     };
 
     return visSettPåVent && toggles[ToggleName.settPåVentMedOppgavestyring] ? (


### PR DESCRIPTION
Dersom man setter på vent, tar av vent, og så forsøker å sette på vent på nytt skal oppgaven hentes på nytt og tilhørende felter være nullet ut