### PR TITLE
visuelle utbedringer for sett på vent funksjonalitet

### DIFF
--- a/src/frontend/Komponenter/Behandling/SettPåVent/EksisterendeBeskrivelse.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/EksisterendeBeskrivelse.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import { ChevronDownIcon, ChevronUpIcon } from '@navikt/aksel-icons';
 import { BreakWordBodyLongSmall } from '../../../Felles/Visningskomponenter/BreakWordBodyLongSmall';
 import { ABlue300 } from '@navikt/ds-tokens/dist/tokens';
+import { BodyLongSmall } from '../../../Felles/Visningskomponenter/Tekster';
 
 const EkspanderbarContainer = styled(BreakWordBodyLongSmall)<{ ekspandert: boolean }>`
     max-height: ${(props) => (props.ekspandert ? 'none' : '15rem')};
@@ -37,7 +38,7 @@ export const EksisterendeBeskrivelse: React.FC<{ beskrivelse?: string }> = ({ be
                 <Label size={'small'}>Beskrivelseshistorikk</Label>
                 <LeftBorder>
                     <EkspanderbarContainer ref={refCallback} ekspandert={ekspandert}>
-                        {beskrivelse}
+                        <BodyLongSmall>{beskrivelse}</BodyLongSmall>
                     </EkspanderbarContainer>
                     {(harOverflow || ekspandert) && (
                         <Button

--- a/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVent.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVent.tsx
@@ -70,10 +70,8 @@ enum VurderHenvendelseOppgavetype {
 }
 
 const vurderHenvendelseOppgaveTilTekst: Record<VurderHenvendelseOppgavetype, string> = {
-    INFORMERE_OM_SØKT_OVERGANGSSTØNAD:
-        'Automatisk oppgave til lokalkontor med beskjed om mottatt søknad',
-    INNSTILLING_VEDRØRENDE_UTDANNING:
-        'Automatisk oppgave om innstilling av utdanning til lokalkontor',
+    INFORMERE_OM_SØKT_OVERGANGSSTØNAD: 'Beskjed om at vi har mottatt søknad',
+    INNSTILLING_VEDRØRENDE_UTDANNING: 'Forespørsel om innstilling - utdanning',
 };
 
 type SettPåVentRequest = {
@@ -275,9 +273,10 @@ export const SettPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
                                 />
                             )}
                             {toggles[ToggleName.visVurderHenvendelseOppgaver] &&
+                                erOvergangsstønadEllerSkolepenger &&
                                 !erBehandlingPåVent && (
                                     <CheckboxGroup
-                                        legend="Alternative aksjoner"
+                                        legend="Send oppgave til lokalkontoret"
                                         onChange={settOppgaverMotLokalkontor}
                                         size="small"
                                     >


### PR DESCRIPTION
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12404)

**Hva var feil?**
Etter funksjonell testing av funksjonaliteten for sett på vent viste det seg at følgende endringer var ønskelige:
- Tekstendringer for sett på vent label og sett på vent checkbokser
- Sett på vent label skal ikke vises for barnetilsyn
- Mindre spacing mellom oppdateringer i oppgavebeskrivelsen
- Tekststørrelse small på oppgavebeskrivelsen

Alle nevnte punkter er nå utbedret

**Backend**
* https://github.com/navikt/familie-ef-sak/pull/2204 

Visuelle utbedringer: Tekstlabel og checkboxbeskrivelse er oppdatert. I tillegg er spacingen mellom innslagene i oppgavebeskrivelsen minket til kun en linje:
![Skjermbilde 2023-05-03 kl  11 32 07](https://user-images.githubusercontent.com/32769446/235881074-9a1e3dcf-e6ab-48fa-8b49-e44f3f4cf84c.png)
![Skjermbilde 2023-05-03 kl  11 31 31](https://user-images.githubusercontent.com/32769446/235881079-9eba2d26-434c-45b1-acf5-0f230d59f01d.png)

