### PR TITLE
skal deaktivere sett mottakere knapp i brevmottakermodal dersom ingen…

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brevmottakere/BrevmottakereModal.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/BrevmottakereModal.tsx
@@ -65,6 +65,11 @@ export const BrevmottakereModal: FC<{
     const [innsendingSuksess, settInnsendingSukksess] = useState(false);
     const { settToast } = useApp();
 
+    const initiellePersonIdenter = mottakere.personer.map((mottaker) => mottaker.personIdent);
+    const valgtePersonIdenter = valgtePersonMottakere.map((mottaker) => mottaker.personIdent);
+    const initelleOrgNumre = mottakere.organisasjoner.map((org) => org.organisasjonsnummer);
+    const valgteOrgNumre = valgteOrganisasjonMottakere.map((org) => org.organisasjonsnummer);
+
     const settBrevmottakere = () => {
         settFeilmelding('');
         settInnsendingSukksess(false);
@@ -81,8 +86,17 @@ export const BrevmottakereModal: FC<{
         });
     };
 
-    const harValgtMottakere =
+    const harNyeMottakere = (initelleIdenter: string[], valgteIdenter: string[]) =>
+        valgteIdenter.some((identNummer) => !initelleIdenter.includes(identNummer));
+
+    const harBrevmottakere =
         valgtePersonMottakere.length > 0 || valgteOrganisasjonMottakere.length > 0;
+
+    const mottakerListeHarEndringer =
+        harNyeMottakere(initiellePersonIdenter, valgtePersonIdenter) ||
+        harNyeMottakere(initelleOrgNumre, valgteOrgNumre);
+
+    const deaktiverSettMottakere = !harBrevmottakere || !mottakerListeHarEndringer;
 
     return (
         <ModalWrapper
@@ -129,7 +143,11 @@ export const BrevmottakereModal: FC<{
                 <Button variant="tertiary" onClick={() => settVisBrevmottakereModal(false)}>
                     Avbryt
                 </Button>
-                <Button variant="primary" onClick={settBrevmottakere} disabled={!harValgtMottakere}>
+                <Button
+                    variant="primary"
+                    onClick={settBrevmottakere}
+                    disabled={deaktiverSettMottakere}
+                >
                     Sett mottakere
                 </Button>
             </SentrerKnapper>


### PR DESCRIPTION
… mottakere er valgt, eller ingen endringer for brevmottakere er gjort

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12433)

**Hva har blitt gjort?**
Dersom det ikke har blitt valgt noen nye brevmottakere siden man åpnet modalen skal knappen for å legge til mottakere være deaktivert. Dette gjør vi for å unngå misforståelser der saksbehandler har søkt opp en mottaker og tror at de har lagt mottakeren til i mottakerlisten uten å ha gjort det.

Legg til knapp er deaktivert på grunn av ingen endringer: 
<img width="1123" alt="Skjermbilde 2023-05-05 kl  10 43 28" src="https://user-images.githubusercontent.com/32769446/236416572-2aa16085-c821-4ab3-8e46-f1992f86e2b4.png">
