### PR TITLE
♻️ Refaktorering brev som forberedelse til frittstående sanitybrev

### DIFF
--- a/src/frontend/App/hooks/useHentBrevStruktur.ts
+++ b/src/frontend/App/hooks/useHentBrevStruktur.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+import { BrevStruktur, datasett, fritekstmal } from '../../Komponenter/Behandling/Brev/BrevTyper';
+import { byggTomRessurs, Ressurs } from '../typer/ressurs';
+import { useApp } from '../context/AppContext';
+
+export const useHentBrevStruktur = (
+    brevMal: string | undefined
+): { brevStruktur: Ressurs<BrevStruktur> } => {
+    const [brevStruktur, settBrevStruktur] = useState<Ressurs<BrevStruktur>>(byggTomRessurs());
+    const { axiosRequest } = useApp();
+
+    useEffect(() => {
+        if (brevMal && brevMal !== fritekstmal) {
+            axiosRequest<BrevStruktur, null>({
+                method: 'GET',
+                url: `/familie-brev/api/${datasett}/avansert-dokument/bokmaal/${brevMal}/felter`,
+            }).then((respons: Ressurs<BrevStruktur>) => {
+                settBrevStruktur(respons);
+            });
+        }
+        // eslint-disable-next-line
+    }, [brevMal]);
+
+    return {
+        brevStruktur,
+    };
+};

--- a/src/frontend/App/hooks/useHentBrevmaler.ts
+++ b/src/frontend/App/hooks/useHentBrevmaler.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import { datasett, DokumentNavn } from '../../Komponenter/Behandling/Brev/BrevTyper';
+import { byggTomRessurs, Ressurs } from '../typer/ressurs';
+import { useApp } from '../context/AppContext';
+import { ToggleName } from '../context/toggles';
+import { useToggles } from '../context/TogglesContext';
+
+export const useHentBrevmaler = (): { brevmaler: Ressurs<DokumentNavn[]> } => {
+    const { axiosRequest } = useApp();
+    const { toggles } = useToggles();
+    const [brevmaler, settBrevmaler] = useState<Ressurs<DokumentNavn[]>>(byggTomRessurs());
+
+    useEffect(() => {
+        const skalViseUpubliserteMaler = toggles[ToggleName.visIkkePubliserteBrevmaler] || false;
+
+        axiosRequest<DokumentNavn[], null>({
+            method: 'GET',
+            url: `/familie-brev/api/${datasett}/avansert-dokument/navn/${skalViseUpubliserteMaler}`,
+        }).then((respons: Ressurs<DokumentNavn[]>) => {
+            settBrevmaler(respons);
+        });
+        // eslint-disable-next-line
+    }, []);
+
+    return {
+        brevmaler,
+    };
+};

--- a/src/frontend/App/hooks/useMellomlagringBrev.ts
+++ b/src/frontend/App/hooks/useMellomlagringBrev.ts
@@ -36,16 +36,18 @@ export interface IMellomlagretBrevResponse {
     brevtype: Brevtype.SANITYBREV;
 }
 
+export type MellomlagreSanitybrev = (
+    flettefelt: FlettefeltMedVerdi[],
+    valgteFelt: ValgtFelt,
+    valgteDelmaler: ValgteDelmaler,
+    fritekstområder: Fritekstområder,
+    brevmal: string
+) => void;
+
 export const useMellomlagringBrev = (
     behandlingId: string
 ): {
-    mellomlagreSanitybrev: (
-        flettefelt: FlettefeltMedVerdi[],
-        valgteFelt: ValgtFelt,
-        valgteDelmaler: ValgteDelmaler,
-        fritekstområder: Fritekstområder,
-        brevmal: string
-    ) => void;
+    mellomlagreSanitybrev: MellomlagreSanitybrev;
     mellomlagretBrev: Ressurs<MellomlagerRespons | undefined>;
 } => {
     const { axiosRequest } = useApp();

--- a/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
@@ -35,7 +35,7 @@ interface Props {
     settFlettefelter: Dispatch<SetStateAction<FlettefeltMedVerdi[]>>;
     flettefelter: FlettefeltMedVerdi[];
     settValgteDelmaler: Dispatch<SetStateAction<Record<string, boolean>>>;
-    settKanSendeTilBeslutter: (kanSendeTilBeslutter: boolean) => void;
+    settBrevOppdatert: (kanSendeTilBeslutter: boolean) => void;
     valgt: boolean;
     skjul: boolean;
 }
@@ -48,7 +48,7 @@ export const BrevMenyDelmal: React.FC<Props> = ({
     settFlettefelter,
     flettefelter,
     settValgteDelmaler,
-    settKanSendeTilBeslutter,
+    settBrevOppdatert,
     valgt,
     skjul,
 }) => {
@@ -59,7 +59,7 @@ export const BrevMenyDelmal: React.FC<Props> = ({
         settFlettefelter((prevState) =>
             prevState.map((felt) => (felt._ref === flettefelt._ref ? { ...felt, verdi } : felt))
         );
-        settKanSendeTilBeslutter(false);
+        settBrevOppdatert(false);
     };
 
     const håndterToggleDelmal = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -72,7 +72,7 @@ export const BrevMenyDelmal: React.FC<Props> = ({
             settEkspanderbartPanelÅpen(true);
         }
 
-        settKanSendeTilBeslutter(false);
+        settBrevOppdatert(false);
     };
 
     if (skjul) {
@@ -115,7 +115,7 @@ export const BrevMenyDelmal: React.FC<Props> = ({
                                         handleFlettefeltInput={handleFlettefeltInput}
                                         delmal={delmal}
                                         key={`${valgteFelt.valgFeltKategori}${index}`}
-                                        settKanSendeTilBeslutter={settKanSendeTilBeslutter}
+                                        settKanSendeTilBeslutter={settBrevOppdatert}
                                     />
                                 ))}
                             {delmalFlettefelter

--- a/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
@@ -299,3 +299,6 @@ export enum Brevtype {
     SANITYBREV = 'SANITYBREV',
     FRITEKSTBREV = 'FRITEKSTBREV',
 }
+
+export const datasett = 'ef-brev';
+export const fritekstmal = 'Fritekstbrev';

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmalSelect.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmalSelect.tsx
@@ -1,0 +1,48 @@
+import { Ressurs } from '../../../App/typer/ressurs';
+import { DokumentNavn, fritekstmal } from './BrevTyper';
+import React, { Dispatch, SetStateAction } from 'react';
+import DataViewer from '../../../Felles/DataViewer/DataViewer';
+import { Select } from '@navikt/ds-react';
+import { visBrevmal } from './BrevUtils';
+import { Stønadstype } from '../../../App/typer/behandlingstema';
+
+type BrevmalSelectProps = {
+    dokumentnavn: Ressurs<DokumentNavn[]>;
+    settBrevmal: Dispatch<SetStateAction<string | undefined>>;
+    brevmal: string | undefined;
+    stønanadstype?: Stønadstype;
+};
+export const BrevmalSelect: React.FC<BrevmalSelectProps> = ({
+    dokumentnavn,
+    settBrevmal,
+    brevmal,
+    stønanadstype,
+}) => (
+    <DataViewer response={{ dokumentnavn }}>
+        {({ dokumentnavn }) => (
+            <Select
+                label="Velg dokument"
+                onChange={(e) => {
+                    settBrevmal(e.target.value);
+                }}
+                value={brevmal}
+            >
+                <option value="">Ikke valgt</option>
+
+                {dokumentnavn
+                    ?.filter((mal) => visBrevmal(mal, stønanadstype))
+                    .map((navn: DokumentNavn) => (
+                        <option value={navn.apiNavn} key={navn.apiNavn}>
+                            {navn.visningsnavn}
+                        </option>
+                    ))}
+                {brevmal === fritekstmal && (
+                    <option value={fritekstmal} key={fritekstmal}>
+                        {' '}
+                        Fritekstbrev
+                    </option>
+                )}
+            </Select>
+        )}
+    </DataViewer>
+);

--- a/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
-import { BrevStruktur, Brevtype, DokumentNavn, IMellomlagretBrevFritekst } from './BrevTyper';
-import { byggTomRessurs, Ressurs, RessursStatus } from '../../../App/typer/ressurs';
-import { useApp } from '../../../App/context/AppContext';
+import { Brevtype, fritekstmal, IMellomlagretBrevFritekst } from './BrevTyper';
+import { Ressurs, RessursStatus } from '../../../App/typer/ressurs';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import BrevmenyVisning from './BrevmenyVisning';
 import styled from 'styled-components';
@@ -10,14 +9,15 @@ import {
     useMellomlagringBrev,
 } from '../../../App/hooks/useMellomlagringBrev';
 import FritekstBrev from './FritekstBrev';
-import { useToggles } from '../../../App/context/TogglesContext';
-import { ToggleName } from '../../../App/context/toggles';
 import { Behandling } from '../../../App/typer/fagsak';
 import { useHentBeløpsperioder } from '../../../App/hooks/useHentBeløpsperioder';
-import { Stønadstype } from '../../../App/typer/behandlingstema';
-import { Select } from '@navikt/ds-react';
 import { EBehandlingResultat } from '../../../App/typer/vedtak';
 import { IPersonopplysninger } from '../../../App/typer/personopplysninger';
+import { BrevmalSelect } from './BrevmalSelect';
+import { useHentBrevStruktur } from '../../../App/hooks/useHentBrevStruktur';
+import { useHentBrevmaler } from '../../../App/hooks/useHentBrevmaler';
+import { useVerdierForBrev } from '../../../App/hooks/useVerdierForBrev';
+import { utledHtmlFelterPåStønadstype } from './BrevUtils';
 
 export interface BrevmenyProps {
     oppdaterBrevRessurs: (brevRessurs: Ressurs<string>) => void;
@@ -35,9 +35,6 @@ const StyledBrevMeny = styled.div`
     margin-top: 2rem;
 `;
 
-const datasett = 'ef-brev';
-const fritekstmal = 'Fritekstbrev';
-
 const Brevmeny: React.FC<BrevmenyProps> = (props) => {
     const {
         oppdaterBrevRessurs,
@@ -47,7 +44,6 @@ const Brevmeny: React.FC<BrevmenyProps> = (props) => {
         personopplysninger,
         settKanSendesTilBeslutter,
     } = props;
-    const { axiosRequest } = useApp();
     const { hentBeløpsperioder, beløpsperioder } = useHentBeløpsperioder(
         behandling.id,
         behandling.stønadstype
@@ -100,21 +96,24 @@ const Brevmeny: React.FC<BrevmenyProps> = (props) => {
                         beløpsperioder,
                     }}
                 >
-                    {({ brevStruktur, mellomlagretBrev, beløpsperioder }) =>
+                    {({ brevStruktur, mellomlagretBrev }) =>
                         brevMal ? (
                             <BrevmenyVisning
                                 behandlingId={behandlingId}
                                 oppdaterBrevRessurs={oppdaterBrevRessurs}
-                                behandling={behandling}
                                 brevStruktur={brevStruktur}
-                                beløpsperioder={beløpsperioder}
                                 brevMal={brevMal}
                                 mellomlagretBrevVerdier={
                                     (mellomlagretBrev as IMellomlagretBrevResponse)?.brevverdier
                                 }
-                                stønadstype={behandling.stønadstype}
                                 personopplysninger={personopplysninger}
-                                settKanSendesTilBeslutter={settKanSendesTilBeslutter}
+                                mellomlagreSanityBrev={mellomlagreSanitybrev}
+                                htmlFelter={utledHtmlFelterPåStønadstype(
+                                    behandling.stønadstype,
+                                    beløpsperioder
+                                )}
+                                brevverdier={brevverdier}
+                                settBrevOppdatert={settKanSendesTilBeslutter}
                             />
                         ) : null
                     }

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
@@ -62,7 +62,7 @@ export interface BrevmenyVisningProps {
     brevMal: string;
     stønadstype: Stønadstype;
     personopplysninger: IPersonopplysninger;
-    settKanSendesTilBeslutter: (kanSendesTilBeslutter: boolean) => void;
+    settBrevOppdatert: (brevOppdatert: boolean) => void;
     oppdaterBrevRessurs: (brevRessurs: Ressurs<string>) => void;
     behandlingId: string;
     behandling: Behandling;
@@ -72,7 +72,7 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
     oppdaterBrevRessurs,
     behandlingId,
     personopplysninger,
-    settKanSendesTilBeslutter,
+    settBrevOppdatert,
     brevStruktur,
     beløpsperioder,
     mellomlagretBrevVerdier,
@@ -289,7 +289,7 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
                                         settFlettefelter={settAlleFlettefelter}
                                         settValgteDelmaler={settValgteDelmaler}
                                         key={delmal.delmalApiNavn}
-                                        settKanSendeTilBeslutter={settKanSendesTilBeslutter}
+                                        settBrevOppdatert={settBrevOppdatert}
                                         skjul={erAutomatiskFeltSomSkalSkjules(delmalStore, delmal)}
                                     />
                                 </BrevMenyDelmalWrapper>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
[Vi skal ta i bruk sanity for frittstående brev.](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12119) For å kunne gjenbruke mest mulig fra brev i behandlingsflyt trekker jeg ut en del felleskode. Dette skal ikke medføre noen funksjonelle endringer for saksbehandler, og jeg har testet mellomlagring, tabell i brev og automatiske flettefelt for innvilgelsesdato.

### Endringer
- Select for å velge brevmal er trukket ut i egen komponent `BrevmalSelect`
- Kode for å hente tilgjengelige brevmaler og tilhørende brevstruktur er flyttet ut i egne hooks `useHentBrevStruktur` og `useHentBrevmaler`
- Generering av htmlFelter (inntektstabell i brev) er flyttet fra `BrevmenyVisning` til `Brevmeny`
- Brevverdier (automatiske flettefelt, valgfelt og delmaler) sendes som prop til BrevmenyVisning
- `mellomlagreBrev` sendes med som prop til `BrevmenyVisning` istedenfor å instansiere der, fordi det blir to forskjellige for frittstående og behandlingsbrev
- `settKanSendesTIlBeslutter` endret til `settBrevOppdatert` da `kanSendesTilBeslutter` ikke gir mening for frittstående brev

Har prøvd å skissere opp hva som faktisk er de forskjellige komponentene: ![brevkomponenter](https://github.com/navikt/familie-ef-sak-frontend/assets/21220467/203b4d31-00e3-4eb1-a1fc-c10a92989f84)

Kan også ta en muntlig gjennomgang dersom noen ønsker det.


