### PR TITLE
Skal kunne legge inn opphør fra og med 2017

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/Opphør/Opphør.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/Opphør/Opphør.tsx
@@ -81,7 +81,7 @@ export const Opphør: React.FC<{
                     settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
                     årMåned && settOpphørtFra(årMåned);
                 }}
-                antallÅrTilbake={4}
+                antallÅrTilbake={6}
                 antallÅrFrem={3}
                 disabled={!behandlingErRedigerbar}
                 årMånedInitiell={opphørtFra}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
[FAVRO](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12713)

SB har behov for å opphøre en sak fra 2017 og det er kun mulig å velge opphør fra og med 2019 nå. 

Har testet at det fungerer å opphøre en sak så lang tilbake i tid lokalt mot backend i preprod.