### PR TITLE
Oppdater G-beløp i barnetilsyn GUI

### DIFF
--- a/src/frontend/Komponenter/Behandling/Vurdering/tekster.ts
+++ b/src/frontend/Komponenter/Behandling/Vurdering/tekster.ts
@@ -33,7 +33,7 @@ export const delvilkårTypeTilTekst: Record<string, string> = {
         'Har søker tidligere mottatt andre stønader som har betydning for stønadstiden i §15-8 første og andre ledd?',
     ER_I_ARBEID_ELLER_FORBIGÅENDE_SYKDOM: 'Er brukeren i arbeid eller har forbigående sykdom?',
     INNTEKT_LAVERE_ENN_INNTEKTSGRENSE:
-        'Har brukeren inntekt under 6 ganger grunnbeløpet (pr 01.05.22: 668 862 kr / 55 738 kr)?',
+        'Har brukeren inntekt under 6 ganger grunnbeløpet (pr 01.05.23: 711 720 kr / 59 310 kr)?',
     INNTEKT_SAMSVARER_MED_OS:
         'Er inntekten i samsvar med den inntekten som er lagt til grunn ved beregning av overgangsstønad?',
     HAR_ALDER_LAVERE_ENN_GRENSEVERDI: 'Har barnet fullført 4.skoleår?',


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
[FAVRO](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12751)
I vilkårsvurderingen for barnetilsyn brukes G-beløp fra 2022 som kan føre til feil vurdering av inntekt. 