### PR TITLE
Skal vise mer informasjon om behandling i journalføring

### DIFF
--- a/src/frontend/Komponenter/Journalføring/Behandling.tsx
+++ b/src/frontend/Komponenter/Journalføring/Behandling.tsx
@@ -98,6 +98,7 @@ const BehandlingInnold: React.FC<Props> = ({
                     <tr>
                         <th></th>
                         <th>Behandlingstype</th>
+                        <th>Opprettet</th>
                         <th>Status</th>
                         <th>Sist endret</th>
                     </tr>
@@ -125,6 +126,7 @@ const BehandlingInnold: React.FC<Props> = ({
                                                 ? Behandlingsårsak.MIGRERING
                                                 : behandlingsEl.type}
                                         </td>
+                                        <td>{formaterIsoDatoTid(behandlingsEl.opprettet)}</td>
                                         <td>{behandlingsEl.status}</td>
                                         <td>{formaterIsoDatoTid(behandlingsEl.sistEndret)}</td>
                                     </tr>

--- a/src/frontend/Komponenter/Journalføring/BehandlingKlageInnold.tsx
+++ b/src/frontend/Komponenter/Journalføring/BehandlingKlageInnold.tsx
@@ -2,7 +2,7 @@ import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
 import 'nav-frontend-tabell-style';
 import styled from 'styled-components';
 import DataViewer from '../../Felles/DataViewer/DataViewer';
-import { formaterNullableIsoDato } from '../../App/utils/formatter';
+import { formaterIsoDatoTid, formaterNullableIsoDato } from '../../App/utils/formatter';
 import { Ressurs, RessursStatus } from '../../App/typer/ressurs';
 import { KlageBehandling, Klagebehandlinger } from '../../App/typer/klage';
 import { BehandlingKlageRequest } from '../../App/hooks/useJournalføringKlageState';
@@ -83,6 +83,7 @@ const BehandlingKlageInnold: React.FC<Props> = ({
                     <tr>
                         <th></th>
                         <th>Behandlingstype</th>
+                        <th>Opprettet</th>
                         <th>Status</th>
                         <th>Sist endret</th>
                     </tr>
@@ -108,6 +109,9 @@ const BehandlingKlageInnold: React.FC<Props> = ({
                                                     </Checkbox>
                                                 </td>
                                                 <td>Klage</td>
+                                                <td>
+                                                    {formaterIsoDatoTid(behandlingsEl.opprettet)}
+                                                </td>
                                                 <td>{behandlingsEl.status}</td>
                                                 <td>
                                                     {formaterNullableIsoDato(


### PR DESCRIPTION
### Hvorfor er dette nødvendig? ✨
[FAVRO](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12365)

Saksbehandlerne vil gjerne ha mer informasjon om de ulike behandlingene i listen over behandlinger i journalføringsbildet. Har derfor lagt på `opprettet`

### Bilder 🎨
<img width="782" alt="image" src="https://user-images.githubusercontent.com/46678893/236764729-f13e3497-cc3d-4735-9b50-09b22c24e6c8.png">
