### PR TITLE
Oppdatert tekst

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
@@ -403,9 +403,11 @@ const InntektsperiodeValg: React.FC<Props> = ({
                                         )}
                                         {årsinntektErAvrundetTilNærmesteHundreOgManglerMånedÅrSats && (
                                             <AdvarselVisning className={'ny-rad-full-bredde'}>
-                                                Årsinntekt som slutter på hundre vil ikke bli
-                                                avrundet ned til nærmeste tusen i beregningen.
-                                                Vennligst utfør manuell avrunding til nærmeste 1000.
+                                                Årsinntekt som slutter på hundre kroner blir ikke
+                                                avrundet ned til nærmeste tusen kroner. Hvis
+                                                årsinntekten skal avrundes ned til nærmeste tusen
+                                                kroner, så må du legge inn avrundet årsinntekt
+                                                manuelt.
                                             </AdvarselVisning>
                                         )}
                                     </React.Fragment>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Må ha bedre/mer beskrivende tekst til saksbehandlere om at inntekter som slutter på 100 blir regnet som g-omregnet beløp