### PR TITLE
Gjør paginering i PdfVisning x-small

### DIFF
--- a/src/frontend/Felles/Pdf/PdfVisning.tsx
+++ b/src/frontend/Felles/Pdf/PdfVisning.tsx
@@ -58,6 +58,7 @@ const PdfVisning: React.FC<PdfVisningProps> = ({ pdfFilInnhold }) => {
                         page={pageNumber}
                         count={numPages}
                         onPageChange={setPageNumber}
+                        size="xsmall"
                     />
                     <StyledDokument
                         file={`data:application/pdf;base64,${pdfFilInnhold}`}


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
[FAVRO](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12326)
Pagineringen i PDF-visning tar veldig stor plass og kan gjøres mindre: 
<img width="646" alt="image" src="https://user-images.githubusercontent.com/46678893/232426532-f8611d1c-d03b-42db-9bf3-86ea2661b8ff.png">
