### PR TITLE
skal kunne legge til brevmottakere når du allerede har satt 3 og fjer…

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brevmottakere/BrevmottakereModal.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/BrevmottakereModal.tsx
@@ -87,7 +87,8 @@ export const BrevmottakereModal: FC<{
     };
 
     const harNyeMottakere = (initelleIdenter: string[], valgteIdenter: string[]) =>
-        valgteIdenter.some((identNummer) => !initelleIdenter.includes(identNummer));
+        valgteIdenter.some((identNummer) => !initelleIdenter.includes(identNummer)) ||
+        valgteIdenter.length !== initelleIdenter.length;
 
     const harBrevmottakere =
         valgtePersonMottakere.length > 0 || valgteOrganisasjonMottakere.length > 0;


### PR DESCRIPTION
…ner en eller flere

### Hvorfor er denne endringen nødvendig? ✨
Tidligere fikk man ikke lov til å sette brevmottakere dersom man kom inn i modalen med 2 eller flere initielle mottakere og fjernet en eller flere av dem. 

Har nå lagt til en sjekk som sørger for at man kan fjerne mottakere og allikevel få lov til å sette mottakere med mindre antall mottakere er 0. ✅ 
