### PR TITLE
For å kalle endringslogg må vi bruke service-discovery

### DIFF
--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -79,7 +79,7 @@ const Environment = (): IEnvironment => {
             modia: 'https://app-q1.adeo.no/modiapersonoversikt',
             historiskPensjon: 'https://historisk-pensjon.intern.dev.nav.no',
             redisUrl: 'familie-ef-sak-frontend-redis',
-            endringsloggProxyUrl: 'https//familie-endringslogg',
+            endringsloggProxyUrl: 'http://familie-endringslogg',
             roller: rollerDev,
         };
     } else if (process.env.ENV === 'lokalt-mot-preprod') {

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -79,7 +79,7 @@ const Environment = (): IEnvironment => {
             modia: 'https://app-q1.adeo.no/modiapersonoversikt',
             historiskPensjon: 'https://historisk-pensjon.intern.dev.nav.no',
             redisUrl: 'familie-ef-sak-frontend-redis',
-            endringsloggProxyUrl: 'https://familie-endringslogg.intern.dev.nav.no',
+            endringsloggProxyUrl: 'https//familie-endringslogg',
             roller: rollerDev,
         };
     } else if (process.env.ENV === 'lokalt-mot-preprod') {
@@ -107,7 +107,7 @@ const Environment = (): IEnvironment => {
         modia: 'https://app.adeo.no/modiapersonoversikt',
         historiskPensjon: 'https://historisk-pensjon.intern.nav.no',
         redisUrl: 'familie-ef-sak-frontend-redis',
-        endringsloggProxyUrl: 'https://familie-endringslogg.intern.nav.no',
+        endringsloggProxyUrl: 'http://familie-endringslogg',
         roller: rollerProd,
     };
 };


### PR DESCRIPTION
Alternativet er å legge inn familie-endringslogg i outbound->external.

Ref:
https://nav-it.slack.com/archives/C5KUST8N6/p1683202885242509?thread_ts=1683200517.702969&cid=C5KUST8N6

Opprinnelig feil i prod:

> [HPM] Error occurred while proxying request ensligmorellerfar.intern.nav.no/endringslogg to https://familie-endringslogg.intern.nav.no/ [ECONNRESET] (https://nodejs.org/api/errors.html#errors_common_system_errors)