### PR TITLE
skal kunne opprette tasks for opprettelse av vurder konsekvens oppgav…

### DIFF
--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -16,5 +16,5 @@ export enum ToggleName {
     angreSendTilBeslutter = 'familie.ef.sak.frontend-angre-send-til-beslutter',
     ulikeInntekter = 'familie.ef.sak-ulike-inntekter',
     settPåVentMedOppgavestyring = 'familie.ef.sak.sett-paa-vent-med-oppgavestyring',
-    automatiskeOppgaverMotLokalkontor = 'familie.ef.sak.automatiske-oppgaver-lokalkontor',
+    visVurderHenvendelseOppgaver = 'familie.ef.sak.automatiske-oppgaver-lokalkontor',
 }

--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -16,4 +16,5 @@ export enum ToggleName {
     angreSendTilBeslutter = 'familie.ef.sak.frontend-angre-send-til-beslutter',
     ulikeInntekter = 'familie.ef.sak-ulike-inntekter',
     settPåVentMedOppgavestyring = 'familie.ef.sak.sett-paa-vent-med-oppgavestyring',
+    automatiskeOppgaverMotLokalkontor = 'familie.ef.sak.automatiske-oppgaver-lokalkontor',
 }

--- a/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVent.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVent.tsx
@@ -280,8 +280,15 @@ export const SettPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
                                         size="small"
                                     >
                                         {aktuelleOppgaver.map((oppgave) => (
-                                            <Checkbox key={oppgave} value={oppgave}>
-                                                {vurderHenvendelseOppgaveTilTekst[oppgave]}
+                                            <Checkbox
+                                                key={oppgave}
+                                                value={oppgave as VurderHenvendelseOppgavetype}
+                                            >
+                                                {
+                                                    vurderHenvendelseOppgaveTilTekst[
+                                                        oppgave as VurderHenvendelseOppgavetype
+                                                    ]
+                                                }
                                             </Checkbox>
                                         ))}
                                     </CheckboxGroup>

--- a/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVent.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVent.tsx
@@ -8,7 +8,7 @@ import {
     RessursSuksess,
 } from '../../../App/typer/ressurs';
 import { useApp } from '../../../App/context/AppContext';
-import { Alert, Button, Heading, Textarea } from '@navikt/ds-react';
+import { Alert, Button, Checkbox, CheckboxGroup, Heading, Textarea } from '@navikt/ds-react';
 import styled from 'styled-components';
 import { ADeepblue50 } from '@navikt/ds-tokens/dist/tokens';
 import { ToggleName } from '../../../App/context/toggles';
@@ -29,6 +29,7 @@ import { Behandling } from '../../../App/typer/fagsak';
 import { TaAvVentModal } from './TaAvVentModal';
 import { EToast } from '../../../App/typer/toast';
 import { EksisterendeBeskrivelse } from './EksisterendeBeskrivelse';
+import { Stønadstype } from '../../../App/typer/behandlingstema';
 
 const AlertStripe = styled(Alert)`
     margin-top: 1rem;
@@ -51,7 +52,6 @@ const KnappeWrapper = styled.div`
     display: flex;
     gap: 2rem;
     justify-content: flex-end;
-    margin-right: 0.5rem;
 `;
 
 const FlexColumnDiv = styled.div`
@@ -64,6 +64,18 @@ const Beskrivelse = styled(Textarea)`
     max-width: 60rem;
 `;
 
+enum VurderHenvendelseOppgavetype {
+    INFORMERE_OM_SØKT_OVERGANGSSTØNAD = 'INFORMERE_OM_SØKT_OVERGANGSSTØNAD',
+    INNSTILLING_VEDRØRENDE_UTDANNING = 'INNSTILLING_VEDRØRENDE_UTDANNING',
+}
+
+const vurderHenvendelseOppgaveTilTekst: Record<VurderHenvendelseOppgavetype, string> = {
+    INFORMERE_OM_SØKT_OVERGANGSSTØNAD:
+        'Automatisk oppgave til lokalkontor med beskjed om mottatt søknad',
+    INNSTILLING_VEDRØRENDE_UTDANNING:
+        'Automatisk oppgave om innstilling av utdanning til lokalkontor',
+};
+
 type SettPåVentRequest = {
     oppgaveId: number;
     saksbehandler: string;
@@ -72,15 +84,22 @@ type SettPåVentRequest = {
     mappe: string | undefined;
     beskrivelse: string | undefined;
     oppgaveVersjon: number;
+    oppfølgingsoppgaverMotLokalKontor: VurderHenvendelseOppgavetype[];
 };
 
 export const SettPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
     const erBehandlingPåVent = behandling.status === BehandlingStatus.SATT_PÅ_VENT;
+    const erOvergangsstønad = behandling.stønadstype === Stønadstype.OVERGANGSSTØNAD;
+    const erOvergangsstønadEllerSkolepenger =
+        erOvergangsstønad || behandling.stønadstype === Stønadstype.SKOLEPENGER;
     const { visSettPåVent, settVisSettPåVent, hentBehandling } = useBehandling();
     const { toggles } = useToggles();
     const { axiosRequest, settToast } = useApp();
 
-    const [oppgave, settOppgave] = useState<Ressurs<IOppgave>>(byggTomRessurs());
+    const [oppgave, settOppgave] = useState<Ressurs<IOppgave>>(byggTomRessurs<IOppgave>());
+    const [oppgaverMotLokalkontor, settOppgaverMotLokalkontor] = useState<
+        VurderHenvendelseOppgavetype[]
+    >([]);
     const [taAvVentStatus, settTaAvVentStatus] = useState<ETaAvVentStatus>();
     const [låsKnapp, settLåsKnapp] = useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState<string>();
@@ -91,7 +110,6 @@ export const SettPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
     const [frist, settFrist] = useState<string | undefined>();
     const [mappe, settMappe] = useState<number | undefined>();
     const [beskrivelse, settBeskrivelse] = useState('');
-
     const lukkSettPåVent = () => {
         settFeilmelding('');
         settVisSettPåVent(false);
@@ -174,6 +192,7 @@ export const SettPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
                 beskrivelse,
                 oppgaveVersjon: oppgave.data.versjon,
                 oppgaveId: oppgave.data.id,
+                oppfølgingsoppgaverMotLokalKontor: oppgaverMotLokalkontor,
             },
         })
             .then((respons: RessursFeilet | RessursSuksess<string>) => {
@@ -195,18 +214,30 @@ export const SettPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
         settPrioritet(undefined);
         settFrist(undefined);
         settMappe(undefined);
+        settOppgaverMotLokalkontor([]);
     };
+
+    const aktuelleOppgaver = Object.keys(VurderHenvendelseOppgavetype)
+        .filter(() => !erBehandlingPåVent)
+        .filter((oppgavetype) =>
+            oppgavetype === VurderHenvendelseOppgavetype.INFORMERE_OM_SØKT_OVERGANGSSTØNAD
+                ? erOvergangsstønad
+                : true
+        )
+        .filter((oppgavetype) =>
+            oppgavetype === VurderHenvendelseOppgavetype.INNSTILLING_VEDRØRENDE_UTDANNING
+                ? erOvergangsstønadEllerSkolepenger
+                : true
+        );
 
     return visSettPåVent && toggles[ToggleName.settPåVentMedOppgavestyring] ? (
         <DataViewer response={{ oppgave }}>
             {({ oppgave }) => {
                 return (
                     <SettPåVentWrapper>
-                        {erBehandlingPåVent ? (
-                            <Heading size={'medium'}>Behandling på vent</Heading>
-                        ) : (
-                            <Heading size={'medium'}>Sett behandling på vent</Heading>
-                        )}
+                        <Heading size={'medium'}>
+                            {erBehandlingPåVent ? 'Behandling på vent' : 'Sett behandling på vent'}
+                        </Heading>
                         <FlexColumnDiv>
                             <OppgaveValg>
                                 <SaksbehandlerVelger
@@ -241,6 +272,20 @@ export const SettPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
                                     onChange={(e) => settBeskrivelse(e.target.value)}
                                 />
                             )}
+                            {toggles[ToggleName.automatiskeOppgaverMotLokalkontor] &&
+                                !erBehandlingPåVent && (
+                                    <CheckboxGroup
+                                        legend="Alternative aksjoner"
+                                        onChange={settOppgaverMotLokalkontor}
+                                        size="small"
+                                    >
+                                        {aktuelleOppgaver.map((oppgave) => (
+                                            <Checkbox key={oppgave} value={oppgave}>
+                                                {vurderHenvendelseOppgaveTilTekst[oppgave]}
+                                            </Checkbox>
+                                        ))}
+                                    </CheckboxGroup>
+                                )}
                         </FlexColumnDiv>
                         <KnappeWrapper>
                             {!erBehandlingPåVent && (

--- a/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVent.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVent.tsx
@@ -217,18 +217,20 @@ export const SettPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
         settOppgaverMotLokalkontor([]);
     };
 
-    const aktuelleOppgaver = Object.keys(VurderHenvendelseOppgavetype)
-        .filter(() => !erBehandlingPåVent)
-        .filter((oppgavetype) =>
-            oppgavetype === VurderHenvendelseOppgavetype.INFORMERE_OM_SØKT_OVERGANGSSTØNAD
-                ? erOvergangsstønad
-                : true
-        )
-        .filter((oppgavetype) =>
-            oppgavetype === VurderHenvendelseOppgavetype.INNSTILLING_VEDRØRENDE_UTDANNING
-                ? erOvergangsstønadEllerSkolepenger
-                : true
-        );
+    const filtrerOppgavetyper = (oppgavetype: string) => {
+        switch (oppgavetype) {
+            case VurderHenvendelseOppgavetype.INFORMERE_OM_SØKT_OVERGANGSSTØNAD:
+                return erOvergangsstønad;
+            case VurderHenvendelseOppgavetype.INNSTILLING_VEDRØRENDE_UTDANNING:
+                return erOvergangsstønadEllerSkolepenger;
+            default:
+                return true;
+        }
+    };
+
+    const aktuelleOppgaver = Object.keys(VurderHenvendelseOppgavetype).filter((oppgavetype) =>
+        filtrerOppgavetyper(oppgavetype)
+    );
 
     return visSettPåVent && toggles[ToggleName.settPåVentMedOppgavestyring] ? (
         <DataViewer response={{ oppgave }}>
@@ -272,7 +274,7 @@ export const SettPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
                                     onChange={(e) => settBeskrivelse(e.target.value)}
                                 />
                             )}
-                            {toggles[ToggleName.automatiskeOppgaverMotLokalkontor] &&
+                            {toggles[ToggleName.visVurderHenvendelseOppgaver] &&
                                 !erBehandlingPåVent && (
                                     <CheckboxGroup
                                         legend="Alternative aksjoner"


### PR DESCRIPTION
…er ved sett behandling på vent

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12235)

**Hva er gjort?**
Når saksbehandler setter en oppgave på vent skal hen kunne velge å huke av to checkboxer for opprettelse av to vurder konsekvens oppgaver som skal sendes til brukers lokalkontor.

Valgmuligheten for den ene oppgaven skal kun opptre dersom behandlingen som settes på vent er en overgangsstønad.
Valgmuligheten for den andre oppgaven skal kun opptre dersom behandlingen som settes på vent er enten en overgangsstønad eller skolepenger.

Dette er testet i preprod og man kan se at vurder konsekvens oppgaver har blitt opprettet på denne brukerens ved å sortere på dato: [gosys](https://gosys-q2.dev.intern.nav.no/gosys/bruker/brukeroversikt.jsf?execution=e2s2)

Checkboxene er featureTogglet og skal være trygge å pushe til prod

**Backend**
* https://github.com/navikt/familie-ef-sak/pull/2184

**To nye checkboxer**
![Skjermbilde 2023-04-26 kl  09 26 32](https://user-images.githubusercontent.com/32769446/234501246-9a8c92c4-6168-4b0d-a0e2-52f38d35dc35.png)
