### PR TITLE
Skal vise frem informasjon om oppholdsland og land i utelandsopphold i vilkårsvurderingen

### DIFF
--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Medlemskap/MedlemskapInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Medlemskap/MedlemskapInfo.tsx
@@ -28,11 +28,20 @@ const MedlemskapInfo: FC<Props> = ({ medlemskap, skalViseSøknadsdata }) => {
     return (
         <InformasjonContainer>
             {skalViseSøknadsdata && søknadsgrunnlag && (
-                <Informasjonsrad
-                    ikon={VilkårInfoIkon.SØKNAD}
-                    label="Har bodd i Norge siste 5 år"
-                    verdi={mapTrueFalse(søknadsgrunnlag.bosattNorgeSisteÅrene)}
-                />
+                <>
+                    <Informasjonsrad
+                        ikon={VilkårInfoIkon.SØKNAD}
+                        label="Har bodd i Norge siste 5 år"
+                        verdi={mapTrueFalse(søknadsgrunnlag.bosattNorgeSisteÅrene)}
+                    />
+                    {søknadsgrunnlag.oppholdsland && (
+                        <Informasjonsrad
+                            ikon={VilkårInfoIkon.SØKNAD}
+                            label="Oppholdsland"
+                            verdi={søknadsgrunnlag.oppholdsland}
+                        />
+                    )}
+                </>
             )}
             {finnesUnntakIMedl && (
                 <Informasjonsrad

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Medlemskap/Utenlandsopphold.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Medlemskap/Utenlandsopphold.tsx
@@ -24,6 +24,10 @@ const Utenlandsopphold: FC<Props> = ({ utenlandsopphold }) => (
                 tekstVerdi: (d) => formaterNullableIsoDato(d.tilDato),
             },
             {
+                overskrift: 'Land',
+                tekstVerdi: (d) => d.land,
+            },
+            {
                 overskrift: 'Årsak',
                 tekstVerdi: (d) => d.årsak,
             },

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Medlemskap/typer.ts
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Medlemskap/typer.ts
@@ -13,6 +13,7 @@ export interface IMedlemskap {
 export interface IMedlemskapSøknadsgrunnlag {
     bosattNorgeSisteÅrene: boolean;
     oppholderDuDegINorge: boolean;
+    oppholdsland?: string;
     utenlandsopphold: IUtenlandsopphold[];
 }
 
@@ -37,6 +38,7 @@ export interface IGyldigVedtakPeriode {
 export interface IUtenlandsopphold {
     fraDato: string;
     tilDato: string;
+    land?: string;
     årsak: string;
 }
 


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨ 
[FAVRO](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12261)
Søknad skal inneholde to nye felter for å registrere hvilket land søker oppholder seg i nå (`oppholdsland`) og hvilket land de oppholdt seg under et utenlandsopphold (`land`). Disse må vises frem i vilkårsvurderingen.

### Hva er gjort? 🤓 

- Visning av informasjon
- Oppdatering av typer

### Bilder
Med oppholdsland og land i utenlandsopphold:
<img width="1460" alt="image" src="https://user-images.githubusercontent.com/46678893/235896955-b5e116ca-4461-46c4-8348-8f2521200e54.png">

Uten oppholdsland og land i utenlandsopphold: 
<img width="1347" alt="image" src="https://user-images.githubusercontent.com/46678893/235897096-c02b838e-cd96-4350-b4b0-d990bafeda3f.png">

### Andre relevante PR-er 🤝

- ef-sak [PR 2195](https://github.com/navikt/familie-ef-sak/pull/2195)
- ef-soknad [PR 1245](https://github.com/navikt/familie-ef-soknad/pull/1245) (Lagt til de nye feltene)
- ef-soknad-api [PR 844](https://github.com/navikt/familie-ef-soknad-api/pull/844) (mapper de nye feltene)
- familie-kontrakter [PR 744](https://github.com/navikt/familie-kontrakter/pull/774) (legger til oppholdsland i medlemskap og land i utenlandsopphold) og [PR 746](https://github.com/navikt/familie-kontrakter/pull/776) (gi mulighet til å sette de nye feltene i `TestSøknadsBuilder`)
- familie-mottak [PR 964](https://github.com/navikt/familie-ef-mottak/pull/964) (bumper kontrakterversjon)