### PR TITLE
Bugfix: Feil fra avslag til innvilgelse i barnetilsyn

### DIFF
--- a/src/frontend/App/hooks/useHentVedtak.ts
+++ b/src/frontend/App/hooks/useHentVedtak.ts
@@ -9,7 +9,7 @@ import {
 import { useApp } from '../context/AppContext';
 import { useCallback, useState } from 'react';
 import { AxiosRequestConfig } from 'axios';
-import { EBehandlingResultat, IVedtakForOvergangsstønad } from '../typer/vedtak';
+import { EBehandlingResultat, IVedtak } from '../typer/vedtak';
 
 export const harVedtaksresultatMedTilkjentYtelse = (
     vedtaksresultat: EBehandlingResultat | undefined
@@ -29,13 +29,11 @@ export const useHentVedtak = (
     behandlingId: string | undefined
 ): {
     hentVedtak: () => void;
-    vedtak: Ressurs<IVedtakForOvergangsstønad | undefined>;
+    vedtak: Ressurs<IVedtak | undefined>;
     vedtaksresultat: EBehandlingResultat | undefined;
 } => {
     const { axiosRequest } = useApp();
-    const [vedtak, settVedtak] = useState<Ressurs<IVedtakForOvergangsstønad | undefined>>(
-        byggTomRessurs()
-    );
+    const [vedtak, settVedtak] = useState<Ressurs<IVedtak | undefined>>(byggTomRessurs());
     const [vedtaksresultat, settVedtaksresultat] = useState<EBehandlingResultat>();
 
     const hentVedtak = useCallback(() => {
@@ -46,11 +44,11 @@ export const useHentVedtak = (
                 method: 'GET',
                 url: `/familie-ef-sak/api/vedtak/${behandlingId}`,
             };
-            axiosRequest<IVedtakForOvergangsstønad | null, null>(behandlingConfig).then(
-                (res: RessursSuksess<IVedtakForOvergangsstønad | null> | RessursFeilet) => {
+            axiosRequest<IVedtak | null, null>(behandlingConfig).then(
+                (res: RessursSuksess<IVedtak | null> | RessursFeilet) => {
                     if (res.status === RessursStatus.SUKSESS) {
                         if (res.data) {
-                            settVedtak(res as RessursSuksess<IVedtakForOvergangsstønad>);
+                            settVedtak(res as RessursSuksess<IVedtak>);
                             settVedtaksresultat(res.data.resultatType);
                         } else {
                             settVedtak(byggSuksessRessurs(undefined));

--- a/src/frontend/App/typer/vedtak.ts
+++ b/src/frontend/App/typer/vedtak.ts
@@ -76,6 +76,7 @@ export type IInnvilgeVedtakForOvergangsstønad = {
 };
 
 export type IInnvilgeVedtakForBarnetilsyn = {
+    resultatType: EBehandlingResultat.INNVILGE;
     begrunnelse?: string;
     perioder: IUtgiftsperiode[];
     perioderKontantstøtte: IPeriodeMedBeløp[];
@@ -132,6 +133,7 @@ export type IVedtakForSkolepenger = {
     begrunnelse?: string;
     skoleårsperioder: ISkoleårsperiodeSkolepenger[];
     _type?: IVedtakType.InnvilgelseSkolepenger | IVedtakType.OpphørSkolepenger;
+    resultatType: EBehandlingResultat.INNVILGE | EBehandlingResultat.OPPHØRT;
 };
 
 export interface ISkoleårsperiodeSkolepenger {
@@ -172,6 +174,8 @@ export interface IOpphørtVedtak {
     opphørFom: string;
     begrunnelse: string;
 }
+
+export type IVedtak = IVedtakForOvergangsstønad | IvedtakForBarnetilsyn | IvedtakForSkolepenger;
 
 export type IVedtakForOvergangsstønad =
     | IAvslagVedtak

--- a/src/frontend/Komponenter/Behandling/Sanksjon/Sanksjonsfastsettelse.tsx
+++ b/src/frontend/Komponenter/Behandling/Sanksjon/Sanksjonsfastsettelse.tsx
@@ -17,7 +17,7 @@ import {
     EPeriodetype,
     ISanksjonereVedtakDto,
     ISanksjonereVedtakForOvergangsstønad,
-    IVedtakForOvergangsstønad,
+    IVedtak,
     IVedtakType,
 } from '../../../App/typer/vedtak';
 import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../App/typer/ressurs';
@@ -107,7 +107,7 @@ const Sanksjonsfastsettelse: FC<Props> = ({ behandlingId }) => {
 
 const SanksjonsvedtakVisning: FC<{
     behandling: Behandling;
-    lagretVedtak?: IVedtakForOvergangsstønad;
+    lagretVedtak?: IVedtak;
 }> = ({ behandling, lagretVedtak }) => {
     const lagretSanksjonertVedtak =
         lagretVedtak?._type === IVedtakType.Sanksjonering

--- a/src/frontend/Komponenter/Behandling/Simulering/SimuleringTabellWrapper.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/SimuleringTabellWrapper.tsx
@@ -8,7 +8,7 @@ import SimuleringOversikt from './SimuleringOversikt';
 import { Tilbakekreving } from './Tilbakekreving';
 import {
     ISanksjonereVedtakForOvergangsstønad,
-    IVedtakForOvergangsstønad,
+    IVedtak,
     IVedtakType,
 } from '../../../App/typer/vedtak';
 import { nåværendeÅrOgMånedFormatert } from '../Sanksjon/utils';
@@ -49,7 +49,7 @@ const mapSimuleringstabellRader = (
 const SimuleringTabellWrapper: React.FC<{
     simuleringsresultat: ISimulering;
     behandlingId: string;
-    lagretVedtak?: IVedtakForOvergangsstønad;
+    lagretVedtak?: IVedtak;
 }> = ({ simuleringsresultat, behandlingId, lagretVedtak }) => {
     const muligeÅr = [...new Set(simuleringsresultat.perioder.map((p) => formaterIsoÅr(p.fom)))];
 

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
@@ -1,11 +1,7 @@
 import React, { FC, useEffect, useState } from 'react';
 import { Behandling } from '../../../../App/typer/fagsak';
 import { IVilkår } from '../../Inngangsvilkår/vilkår';
-import {
-    EBehandlingResultat,
-    IInnvilgeVedtakForBarnetilsyn,
-    IVedtakType,
-} from '../../../../App/typer/vedtak';
+import { EBehandlingResultat, IVedtakType } from '../../../../App/typer/vedtak';
 import { useHentVedtak } from '../../../../App/hooks/useHentVedtak';
 import { erAlleVilkårOppfylt, skalViseNullstillVedtakKnapp } from '../Felles/utils';
 import { RessursStatus } from '../../../../App/typer/ressurs';
@@ -57,7 +53,7 @@ const VedtakOgBeregningBarnetilsyn: FC<Props> = ({ behandling, vilkår }) => {
                                     behandling={behandling}
                                     lagretVedtak={
                                         vedtak?._type === IVedtakType.InnvilgelseBarnetilsyn
-                                            ? (vedtak as IInnvilgeVedtakForBarnetilsyn)
+                                            ? vedtak
                                             : undefined
                                     }
                                     barn={barnSomOppfyllerAlleVilkår(vilkår)}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
@@ -1,7 +1,11 @@
 import React, { FC, useEffect, useState } from 'react';
 import { Behandling } from '../../../../App/typer/fagsak';
 import { IVilkår } from '../../Inngangsvilkår/vilkår';
-import { EBehandlingResultat, IInnvilgeVedtakForBarnetilsyn } from '../../../../App/typer/vedtak';
+import {
+    EBehandlingResultat,
+    IInnvilgeVedtakForBarnetilsyn,
+    IVedtakType,
+} from '../../../../App/typer/vedtak';
 import { useHentVedtak } from '../../../../App/hooks/useHentVedtak';
 import { erAlleVilkårOppfylt, skalViseNullstillVedtakKnapp } from '../Felles/utils';
 import { RessursStatus } from '../../../../App/typer/ressurs';
@@ -52,7 +56,9 @@ const VedtakOgBeregningBarnetilsyn: FC<Props> = ({ behandling, vilkår }) => {
                                 <InnvilgeBarnetilsyn
                                     behandling={behandling}
                                     lagretVedtak={
-                                        vedtak as IInnvilgeVedtakForBarnetilsyn | undefined
+                                        vedtak?._type === IVedtakType.InnvilgelseBarnetilsyn
+                                            ? (vedtak as IInnvilgeVedtakForBarnetilsyn)
+                                            : undefined
                                     }
                                     barn={barnSomOppfyllerAlleVilkår(vilkår)}
                                     settResultatType={settResultatType}
@@ -64,11 +70,20 @@ const VedtakOgBeregningBarnetilsyn: FC<Props> = ({ behandling, vilkår }) => {
                                     behandling={behandling}
                                     alleVilkårOppfylt={alleVilkårOppfylt}
                                     ikkeOppfyltVilkårEksisterer={true}
-                                    lagretVedtak={vedtak}
+                                    lagretVedtak={
+                                        vedtak?._type === IVedtakType.Avslag ? vedtak : undefined
+                                    }
                                 />
                             );
                         case EBehandlingResultat.OPPHØRT:
-                            return <Opphør behandlingId={behandlingId} lagretVedtak={vedtak} />;
+                            return (
+                                <Opphør
+                                    behandlingId={behandlingId}
+                                    lagretVedtak={
+                                        vedtak?._type === IVedtakType.Opphør ? vedtak : undefined
+                                    }
+                                />
+                            );
                         case undefined:
                         default:
                             return null;

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/Vedtaksform.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/Vedtaksform.tsx
@@ -6,7 +6,6 @@ import {
     IInnvilgeVedtakForBarnetilsyn,
     IPeriodeMedBeløp,
     IUtgiftsperiode,
-    IvedtakForBarnetilsyn,
     IVedtakType,
 } from '../../../../App/typer/vedtak';
 import { Behandling } from '../../../../App/typer/fagsak';
@@ -100,7 +99,7 @@ const initNullUtbetalingPgaKontantstøtte = (
 
 export const Vedtaksform: React.FC<{
     behandling: Behandling;
-    lagretVedtak?: IvedtakForBarnetilsyn;
+    lagretVedtak?: IInnvilgeVedtakForBarnetilsyn;
     barn: IBarnMedSamvær[];
     settResultatType: (val: EBehandlingResultat | undefined) => void;
     låsFraDatoFørsteRad: boolean;
@@ -215,6 +214,7 @@ export const Vedtaksform: React.FC<{
             _type: nullUtbetalingPgaKontantstøtte
                 ? IVedtakType.InnvilgelseBarnetilsynUtenUtbetaling
                 : IVedtakType.InnvilgelseBarnetilsyn,
+            resultatType: EBehandlingResultat.INNVILGE,
         };
         lagreVedtak(vedtaksRequest);
     };

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
@@ -14,7 +14,7 @@ import {
     EBehandlingResultat,
     IBeregningsperiodeBarnetilsyn,
     IVedtak,
-    IVedtakForOvergangsstønad,
+    IVedtakType,
 } from '../../../../App/typer/vedtak';
 import { Ressurs, RessursStatus } from '../../../../App/typer/ressurs';
 
@@ -175,11 +175,10 @@ export const blirNullUtbetalingPgaOverstigendeKontantstøtte = (
 export const skalViseNullstillVedtakKnapp = (vedtak: Ressurs<IVedtak | undefined>): boolean =>
     vedtak.status === RessursStatus.SUKSESS && vedtak.data !== undefined;
 
-export const skalFerdigstilleUtenBeslutter = (
-    vedtak?: IVedtakForOvergangsstønad | undefined
-): boolean => {
+export const skalFerdigstilleUtenBeslutter = (vedtak?: IVedtak | undefined): boolean => {
     return (
         !!vedtak &&
+        vedtak._type === IVedtakType.Avslag &&
         vedtak.resultatType === EBehandlingResultat.AVSLÅ &&
         vedtak.avslåÅrsak === EAvslagÅrsak.MINDRE_INNTEKTSENDRINGER
     );

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
@@ -13,6 +13,7 @@ import {
     EAvslagÅrsak,
     EBehandlingResultat,
     IBeregningsperiodeBarnetilsyn,
+    IVedtak,
     IVedtakForOvergangsstønad,
 } from '../../../../App/typer/vedtak';
 import { Ressurs, RessursStatus } from '../../../../App/typer/ressurs';
@@ -171,9 +172,8 @@ export const blirNullUtbetalingPgaOverstigendeKontantstøtte = (
             periode.beregningsgrunnlag.kontantstøttebeløp >= periode.beregningsgrunnlag.utgifter
     );
 
-export const skalViseNullstillVedtakKnapp = (
-    vedtak: Ressurs<IVedtakForOvergangsstønad | undefined>
-): boolean => vedtak.status === RessursStatus.SUKSESS && vedtak.data !== undefined;
+export const skalViseNullstillVedtakKnapp = (vedtak: Ressurs<IVedtak | undefined>): boolean =>
+    vedtak.status === RessursStatus.SUKSESS && vedtak.data !== undefined;
 
 export const skalFerdigstilleUtenBeslutter = (
     vedtak?: IVedtakForOvergangsstønad | undefined

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/AvslåVedtak/AvslåVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/AvslåVedtak/AvslåVedtak.tsx
@@ -6,7 +6,6 @@ import {
     EAvslagÅrsak,
     EBehandlingResultat,
     IAvslagVedtak,
-    IVedtakForOvergangsstønad,
     IVedtakType,
 } from '../../../../../App/typer/vedtak';
 import { Behandling } from '../../../../../App/typer/fagsak';
@@ -18,7 +17,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 export const AvslåVedtak: React.FC<{
     behandling: Behandling;
-    lagretVedtak?: IVedtakForOvergangsstønad;
+    lagretVedtak?: IAvslagVedtak;
     alleVilkårOppfylt: boolean;
     ikkeOppfyltVilkårEksisterer: boolean;
 }> = ({ behandling, lagretVedtak, alleVilkårOppfylt, ikkeOppfyltVilkårEksisterer }) => {

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/Opphør/Opphør.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/Opphør/Opphør.tsx
@@ -2,12 +2,7 @@ import MånedÅrVelger from '../../../../../Felles/Input/MånedÅr/MånedÅrVelg
 import React, { FormEvent, useState } from 'react';
 import { useBehandling } from '../../../../../App/context/BehandlingContext';
 import { useApp } from '../../../../../App/context/AppContext';
-import {
-    EBehandlingResultat,
-    IOpphørtVedtak,
-    IVedtakForOvergangsstønad,
-    IVedtakType,
-} from '../../../../../App/typer/vedtak';
+import { EBehandlingResultat, IOpphørtVedtak, IVedtakType } from '../../../../../App/typer/vedtak';
 import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../../../App/typer/ressurs';
 import styled from 'styled-components';
 import { EnsligTextArea } from '../../../../../Felles/Input/TekstInput/EnsligTextArea';
@@ -28,7 +23,7 @@ const Form = styled.form`
 
 export const Opphør: React.FC<{
     behandlingId: string;
-    lagretVedtak?: IVedtakForOvergangsstønad;
+    lagretVedtak?: IOpphørtVedtak;
 }> = ({ behandlingId, lagretVedtak }) => {
     const { utførRedirect } = useRedirectEtterLagring(`/behandling/${behandlingId}/simulering`);
     const [laster, settLaster] = useState(false);

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/VedtaksresultatSwitch.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/VedtaksresultatSwitch.tsx
@@ -1,11 +1,5 @@
 import React from 'react';
-import {
-    EBehandlingResultat,
-    IAvslagVedtak,
-    IOpphørtVedtak,
-    IVedtak,
-    IVedtakType,
-} from '../../../../App/typer/vedtak';
+import { EBehandlingResultat, IVedtak, IVedtakType } from '../../../../App/typer/vedtak';
 import { Behandling } from '../../../../App/typer/fagsak';
 import { InnvilgeOvergangsstønad } from './InnvilgeVedtak/InnvilgeOvergangsstønad';
 import { AvslåVedtak } from './AvslåVedtak/AvslåVedtak';
@@ -36,9 +30,7 @@ const VedtaksresultatSwitch: React.FC<Props> = ({
                 <AvslåVedtak
                     behandling={behandling}
                     lagretVedtak={
-                        lagretVedtak?._type === IVedtakType.Avslag
-                            ? (lagretVedtak as IAvslagVedtak)
-                            : undefined
+                        lagretVedtak?._type === IVedtakType.Avslag ? lagretVedtak : undefined
                     }
                     alleVilkårOppfylt={alleVilkårOppfylt}
                     ikkeOppfyltVilkårEksisterer={ikkeOppfyltVilkårEksisterer}
@@ -61,9 +53,7 @@ const VedtaksresultatSwitch: React.FC<Props> = ({
                 <Opphør
                     behandlingId={behandling.id}
                     lagretVedtak={
-                        lagretVedtak?._type === IVedtakType.Opphør
-                            ? (lagretVedtak as IOpphørtVedtak)
-                            : undefined
+                        lagretVedtak?._type === IVedtakType.Opphør ? lagretVedtak : undefined
                     }
                 />
             );

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/VedtaksresultatSwitch.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/VedtaksresultatSwitch.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import {
     EBehandlingResultat,
-    IVedtakForOvergangsstønad,
+    IAvslagVedtak,
+    IOpphørtVedtak,
+    IVedtak,
     IVedtakType,
 } from '../../../../App/typer/vedtak';
 import { Behandling } from '../../../../App/typer/fagsak';
@@ -13,7 +15,7 @@ import { IVilkår } from '../../Inngangsvilkår/vilkår';
 interface Props {
     vedtaksresultatType?: EBehandlingResultat;
     behandling: Behandling;
-    lagretVedtak?: IVedtakForOvergangsstønad;
+    lagretVedtak?: IVedtak;
     alleVilkårOppfylt: boolean;
     ikkeOppfyltVilkårEksisterer: boolean;
     vilkår: IVilkår;
@@ -33,7 +35,11 @@ const VedtaksresultatSwitch: React.FC<Props> = ({
             return (
                 <AvslåVedtak
                     behandling={behandling}
-                    lagretVedtak={lagretVedtak}
+                    lagretVedtak={
+                        lagretVedtak?._type === IVedtakType.Avslag
+                            ? (lagretVedtak as IAvslagVedtak)
+                            : undefined
+                    }
                     alleVilkårOppfylt={alleVilkårOppfylt}
                     ikkeOppfyltVilkårEksisterer={ikkeOppfyltVilkårEksisterer}
                 />
@@ -51,7 +57,16 @@ const VedtaksresultatSwitch: React.FC<Props> = ({
                 />
             );
         case EBehandlingResultat.OPPHØRT:
-            return <Opphør behandlingId={behandling.id} lagretVedtak={lagretVedtak} />;
+            return (
+                <Opphør
+                    behandlingId={behandling.id}
+                    lagretVedtak={
+                        lagretVedtak?._type === IVedtakType.Opphør
+                            ? (lagretVedtak as IOpphørtVedtak)
+                            : undefined
+                    }
+                />
+            );
         default:
             return null;
     }

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/VedtaksformSkolepenger.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/VedtaksformSkolepenger.tsx
@@ -1,4 +1,5 @@
 import {
+    EBehandlingResultat,
     IBeregningSkolepengerResponse,
     IBeregningsrequestSkolepenger,
     ISkoleårsperiodeSkolepenger,
@@ -138,6 +139,7 @@ export const VedtaksformSkolepenger: React.FC<{
                 _type: erOpphør
                     ? IVedtakType.OpphørSkolepenger
                     : IVedtakType.InnvilgelseSkolepenger,
+                resultatType: erOpphør ? EBehandlingResultat.OPPHØRT : EBehandlingResultat.INNVILGE,
             };
             lagreVedtak(vedtaksRequest);
         } else {

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/VedtakOgBeregningSkolepenger.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/VedtakOgBeregningSkolepenger.tsx
@@ -3,6 +3,7 @@ import { Behandling } from '../../../../App/typer/fagsak';
 import { IVilkår } from '../../Inngangsvilkår/vilkår';
 import {
     EBehandlingResultat,
+    IAvslagVedtak,
     IVedtakForSkolepenger,
     IVedtakType,
 } from '../../../../App/typer/vedtak';
@@ -82,7 +83,11 @@ const VedtakOgBeregningSkolepenger: FC<Props> = ({ behandling, vilkår }) => {
                                     behandling={behandling}
                                     alleVilkårOppfylt={alleVilkårOppfylt}
                                     ikkeOppfyltVilkårEksisterer={true}
-                                    lagretVedtak={vedtak}
+                                    lagretVedtak={
+                                        vedtak?._type === IVedtakType.Avslag
+                                            ? (vedtak as IAvslagVedtak)
+                                            : undefined
+                                    }
                                 />
                             );
                         case undefined:

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/VedtakOgBeregningSkolepenger.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/VedtakOgBeregningSkolepenger.tsx
@@ -3,7 +3,6 @@ import { Behandling } from '../../../../App/typer/fagsak';
 import { IVilkår } from '../../Inngangsvilkår/vilkår';
 import {
     EBehandlingResultat,
-    IAvslagVedtak,
     IVedtakForSkolepenger,
     IVedtakType,
 } from '../../../../App/typer/vedtak';
@@ -84,9 +83,7 @@ const VedtakOgBeregningSkolepenger: FC<Props> = ({ behandling, vilkår }) => {
                                     alleVilkårOppfylt={alleVilkårOppfylt}
                                     ikkeOppfyltVilkårEksisterer={true}
                                     lagretVedtak={
-                                        vedtak?._type === IVedtakType.Avslag
-                                            ? (vedtak as IAvslagVedtak)
-                                            : undefined
+                                        vedtak?._type === IVedtakType.Avslag ? vedtak : undefined
                                     }
                                 />
                             );


### PR DESCRIPTION
Hvorfor gjøres dette?
Dersom det først avslås og deretter innvilges i barnetilsyn fikk man en feilmelding, som vist i favro-kortet. Dette er en fix for det.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12369)

Koden bærer preg av at barnetilsyn og skolepenger er lagt til i etterkant, og det er derfor notert ned hva som kan forbedres: [Favro-kort på forslag til forbedringer](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12371)