### PR TITLE
Paginering skal være size=xsmall

### DIFF
--- a/src/frontend/Felles/Pdf/PdfVisning.tsx
+++ b/src/frontend/Felles/Pdf/PdfVisning.tsx
@@ -75,6 +75,7 @@ const PdfVisning: React.FC<PdfVisningProps> = ({ pdfFilInnhold }) => {
                         page={pageNumber}
                         count={numPages}
                         onPageChange={setPageNumber}
+                        size="xsmall"
                     />
                 </DokumentWrapper>
             )}


### PR DESCRIPTION
En av to pagineringer i pdf-visningen av brev ble glemt i PR #2264 🐒