### PR TITLE
💄  Oppdater visning av 6G i vilkårvurdering

### DIFF
--- a/src/frontend/Komponenter/Behandling/Aktivitet/Inntekt/GrunnbeløpInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Inntekt/GrunnbeløpInfo.tsx
@@ -1,0 +1,43 @@
+import React, { FC } from 'react';
+import { formaterTallMedTusenSkille } from '../../../../App/utils/formatter';
+import TabellVisning from '../../Tabell/TabellVisning';
+import { VilkårInfoIkon } from '../../Vilkårpanel/VilkårInformasjonKomponenter';
+
+export const GrunnbeløpInfo: FC = () => {
+    const grunnbeløpGanger6 = [
+        {
+            fra: '01.05.2023',
+            grunnbeløpÅr: 711720,
+            grunnbeløpMåned: 59310,
+        },
+        {
+            fra: '01.05.2022',
+            grunnbeløpÅr: 668862,
+            grunnbeløpMåned: 55739,
+        },
+    ];
+    return (
+        <div>
+            <TabellVisning
+                ikon={VilkårInfoIkon.PENGESEKK}
+                tittel="6 ganger grunnbeløpet"
+                verdier={grunnbeløpGanger6}
+                minimerKolonnebredde={true}
+                kolonner={[
+                    {
+                        overskrift: 'Fra',
+                        tekstVerdi: (d) => d.fra,
+                    },
+                    {
+                        overskrift: '6G  (år)',
+                        tekstVerdi: (d) => `${formaterTallMedTusenSkille(d.grunnbeløpÅr)} kr`,
+                    },
+                    {
+                        overskrift: '6G (måned)',
+                        tekstVerdi: (d) => `${formaterTallMedTusenSkille(d.grunnbeløpMåned)} kr`,
+                    },
+                ]}
+            />
+        </div>
+    );
+};

--- a/src/frontend/Komponenter/Behandling/Aktivitet/Inntekt/Inntekt.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Inntekt/Inntekt.tsx
@@ -5,6 +5,7 @@ import VisEllerEndreVurdering from '../../Vurdering/VisEllerEndreVurdering';
 import { AlertError } from '../../../../Felles/Visningskomponenter/Alerts';
 import { Vilkårpanel } from '../../Vilkårpanel/Vilkårpanel';
 import { VilkårpanelInnhold } from '../../Vilkårpanel/VilkårpanelInnhold';
+import { GrunnbeløpInfo } from './GrunnbeløpInfo';
 
 export const Inntekt: React.FC<VilkårProps> = ({
     vurderinger,
@@ -32,6 +33,7 @@ export const Inntekt: React.FC<VilkårProps> = ({
         >
             <VilkårpanelInnhold>
                 {{
+                    venstre: <GrunnbeløpInfo />,
                     høyre: (
                         <VisEllerEndreVurdering
                             ikkeVurderVilkår={ikkeVurderVilkår}

--- a/src/frontend/Komponenter/Behandling/Tabell/TabellVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Tabell/TabellVisning.tsx
@@ -9,6 +9,7 @@ export interface Kolonnedata<T> {
     verdier: T[];
     kolonner: Kolonner<T>[];
     ikonVisning?: boolean;
+    minimerKolonnebredde?: boolean;
 }
 
 export interface Kolonner<T> {
@@ -30,12 +31,17 @@ const breddeKolonner = (antallKolonner: number) => {
 const GridTabell = styled.div<{
     kolonner: number;
     ikonVisning: boolean;
+    minimerKolonnebredde: boolean;
 }>`
     display: grid;
-    grid-template-columns: ${(props) => props.ikonVisning && '21px'} min(200px, 250px) repeat(
-            ${(props) => props.kolonner - 2},
-            ${(props) => breddeKolonner(props.kolonner)}
-        );
+    grid-template-columns:
+        ${(props) => props.ikonVisning && '21px'}
+        ${(props) =>
+            props.minimerKolonnebredde
+                ? `repeat(${props.kolonner - 1}, minmax(max-content, 7rem))`
+                : `min(200px, 250px) repeat(${props.kolonner - 1}, ${breddeKolonner(
+                      props.kolonner
+                  )})`};
     grid-gap: 0.5rem;
 
     .tittel {
@@ -57,9 +63,20 @@ const FlexDiv = styled.div`
 `;
 
 function TabellVisning<T>(props: Kolonnedata<T>): React.ReactElement<Kolonnedata<T>> {
-    const { ikon, tittel, verdier, kolonner, ikonVisning = true } = props;
+    const {
+        ikon,
+        tittel,
+        verdier,
+        kolonner,
+        ikonVisning = true,
+        minimerKolonnebredde = false,
+    } = props;
     return (
-        <GridTabell kolonner={kolonner.length + 1} ikonVisning={ikonVisning}>
+        <GridTabell
+            kolonner={kolonner.length + 1}
+            ikonVisning={ikonVisning}
+            minimerKolonnebredde={minimerKolonnebredde}
+        >
             {ikon && mapIkon(ikon)}
             {tittel && (
                 <Label size="small" className="tittel" as="h3">

--- a/src/frontend/Komponenter/Behandling/Vilkårpanel/VilkårInformasjonKomponenter.tsx
+++ b/src/frontend/Komponenter/Behandling/Vilkårpanel/VilkårInformasjonKomponenter.tsx
@@ -7,6 +7,7 @@ import LiteBarn from '../../../Felles/Ikoner/LiteBarn';
 import styled from 'styled-components';
 import { Registergrunnlag, Søknadsgrunnlag } from '../../../Felles/Ikoner/DataGrunnlagIkoner';
 import { Calculator } from '@navikt/ds-icons';
+import { SackKronerIcon } from '@navikt/aksel-icons';
 
 interface UnderseksjonWrapperProps {
     underoverskrift: string;
@@ -83,6 +84,7 @@ export enum VilkårInfoIkon {
     REGISTER = 'REGISTER',
     SØKNAD = 'SØKNAD',
     KALKULATOR = 'KALKULATOR',
+    PENGESEKK = 'PENGESEKK',
 }
 
 export const mapIkon = (ikon: VilkårInfoIkon) => {
@@ -93,5 +95,7 @@ export const mapIkon = (ikon: VilkårInfoIkon) => {
             return <Søknadsgrunnlag />;
         case VilkårInfoIkon.KALKULATOR:
             return <Calculator />;
+        case VilkårInfoIkon.PENGESEKK:
+            return <SackKronerIcon />;
     }
 };

--- a/src/frontend/Komponenter/Behandling/Vurdering/tekster.ts
+++ b/src/frontend/Komponenter/Behandling/Vurdering/tekster.ts
@@ -32,8 +32,7 @@ export const delvilkårTypeTilTekst: Record<string, string> = {
     HAR_TIDLIGERE_ANDRE_STØNADER_SOM_HAR_BETYDNING:
         'Har søker tidligere mottatt andre stønader som har betydning for stønadstiden i §15-8 første og andre ledd?',
     ER_I_ARBEID_ELLER_FORBIGÅENDE_SYKDOM: 'Er brukeren i arbeid eller har forbigående sykdom?',
-    INNTEKT_LAVERE_ENN_INNTEKTSGRENSE:
-        'Har brukeren inntekt under 6 ganger grunnbeløpet (pr 01.05.23: 711 720 kr / 59 310 kr)?',
+    INNTEKT_LAVERE_ENN_INNTEKTSGRENSE: 'Har brukeren inntekt under 6 ganger grunnbeløpet?',
     INNTEKT_SAMSVARER_MED_OS:
         'Er inntekten i samsvar med den inntekten som er lagt til grunn ved beregning av overgangsstønad?',
     HAR_ALDER_LAVERE_ENN_GRENSEVERDI: 'Har barnet fullført 4.skoleår?',


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker å vise både grunnbeløp for 2023 og 2022 på en strukturert måte i vilkårsvurderingen.

### Hva er gjort? 🤓 

- Fjernet grunnbeløpet fra tekst i vurderingen (høyre side)
- Lagt til en tabell med 6G for 2023 og 2022
- Tilpasset tabellvisning slik at den ikke må ha kolonnebredder som er tilpasset bredden på elementer i `Informasjonsrad`

Nå: 
![image](https://github.com/navikt/familie-ef-sak-frontend/assets/46678893/cbf9a1ef-10b9-4308-b365-159cf517fa85)

Før: 
![image](https://github.com/navikt/familie-ef-sak-frontend/assets/46678893/0d3ad68e-c2f3-430d-aecf-c9da65b88a92)
