### PR TITLE
Advarsel for inntekt avrundet til nærmeste hundre

### DIFF
--- a/src/frontend/App/typer/vedtak.ts
+++ b/src/frontend/App/typer/vedtak.ts
@@ -194,6 +194,7 @@ export interface IInntektsperiode {
     forventetInntekt?: number;
     samordningsfradrag?: number;
     endretKey?: string; // intern for re-rendring
+    harSaksbehandlerManueltTastetHundreBeløp?: boolean;
 }
 
 export interface IVedtaksperiode {
@@ -228,6 +229,7 @@ export enum EInntektsperiodeProperty {
     månedsinntekt = 'månedsinntekt',
     forventetInntekt = 'forventetInntekt',
     samordningsfradrag = 'samordningsfradrag',
+    harSaksbehandlerManueltTastetHundreBeløp = 'harSaksbehandlerManueltTastetHundreBeløp',
 }
 
 export enum EBehandlingResultat {

--- a/src/frontend/App/utils/utils.ts
+++ b/src/frontend/App/utils/utils.ts
@@ -75,9 +75,9 @@ export const harVerdi = (str: string | undefined | null): boolean =>
 export const harTallverdi = (verdi: number | undefined | null): boolean =>
     verdi !== undefined && verdi !== null;
 
-export const tilTallverdi = (verdi: number | string | undefined): number | string | undefined => {
+export const tilTallverdi = (verdi: number | string | undefined): number | undefined => {
     if (verdi === '' || verdi === undefined || verdi === null) {
-        return verdi;
+        return undefined;
     }
     if (typeof verdi === 'string') {
         return Number(verdi.replace(/\s/g, ''));

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
@@ -147,18 +147,6 @@ const InntektsperiodeValg: React.FC<Props> = ({
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [inntektsperiodeListe.value[0].endretKey]);
 
-    // const oppdaterInntektslisteElement = (
-    //     index: number,
-    //     property: EInntektsperiodeProperty,
-    //     value: string | number | undefined
-    // ) => {
-    //     settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
-    //     inntektsperiodeListe.update(
-    //         { ...inntektsperiodeListe.value[index], [property]: value },
-    //         index
-    //     );
-    // };
-
     const oppdaterInntektslisteVerdier = (index: number, verdier: Partial<IInntektsperiode>) => {
         settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal vise en advarsel til saksbehandler dersom de taster inn årsinntekt som er avrundet til nærmeste hundre, uten at det foreligger måneds- eller dagsats. Dette vil bli ansett som et G-omregnet inntektsbeløp og derfor ikke avrundet i beregningen
