### PR TITLE
Marker klage tilbakekreving

### DIFF
--- a/src/frontend/App/hooks/useJournalføringKlageState.ts
+++ b/src/frontend/App/hooks/useJournalføringKlageState.ts
@@ -14,6 +14,7 @@ interface JournalføringRequest {
     oppgaveId: string;
     behandling: BehandlingKlageRequest;
     journalførendeEnhet: string;
+    klageGjelderTilbakekreving: boolean;
 }
 
 export interface JournalføringKlageStateRequest {
@@ -26,6 +27,8 @@ export interface JournalføringKlageStateRequest {
     innsending: Ressurs<string>;
     settInnsending: Dispatch<SetStateAction<Ressurs<string>>>;
     fullførJournalføring: () => void;
+    klageGjelderTilbakekreving: boolean;
+    settKlageGjelderTilbakekreving: Dispatch<SetStateAction<boolean>>;
 }
 
 export const useJournalføringKlageState = (
@@ -37,6 +40,7 @@ export const useJournalføringKlageState = (
     const [behandling, settBehandling] = useState<BehandlingKlageRequest>();
     const [dokumentTitler, settDokumentTitler] = useState<DokumentTitler>();
     const [innsending, settInnsending] = useState<Ressurs<string>>(byggTomRessurs());
+    const [klageGjelderTilbakekreving, settKlageGjelderTilbakekreving] = useState<boolean>(false);
 
     useEffect(() => {
         settBehandling(undefined);
@@ -53,7 +57,9 @@ export const useJournalføringKlageState = (
             behandling,
             dokumentTitler,
             journalførendeEnhet: innloggetSaksbehandler.enhet || '9999',
+            klageGjelderTilbakekreving: klageGjelderTilbakekreving,
         };
+
         settInnsending(byggHenterRessurs());
         axiosRequest<string, JournalføringRequest>({
             method: 'POST',
@@ -72,5 +78,7 @@ export const useJournalføringKlageState = (
         innsending,
         settInnsending,
         fullførJournalføring,
+        klageGjelderTilbakekreving,
+        settKlageGjelderTilbakekreving,
     };
 };

--- a/src/frontend/Komponenter/Journalføring/JournalføringKlageApp.tsx
+++ b/src/frontend/Komponenter/Journalføring/JournalføringKlageApp.tsx
@@ -40,6 +40,7 @@ import styled from 'styled-components';
 import JournalpostTittelOgLenke from './JournalpostTittelOgLenke';
 import { Button, Fieldset, Heading } from '@navikt/ds-react';
 import { ÅpneKlager } from '../Personoversikt/Klage/ÅpneKlager';
+import KlageGjelderTilbakekreving from './KlageGjelderTilbakekreving';
 
 const KlageMottatt = styled.div`
     margin-top: 1rem;
@@ -163,6 +164,12 @@ const JournalføringAppContent: React.FC<JournalføringAppProps> = ({
                     <VelgFagsakForIkkeSøknad
                         journalResponse={journalResponse}
                         hentFagsak={hentFagsak}
+                    />
+                    <KlageGjelderTilbakekreving
+                        klageGjelderTilbakekreving={journalpostState.klageGjelderTilbakekreving}
+                        settKlageGjelderTilbakekreving={
+                            journalpostState.settKlageGjelderTilbakekreving
+                        }
                     />
                     <Brukerinfo
                         navn={journalResponse.navn}

--- a/src/frontend/Komponenter/Journalføring/KlageGjelderTilbakekreving.tsx
+++ b/src/frontend/Komponenter/Journalføring/KlageGjelderTilbakekreving.tsx
@@ -6,7 +6,7 @@ interface Props {
     settKlageGjelderTilbakekreving: Dispatch<SetStateAction<boolean>>;
 }
 
-const KlageGjelderTilbakekreving: React.FC<KlageGjelderTilbakekrevingProps> = ({
+const KlageGjelderTilbakekreving: React.FC<Props> = ({
     klageGjelderTilbakekreving,
     settKlageGjelderTilbakekreving,
 }) => {

--- a/src/frontend/Komponenter/Journalføring/KlageGjelderTilbakekreving.tsx
+++ b/src/frontend/Komponenter/Journalføring/KlageGjelderTilbakekreving.tsx
@@ -1,0 +1,24 @@
+import React, { Dispatch, SetStateAction } from 'react';
+import { Checkbox } from '@navikt/ds-react';
+
+interface KlageGjelderTilbakekrevingProps {
+    klageGjelderTilbakekreving: boolean;
+    settKlageGjelderTilbakekreving: Dispatch<SetStateAction<boolean>>;
+}
+
+const KlageGjelderTilbakekreving: React.FC<KlageGjelderTilbakekrevingProps> = ({
+    klageGjelderTilbakekreving,
+    settKlageGjelderTilbakekreving,
+}) => {
+    const håndterCheck = () => {
+        settKlageGjelderTilbakekreving((prevState) => !prevState);
+    };
+
+    return (
+        <Checkbox size="small" checked={klageGjelderTilbakekreving} onChange={håndterCheck}>
+            Klagen gjelder tilbakekreving
+        </Checkbox>
+    );
+};
+
+export default KlageGjelderTilbakekreving;

--- a/src/frontend/Komponenter/Journalføring/KlageGjelderTilbakekreving.tsx
+++ b/src/frontend/Komponenter/Journalføring/KlageGjelderTilbakekreving.tsx
@@ -1,7 +1,7 @@
 import React, { Dispatch, SetStateAction } from 'react';
 import { Checkbox } from '@navikt/ds-react';
 
-interface KlageGjelderTilbakekrevingProps {
+interface Props {
     klageGjelderTilbakekreving: boolean;
     settKlageGjelderTilbakekreving: Dispatch<SetStateAction<boolean>>;
 }

--- a/src/frontend/Komponenter/Personoversikt/Klage/OpprettKlage.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Klage/OpprettKlage.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { FamilieDatovelger } from '@navikt/familie-form-elements';
 import { erFørEllerLikDagensDato, erGyldigDato } from '../../../App/utils/dato';
 import { Alert, Button } from '@navikt/ds-react';
+import KlageGjelderTilbakekreving from '../../Journalføring/KlageGjelderTilbakekreving';
 
 const AlertStripe = styled(Alert)`
     margin-top: 1rem;
@@ -26,19 +27,28 @@ const ModalKnapp = styled(Button)`
     margin-left: 1rem;
 `;
 
+export interface OpprettKlageRequest {
+    mottattDato: string;
+    klageGjelderTilbakekreving: boolean;
+}
+
 interface IProps {
     settVisModal: (bool: boolean) => void;
-    opprettKlage: (mottattDato: string) => void;
+    opprettKlage: (data: OpprettKlageRequest) => void;
 }
 
 export const OpprettKlage: React.FunctionComponent<IProps> = ({ settVisModal, opprettKlage }) => {
     const [feilmelding, settFeilmelding] = useState<string>('');
     const [valgtDato, settValgtDato] = useState<string>();
+    const [klageGjelderTilbakekreving, settKlageGjelderTilbakekreving] = useState<boolean>(false);
 
     const validerValgtDato = (valgtDato: string | undefined) => {
         settFeilmelding('');
         if (valgtDato && erGyldigDato(valgtDato) && erFørEllerLikDagensDato(valgtDato)) {
-            opprettKlage(valgtDato);
+            opprettKlage({
+                mottattDato: valgtDato,
+                klageGjelderTilbakekreving: klageGjelderTilbakekreving,
+            });
         } else if (!valgtDato) {
             settFeilmelding('Vennligst velg en dato fra datovelgeren');
         } else {
@@ -48,6 +58,10 @@ export const OpprettKlage: React.FunctionComponent<IProps> = ({ settVisModal, op
 
     return (
         <>
+            <KlageGjelderTilbakekreving
+                klageGjelderTilbakekreving={klageGjelderTilbakekreving}
+                settKlageGjelderTilbakekreving={settKlageGjelderTilbakekreving}
+            />
             <DatoContainer>
                 <FamilieDatovelger
                     id={'krav-mottatt'}

--- a/src/frontend/Komponenter/Personoversikt/LagBehandlingModal.tsx
+++ b/src/frontend/Komponenter/Personoversikt/LagBehandlingModal.tsx
@@ -8,7 +8,7 @@ import { EToast } from '../../App/typer/toast';
 import { LagRevurdering } from './Revurdering/LagRevurdering';
 import { RevurderingInnhold } from '../../App/typer/revurderingstype';
 import { Fagsak } from '../../App/typer/fagsak';
-import OpprettKlage from './Klage/OpprettKlage';
+import OpprettKlage, { OpprettKlageRequest } from './Klage/OpprettKlage';
 import { ModalWrapper } from '../../Felles/Modal/ModalWrapper';
 import { Alert, Button, Select } from '@navikt/ds-react';
 import { AlertError } from '../../Felles/Visningskomponenter/Alerts';
@@ -108,15 +108,15 @@ const LagBehandlingModal: React.FunctionComponent<IProps> = ({
         }
     };
 
-    const opprettKlage = (mottattDato: string) => {
+    const opprettKlage = (data: OpprettKlageRequest) => {
         settFeilmeldingModal('');
 
         if (!senderInnBehandling) {
             settSenderInnBehandling(true);
-            axiosRequest<Ressurs<void>, { mottattDato: string }>({
+            axiosRequest<Ressurs<void>, OpprettKlageRequest>({
                 method: 'POST',
                 url: `/familie-ef-sak/api/klage/fagsak/${fagsak.id}`,
-                data: { mottattDato },
+                data: data,
             })
                 .then((response) => {
                     if (response.status === RessursStatus.SUKSESS) {


### PR DESCRIPTION
### Hvorfor er dette nødvendig?
Saksbehandlere skal ha muligheten til å huke av for at en klage gjelder tilbakekreving, som skal sette behandlingstemaet på behandle sak oppgaven til `ab0007` (tilbakekreving). 

Dette skal skje både via journalføring og ved manuell opprettelse av en klage.

### Hva er gjort? 🤓
Oppgaven ble løst ved å lage en ny komponent `KlageGjelderTilbakekreving` og sende med `klageGjelderTilbakekreving` (boolean) til ef-sak som viser om klagen gjelder tilbakekreving både ved manuell opprettelse og klage. 

### Henger sammen med 🤹‍♀️

- [PR i EF-sak](https://github.com/navikt/familie-ef-sak/pull/2160) (Sende med klageGjelderTilbakekreving og opprette task for kall på nytt endepunkt)
- [PR i Klage](https://github.com/navikt/familie-klage/pull/289) (Opprette ny klage med riktig behandlingstema og oppdatere eksisterende oppgave)
- [PR i Kontrakter](https://github.com/navikt/familie-kontrakter/pull/767) (Legge til `klageGjelderTIlbakekreving` som felt i request). 

### Bilder 📈
Avhukning ved journalføring: 
<img width="718" alt="image" src="https://user-images.githubusercontent.com/46678893/231464451-5c077146-774c-4c0f-acc2-0d35ead0c56a.png">

Ved opprettelse av klage manuelt: 
<img width="657" alt="image" src="https://user-images.githubusercontent.com/46678893/231464720-9f51dd7a-3c96-41fe-8c0c-b2b79077e770.png">


