### PR TITLE
Vis alle barna i nedtrekkslisten på barnetilsyn

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtgiftsperiodeValg.tsx
@@ -258,6 +258,7 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
                                         label={''}
                                         options={barnForPeriode}
                                         creatable={false}
+                                        menuPortalTarget={document.querySelector('body')}
                                         isMulti={true}
                                         isDisabled={opphørEllerSanksjon}
                                         defaultValue={ikkeValgteBarn}


### PR DESCRIPTION

<img width="1328" alt="Skjermbilde 2023-06-16 kl  16 34 06" src="https://github.com/navikt/familie-ef-sak-frontend/assets/402915/2842192a-9d19-4de1-b4df-1a5b54cc76c0">
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12512)

### Hvorfor er denne endringen nødvendig? ✨
For å kunne vise alle barna i nedtrekkslisten ved innvilgelse av barnetilsyn dersom saksbehandler har smal skjerm (som trigger scroll) må vi sette menuPortalTarget til f.eks. body. Da blir ikke select-valgene påvirket av at morkomponenten har `overflow:scroll/visible/hidden` 
