### PR TITLE
Legger til mer padding i bunn for å vise alt innhold

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
@@ -19,7 +19,7 @@ import { useToggles } from '../../../App/context/TogglesContext';
 
 const StyledBrev = styled.div`
     background-color: #f2f2f2;
-    padding: 2rem 2rem;
+    padding: 2rem 2rem 20rem 2rem;
     display: flex;
     flex-flow: wrap;
     gap: 3rem;

--- a/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
@@ -19,11 +19,12 @@ import { useToggles } from '../../../App/context/TogglesContext';
 
 const StyledBrev = styled.div`
     background-color: #f2f2f2;
-    padding: 2rem 2rem 20rem 2rem;
+    padding: 2rem 2rem 15rem 2rem;
     display: flex;
     flex-flow: wrap;
     gap: 3rem;
     justify-content: center;
+    height: 100%;
 `;
 
 const VenstreKolonne = styled.div`


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
SB har meldt inn at de ikke klarer å trykke på alt nederst på siden dersom det er lite i dokumentoversikten og det kan hukes av for å lage fremleggsoppgaver. 

Har derfor lagt til litt mer padding i bunn av brevcontaineren og gjort høyden 100% for å fjerne hvit bakgrunn som har vært nederst. 

<img width="1719" alt="image" src="https://github.com/navikt/familie-ef-sak-frontend/assets/46678893/c7825c1f-e55d-4720-b35a-e4e1c7a6530b">

Høyden påvirker dokumentoversikten så når man scroller så er ikke den helt til bunn og det kan se litt rart ut underveis: 
<img width="1719" alt="image" src="https://github.com/navikt/familie-ef-sak-frontend/assets/46678893/d3d85265-0a8b-48a5-aa93-c426df319108">

Avklarte med Lars at det gikk fint, og ser sånn her ut når man har scrollet helt ned (footer går helt ut): 
<img width="1719" alt="image" src="https://github.com/navikt/familie-ef-sak-frontend/assets/46678893/8f707a97-6bc6-4dbd-83c4-3ab70af455ec">

