### PR TITLE
Tekstendring i brev for innhenting av karakterutskrift - utvidet, ett…

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/BrevTyperTekst.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevTyperTekst.ts
@@ -177,7 +177,7 @@ export const initielleAvsnittInnhentingAvKarakterutskriftUtvidetPeriode: Avsnitt
     {
         deloverskrift: '',
         innhold:
-            'Du får utvidet tid med overgangsstønad fordi du er i utdanning.' +
+            'Du får overgangsstønad og er i utdanning.' +
             '\n\nVi følger opp saken din, og ber deg om å sende oss:' +
             '\n\n•\tKarakterutskrift for skoleåret 2021/2022' +
             '\n\nDu må sende oss dokumentasjonen innen 21.07.22.',


### PR DESCRIPTION
…er bestilling fra Mirja

### Hvorfor er denne endringen nødvendig? ✨
Bestilling av Mirja. Brevet skal også kunne brukes i noen tilfeller der det ikke er utvidet overgangsstønad.