### PR TITLE
Flytt valg av samordningsfradragstype ut av inntektsrader

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
@@ -35,7 +35,7 @@ import { HorizontalScroll } from '../../Felles/HorizontalScroll';
 import { initierValgteInntektstyper } from './utils';
 import { AlertError } from '../../../../../Felles/Visningskomponenter/Alerts';
 import { EInntektstype, inntektsTypeTilKey, inntektsTypeTilTekst } from './typer';
-import { AGray50 } from '@navikt/ds-tokens/dist/tokens';
+import { ABorderDivider, AGray50 } from '@navikt/ds-tokens/dist/tokens';
 import { IngenBegrunnelseOppgitt } from './IngenBegrunnelseOppgitt';
 import { EnsligTextArea } from '../../../../../Felles/Input/TekstInput/EnsligTextArea';
 
@@ -89,6 +89,17 @@ const CheckboxGroupRow = styled(CheckboxGroup)`
 
 const ReadMoreMedMarginBottom = styled(ReadMore)`
     margin-bottom: 2rem;
+`;
+
+const SamordningsfradragTypeContainer = styled.div`
+    margin: 1.5rem 0;
+    border-top: 1px solid ${ABorderDivider};
+    width: 100%;
+`;
+
+const EnsligFamilieSelectBegrensetWidth = styled(EnsligFamilieSelect)`
+    width: max-content;
+    margin-top: 1rem;
 `;
 
 interface Props {
@@ -235,10 +246,7 @@ const InntektsperiodeValg: React.FC<Props> = ({
                                 <TextLabel>Årsinntekt</TextLabel>
                             )}
                             {valgteInntektstyper.includes(EInntektstype.SAMORDNINGSFRADRAG) && (
-                                <>
-                                    <TextLabel>Samordningsfradrag</TextLabel>
-                                    <TextLabel>Type samordningsfradrag</TextLabel>
-                                </>
+                                <TextLabel>Samordningsfradrag</TextLabel>
                             )}
 
                             {inntektsperiodeListe.value.map((rad, index) => {
@@ -347,53 +355,6 @@ const InntektsperiodeValg: React.FC<Props> = ({
                                                     }}
                                                     erLesevisning={!behandlingErRedigerbar}
                                                 />
-                                                <div>
-                                                    <EnsligFamilieSelect
-                                                        label={'Type samordninsfradrag'}
-                                                        hideLabel
-                                                        size={'medium'}
-                                                        value={
-                                                            skalVelgeSamordningstype
-                                                                ? samordningsfradragstype.value
-                                                                : ''
-                                                        }
-                                                        onChange={(event) => {
-                                                            settIkkePersistertKomponent(
-                                                                VEDTAK_OG_BEREGNING
-                                                            );
-                                                            samordningsfradragstype.onChange(event);
-                                                        }}
-                                                        disabled={
-                                                            !skalVelgeSamordningstype || index > 0
-                                                        }
-                                                        erLesevisning={!behandlingErRedigerbar}
-                                                        lesevisningVerdi={
-                                                            samordningsfradragstype.value &&
-                                                            samordningsfradagTilTekst[
-                                                                samordningsfradragstype.value as ESamordningsfradragtype
-                                                            ]
-                                                        }
-                                                    >
-                                                        <option value="">Velg</option>
-                                                        <option
-                                                            value={
-                                                                ESamordningsfradragtype.GJENLEVENDEPENSJON
-                                                            }
-                                                        >
-                                                            Gjenlevendepensjon
-                                                        </option>
-                                                        <option
-                                                            value={
-                                                                ESamordningsfradragtype.UFØRETRYGD
-                                                            }
-                                                        >
-                                                            Uføretrygd
-                                                        </option>
-                                                    </EnsligFamilieSelect>
-                                                    <EnsligErrorMessage>
-                                                        {errorState?.samordningsfradragType}
-                                                    </EnsligErrorMessage>
-                                                </div>
                                             </>
                                         )}
                                         {skalViseLeggTilKnapp && (
@@ -430,6 +391,42 @@ const InntektsperiodeValg: React.FC<Props> = ({
                                 );
                             })}
                         </Grid>
+                        {skalVelgeSamordningstype && (
+                            <SamordningsfradragTypeContainer>
+                                <EnsligFamilieSelectBegrensetWidth
+                                    label={'Type samordninsfradrag'}
+                                    size={'medium'}
+                                    value={
+                                        skalVelgeSamordningstype
+                                            ? samordningsfradragstype.value
+                                            : ''
+                                    }
+                                    onChange={(event) => {
+                                        settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
+                                        samordningsfradragstype.onChange(event);
+                                    }}
+                                    disabled={!skalVelgeSamordningstype}
+                                    erLesevisning={!behandlingErRedigerbar}
+                                    lesevisningVerdi={
+                                        samordningsfradragstype.value &&
+                                        samordningsfradagTilTekst[
+                                            samordningsfradragstype.value as ESamordningsfradragtype
+                                        ]
+                                    }
+                                >
+                                    <option value="">Velg</option>
+                                    <option value={ESamordningsfradragtype.GJENLEVENDEPENSJON}>
+                                        Gjenlevendepensjon
+                                    </option>
+                                    <option value={ESamordningsfradragtype.UFØRETRYGD}>
+                                        Uføretrygd
+                                    </option>
+                                </EnsligFamilieSelectBegrensetWidth>
+                                <EnsligErrorMessage>
+                                    {errorState?.samordningsfradragType}
+                                </EnsligErrorMessage>
+                            </SamordningsfradragTypeContainer>
+                        )}
                         {behandlingErRedigerbar && (
                             <LeggTilRadKnapp
                                 onClick={() => inntektsperiodeListe.push(tomInntektsperiodeRad())}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
@@ -394,7 +394,7 @@ const InntektsperiodeValg: React.FC<Props> = ({
                         {skalVelgeSamordningstype && (
                             <SamordningsfradragTypeContainer>
                                 <EnsligFamilieSelectBegrensetWidth
-                                    label={'Type samordninsfradrag'}
+                                    label={'Type samordningsfradrag'}
                                     size={'medium'}
                                     value={
                                         skalVelgeSamordningstype


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
Da opplæringsmaterialet for den nye inntektsvisningen ble lagt ut kom det kommentarer om at det er rart å velge samordningstype per rad fordi typen ikke bare gjelder den raden. 

### Hva er gjort? 🤹‍♀️
Flyttet selecten utenfor grid og beholdt funksjonaliteten ellers. Divider + select syntes først når det er skrevet inn en sum > 0 i samordningsfradragsfeltet. 
![Apr-19-2023 09-07-27](https://user-images.githubusercontent.com/46678893/232994307-67b8f4a1-8567-4691-a940-2c48a822f700.gif)
