### PR TITLE
🐛 Bugfix - Endre revurderFra uten å slette ulagret arbeid

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
@@ -4,7 +4,7 @@ import {
     IInntektsperiode,
     samordningsfradagTilTekst,
 } from '../../../../../App/typer/vedtak';
-import React, { Dispatch, SetStateAction, useState } from 'react';
+import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import InputMedTusenSkille from '../../../../../Felles/Visningskomponenter/InputMedTusenskille';
 import { harTallverdi, tilTallverdi } from '../../../../../App/utils/utils';
@@ -132,6 +132,12 @@ const InntektsperiodeValg: React.FC<Props> = ({
     const [valgteInntektstyper, settValgteInntektstyper] = useState<EInntektstype[]>(
         initierValgteInntektstyper(inntektsperiodeListe.value)
     );
+
+    useEffect(() => {
+        settValgteInntektstyper(initierValgteInntektstyper(inntektsperiodeListe.value));
+
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [inntektsperiodeListe.value[0].endretKey]);
 
     const oppdaterInntektslisteElement = (
         index: number,

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeOvergangsstønad.tsx
@@ -32,7 +32,6 @@ export const InnvilgeOvergangsstønad: React.FC<{
 
     const hentVedtakshistorikk = useCallback(
         (revurderesFra: string) => {
-            settVedtak(undefined);
             axiosRequest<IInnvilgeVedtakForOvergangsstønad, void>({
                 method: 'GET',
                 url: `/familie-ef-sak/api/vedtak/fagsak/${behandling.fagsakId}/historikk/${revurderesFra}`,

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeOvergangsstønad.tsx
@@ -29,6 +29,8 @@ export const InnvilgeOvergangsstønad: React.FC<{
     const [revurderesFraOgMedFeilmelding, settRevurderesFraOgMedFeilmelding] = useState<
         string | null
     >(null);
+    const [revurderersFraPeriodeUtenStønad, settRevurderersFraPeriodeUtenStønad] =
+        useState<boolean>(revurdererFraPeriodeUtenStønad(lagretVedtak, revurderesFra));
 
     const hentVedtakshistorikk = useCallback(
         (revurderesFra: string) => {
@@ -39,6 +41,9 @@ export const InnvilgeOvergangsstønad: React.FC<{
                 if (res.status === RessursStatus.SUKSESS) {
                     settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
                     const oppdatertVedtakMedEndretKey = oppdaterVedtakMedEndretKey(res.data);
+                    settRevurderersFraPeriodeUtenStønad(
+                        revurdererFraPeriodeUtenStønad(oppdatertVedtakMedEndretKey, revurderesFra)
+                    );
                     settVedtak(
                         oppdaterVedtakMedInitPeriodeOgOpphørshull(
                             oppdatertVedtakMedEndretKey,
@@ -62,10 +67,7 @@ export const InnvilgeOvergangsstønad: React.FC<{
                     hentVedtakshistorikk={hentVedtakshistorikk}
                     revurderesFra={revurderesFra}
                     feilmelding={revurderesFraOgMedFeilmelding}
-                    revurdererFraPeriodeUtenStønad={revurdererFraPeriodeUtenStønad(
-                        vedtak,
-                        revurderesFra
-                    )}
+                    revurdererFraPeriodeUtenStønad={revurderersFraPeriodeUtenStønad}
                     stønadstype={behandling.stønadstype}
                 />
             ) : null}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/Vedtaksform.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/Vedtaksform.tsx
@@ -112,6 +112,17 @@ export const Vedtaksform: React.FC<{
         // eslint-disable-next-line
     }, [vedtaksperioder, inntektsperioder]);
 
+    useEffect(() => {
+        if (lagretVedtak?.inntekter) {
+            inntektsperiodeState.setValue(lagretVedtak?.inntekter);
+        }
+
+        if (lagretVedtak?.perioder) {
+            vedtaksperiodeState.setValue(lagretVedtak?.perioder);
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [lagretVedtak]);
+
     const skalVelgeSamordningstype = inntektsperiodeState.value.some(
         (rad) => rad.samordningsfradrag
     );


### PR DESCRIPTION
### Hvorfor er dette nødvendig? 🤔
[FAVRO](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12422)

"Dersom man endrer måned man skal revurdere fra på vedtak og beregnings siden, blir det man har skrevet i begge begrunnelsesfeltene borte." Kom inn som tilbakemelding på teams. 

Dette kommer som følge av splittingen som skjedde i [PR 2219](https://github.com/navikt/familie-ef-sak-frontend/pull/2219/files) hvor hele `VedtaksForm` rendres på nytt dersom `revurderesFra` endres fordi `vedtak` ble nullstilt mens vedtakshistorikk hentes på nytt. 

Advarselen ble borte i tidligere bugfix PR-er ([2272](https://github.com/navikt/familie-ef-sak-frontend/pull/2272) og [2274](https://github.com/navikt/familie-ef-sak-frontend/pull/2274)). 

### Hva er gjort? 🤓

- Det er lagt til en `useEffect` i `Vedtaksform` for å trigge oppdatering av periodene dersom vedtaket oppdateres. På denne måten beholdes begrunnelsene. 
- Det er lagt til en `useEffect` i `InntektsperiodeValg` for å trigge initiering av checkboxene dersom periodene oppdateres (bruker endringskey for å sjekke om endring faktisk har skjedd).
- Det er laget en egen state for å bestemme om advarselen skal vises. Denne bruker datoen fra historikk **før** den fylles med tomme perioder for hull. 

### Hva er målet? ✨ 

- Hvis man endrer `revurderFra` skal vedtaksperioder og inntektsperioder oppdateres, men begrunnelsene skal beholdes.
- Hvis man revurderer fra en måned uten stønad skal en advarsel vises.