### PR TITLE
🐛 Skal lage tomme inntekt og periode rader om revurdering er før fradato i første periode

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeOvergangsstønad.tsx
@@ -9,7 +9,7 @@ import { revurdererFraPeriodeUtenStønad } from './revurderFraUtils';
 import { RevurderesFraOgMed } from '../../Felles/RevurderesFraOgMed';
 import { IVilkår } from '../../../Inngangsvilkår/vilkår';
 import { Vedtaksform } from './Vedtaksform';
-import { oppdaterVedtakMedEndretKey } from './utils';
+import { oppdaterVedtakMedEndretKey, oppdaterVedtakMedInitPeriodeOgOpphørshull } from './utils';
 
 export const InnvilgeOvergangsstønad: React.FC<{
     behandling: Behandling;
@@ -39,7 +39,13 @@ export const InnvilgeOvergangsstønad: React.FC<{
             }).then((res: RessursSuksess<IInnvilgeVedtakForOvergangsstønad> | RessursFeilet) => {
                 if (res.status === RessursStatus.SUKSESS) {
                     settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
-                    settVedtak(oppdaterVedtakMedEndretKey(res.data));
+                    const oppdatertVedtakMedEndretKey = oppdaterVedtakMedEndretKey(res.data);
+                    settVedtak(
+                        oppdaterVedtakMedInitPeriodeOgOpphørshull(
+                            oppdatertVedtakMedEndretKey,
+                            revurderesFra
+                        )
+                    );
                 } else {
                     settRevurderesFraOgMedFeilmelding(res.frontendFeilmelding);
                 }

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/utils.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/utils.ts
@@ -1,9 +1,33 @@
 import {
     IInntektsperiode,
     IInnvilgeVedtakForOvergangsstønad,
+    IVedtaksperiode,
 } from '../../../../../App/typer/vedtak';
 import { v4 as uuidv4 } from 'uuid';
 import { EInntektstype, inntektsTypeTilKey } from './typer';
+import { fyllHullMedOpphør, revurderFraInitPeriode } from './revurderFraUtils';
+import { tomVedtaksperiodeRad } from './VedtaksperiodeValg';
+import { tomInntektsperiodeRad } from './InntektsperiodeValg';
+
+export const oppdaterVedtakMedInitPeriodeOgOpphørshull = (
+    vedtak: IInnvilgeVedtakForOvergangsstønad | undefined,
+    revurderesFra: string | undefined
+): IInnvilgeVedtakForOvergangsstønad | undefined => {
+    if (!vedtak || !revurderesFra) {
+        return vedtak;
+    }
+    return {
+        ...vedtak,
+        perioder: [
+            ...revurderFraInitPeriode(vedtak, revurderesFra, tomVedtaksperiodeRad),
+            ...vedtak.perioder.reduce(fyllHullMedOpphør, [] as IVedtaksperiode[]),
+        ],
+        inntekter: [
+            ...revurderFraInitPeriode(vedtak, revurderesFra, tomInntektsperiodeRad),
+            ...vedtak.inntekter,
+        ],
+    };
+};
 
 export const oppdaterVedtakMedEndretKey = (
     vedtak: IInnvilgeVedtakForOvergangsstønad | undefined


### PR DESCRIPTION
Tar inn igjen kode som tidligere lå i vedtaksform (https://github.com/navikt/familie-ef-sak-frontend/pull/2219/files#diff-0dda3fa38489e0ae95285e9bb6fd2e5aa44c06031298ef8a757b5272dde05abb)