### PR TITLE
Frittstående sanitybrev

### DIFF
--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -18,4 +18,5 @@ export enum ToggleName {
     settPåVentMedOppgavestyring = 'familie.ef.sak.sett-paa-vent-med-oppgavestyring',
     visVurderHenvendelseOppgaver = 'familie.ef.sak.automatiske-oppgaver-lokalkontor',
     fremleggsoppgave = 'familie.ef.sak.automatiske-oppgaver.fremleggsoppgave',
+    sanitybrev_frittstående = 'familie.ef.sak.frontend-frittstaaende-sanitybrev',
 }

--- a/src/frontend/App/hooks/useMellomlagringFrittståendeSanitybrev.ts
+++ b/src/frontend/App/hooks/useMellomlagringFrittståendeSanitybrev.ts
@@ -1,0 +1,71 @@
+import { useApp } from '../context/AppContext';
+import { byggTomRessurs, Ressurs, RessursFeilet, RessursSuksess } from '../typer/ressurs';
+import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react';
+import {
+    FlettefeltMedVerdi,
+    Fritekstområder,
+    MellomlagerRespons,
+    ValgteDelmaler,
+    ValgtFelt,
+} from '../../Komponenter/Behandling/Brev/BrevTyper';
+import { IMellomlagretBrev, MellomlagreSanitybrev } from './useMellomlagringBrev';
+
+export const useMellomlagringFrittståendeSanitybrev = (
+    fagsakId: string
+): {
+    mellomlagreSanitybrev: MellomlagreSanitybrev;
+    mellomlagretBrev: Ressurs<MellomlagerRespons | undefined>;
+    settMellomlagretBrev: Dispatch<SetStateAction<Ressurs<MellomlagerRespons | undefined>>>;
+} => {
+    const { axiosRequest } = useApp();
+    const [mellomlagretBrevRessurs, settMellomlagretBrevRessurs] = useState<
+        Ressurs<MellomlagerRespons | undefined>
+    >(byggTomRessurs());
+
+    const sanityVersjon = '1';
+
+    const mellomlagreSanitybrev = (
+        flettefelt: FlettefeltMedVerdi[],
+        valgteFelt: ValgtFelt,
+        valgteDelmaler: ValgteDelmaler,
+        fritekstområder: Fritekstområder,
+        brevmal: string
+    ): void => {
+        axiosRequest<string, IMellomlagretBrev>({
+            method: 'POST',
+            url: `/familie-ef-sak/api/brev/mellomlager/fagsak/${fagsakId}`,
+            data: {
+                brevverdier: JSON.stringify({
+                    flettefeltFraMellomlager: flettefelt,
+                    valgteFeltFraMellomlager: valgteFelt,
+                    valgteDelmalerFraMellomlager: valgteDelmaler,
+                    fritekstområderFraMellomlager: fritekstområder,
+                }),
+                brevmal,
+                versjon: sanityVersjon,
+            },
+        });
+    };
+
+    const hentMellomlagretBrev = useCallback(
+        () =>
+            axiosRequest<MellomlagerRespons | undefined, null>({
+                method: 'GET',
+                url: `/familie-ef-sak/api/brev/mellomlager/fagsak/${fagsakId}`,
+            }).then((res: RessursSuksess<MellomlagerRespons | undefined> | RessursFeilet) => {
+                settMellomlagretBrevRessurs(res);
+            }),
+        // eslint-disable-next-line
+        [fagsakId]
+    );
+
+    useEffect(() => {
+        hentMellomlagretBrev();
+    }, [fagsakId, hentMellomlagretBrev]);
+
+    return {
+        mellomlagreSanitybrev,
+        mellomlagretBrev: mellomlagretBrevRessurs,
+        settMellomlagretBrev: settMellomlagretBrevRessurs,
+    };
+};

--- a/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
@@ -16,27 +16,7 @@ import { AlertInfo } from '../../../Felles/Visningskomponenter/Alerts';
 import { oppgaveSomSkalOpprettesTilTekst } from '../Totrinnskontroll/oppgaveForOpprettelseTyper';
 import { ToggleName } from '../../../App/context/toggles';
 import { useToggles } from '../../../App/context/TogglesContext';
-
-const StyledBrev = styled.div`
-    background-color: #f2f2f2;
-    padding: 2rem 2rem 15rem 2rem;
-    display: flex;
-    flex-flow: wrap;
-    gap: 3rem;
-    justify-content: center;
-    height: 100%;
-`;
-
-const VenstreKolonne = styled.div`
-    flex-basis: 450px;
-    flex-shrink: 1;
-    flex-grow: 1;
-`;
-
-const HøyreKolonne = styled.div`
-    flex-shrink: 0;
-    flex-grow: 1;
-`;
+import { HøyreKolonne, StyledBrev, VenstreKolonne } from './StyledBrev';
 
 const InfostripeGruppe = styled.div`
     display: flex;

--- a/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
@@ -89,9 +89,6 @@ const Brev: React.FC<Props> = ({ behandlingId }) => {
 
     const oppdaterBrevRessurs = (respons: Ressurs<string>) => {
         settBrevRessurs(respons);
-        if (respons.status === RessursStatus.SUKSESS) {
-            settKanSendesTilBeslutter(true);
-        }
     };
 
     useEffect(() => {

--- a/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
@@ -117,6 +117,7 @@ export interface DokumentNavn {
     overgangsstonad?: boolean;
     barnetilsyn?: boolean;
     skolepenger?: boolean;
+    frittstaendeBrev?: { tittelDokumentOversikt: string };
 }
 
 export interface IAvsnitt {

--- a/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
@@ -117,7 +117,7 @@ export interface DokumentNavn {
     overgangsstonad?: boolean;
     barnetilsyn?: boolean;
     skolepenger?: boolean;
-    frittstaendeBrev?: { tittelDokumentOversikt: string };
+    frittstaendeBrev?: { tittelDokumentoversikt: string };
 }
 
 export interface IAvsnitt {
@@ -142,6 +142,12 @@ export interface IFrittståendeBrev {
     brevType: FrittståendeBrevtype;
     mottakere?: IBrevmottakere;
 }
+
+export type FrittståendeSanitybrevDto = {
+    pdf: string;
+    mottakere: IBrevmottakere;
+    tittel: string;
+};
 
 export enum FrittståendeBrevtype {
     INFORMASJONSBREV = 'INFORMASJONSBREV',

--- a/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
@@ -321,7 +321,7 @@ export const utledHtmlFelterPåStønadstype = (
     }
 };
 
-export const utledDokumenttittel = (
+export const finnDokumenttittelForBrevmal = (
     brevmaler: Ressurs<DokumentNavn[]>,
     valgtBrevmal: string | undefined
 ) =>

--- a/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
@@ -320,3 +320,11 @@ export const utledHtmlFelterPåStønadstype = (
         return null;
     }
 };
+
+export const utledDokumenttittel = (
+    brevmaler: Ressurs<DokumentNavn[]>,
+    valgtBrevmal: string | undefined
+) =>
+    brevmaler.status === RessursStatus.SUKSESS &&
+    brevmaler.data.find((mal) => mal.apiNavn == valgtBrevmal)?.frittstaendeBrev
+        ?.tittelDokumentoversikt;

--- a/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
@@ -277,7 +277,14 @@ export const erAutomatiskFeltSomSkalSkjules = (
 export const skalSkjuleAlleDelmaler = (gruppe: DelmalGruppe, delmalStore: DelmalStore): boolean =>
     gruppe.delmaler.every((delmal) => erAutomatiskFeltSomSkalSkjules(delmalStore, delmal));
 
-export function visBrevmal(mal: DokumentNavn, stønadstype: Stønadstype | undefined): boolean {
+export function visBrevmal(
+    mal: DokumentNavn,
+    stønadstype: Stønadstype | undefined,
+    frittstående: boolean | undefined
+): boolean {
+    if (frittstående) {
+        return !!mal.frittstaendeBrev;
+    }
     if (mal.overgangsstonad == null && mal.barnetilsyn == null && mal.skolepenger == null) {
         return true; // bakoverkompatibilitet ( valg er kanskje ikke utført på eksisterende maler, vises intil videre)
     }

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmalSelect.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmalSelect.tsx
@@ -11,12 +11,14 @@ type BrevmalSelectProps = {
     settBrevmal: Dispatch<SetStateAction<string | undefined>>;
     brevmal: string | undefined;
     stønanadstype?: Stønadstype;
+    frittstående?: boolean;
 };
 export const BrevmalSelect: React.FC<BrevmalSelectProps> = ({
     dokumentnavn,
     settBrevmal,
     brevmal,
     stønanadstype,
+    frittstående,
 }) => (
     <DataViewer response={{ dokumentnavn }}>
         {({ dokumentnavn }) => (
@@ -30,7 +32,7 @@ export const BrevmalSelect: React.FC<BrevmalSelectProps> = ({
                 <option value="">Ikke valgt</option>
 
                 {dokumentnavn
-                    ?.filter((mal) => visBrevmal(mal, stønanadstype))
+                    ?.filter((mal) => visBrevmal(mal, stønanadstype, frittstående))
                     .map((navn: DokumentNavn) => (
                         <option value={navn.apiNavn} key={navn.apiNavn}>
                             {navn.visningsnavn}

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
@@ -23,7 +23,7 @@ import {
     initValgteFelt,
     skalSkjuleAlleDelmaler,
 } from './BrevUtils';
-import { Ressurs } from '../../../App/typer/ressurs';
+import { Ressurs, RessursStatus } from '../../../App/typer/ressurs';
 import { useApp } from '../../../App/context/AppContext';
 import styled from 'styled-components';
 import { apiLoggFeil } from '../../../App/api/axios';
@@ -108,8 +108,7 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
                 ...delmalStore.reduce((acc, delmal) => ({ ...acc, [delmal.delmal]: true }), {}),
             }));
         }
-        // eslint-disable-next-line
-    }, [brevStruktur, flettefeltStore, mellomlagretBrevVerdier]);
+    }, [brevStruktur, flettefeltStore, delmalStore, valgfeltStore, mellomlagretBrevVerdier]);
 
     const [valgteFelt, settValgteFelt] = useState<ValgtFelt>({});
     const [valgteDelmaler, settValgteDelmaler] = useState<ValgteDelmaler>({});
@@ -209,7 +208,7 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
 
         const url = behandlingId
             ? `/familie-ef-sak/api/brev/${behandlingId}/${brevMal}`
-            : `/familie-ef-sak/api/frittstaende-brev/fagsak/${fagsakId}/${brevMal}`;
+            : `/familie-ef-sak/api/frittstaende-brev/${fagsakId}/${brevMal}`;
 
         axiosRequest<string, unknown>({
             method: 'POST',
@@ -224,6 +223,9 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
                 fritekstområder: utledFritekstområderForBrev(),
             },
         }).then((respons: Ressurs<string>) => {
+            if (respons.status === RessursStatus.SUKSESS) {
+                settBrevOppdatert(true);
+            }
             oppdaterBrevRessurs(respons);
         });
     };

--- a/src/frontend/Komponenter/Behandling/Brev/FrittståendeBrevMedVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/FrittståendeBrevMedVisning.tsx
@@ -8,6 +8,9 @@ import { AxiosRequestConfig } from 'axios';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import FrittståendeBrev from './FrittståendeBrev';
 import { IPersonopplysninger } from '../../../App/typer/personopplysninger';
+import { useToggles } from '../../../App/context/TogglesContext';
+import { ToggleName } from '../../../App/context/toggles';
+import { FrittståendeSanitybrev } from './FrittståendeSanitybrev';
 
 type Props = {
     fagsakId: string;
@@ -34,6 +37,9 @@ const HøyreKolonne = styled.div`
 
 const FrittståendeBrevMedVisning: React.FC<Props> = ({ fagsakId, personopplysninger }: Props) => {
     const [brevRessurs, oppdaterBrevressurs] = useState<Ressurs<string>>(byggTomRessurs());
+
+    const { toggles } = useToggles();
+
     const hentMellomlagretFrittståendeBrev: AxiosRequestConfig = useMemo(
         () => ({
             method: 'GET',
@@ -48,16 +54,30 @@ const FrittståendeBrevMedVisning: React.FC<Props> = ({ fagsakId, personopplysni
     return (
         <BrevMedVisning>
             <DataViewer response={{ mellomlagretFrittståendeBrev }}>
-                {({ mellomlagretFrittståendeBrev }) => (
-                    <VenstreKolonne>
-                        <FrittståendeBrev
-                            oppdaterBrevressurs={oppdaterBrevressurs}
-                            fagsakId={fagsakId}
-                            mellomlagretFrittståendeBrev={mellomlagretFrittståendeBrev}
-                            personopplysninger={personopplysninger}
-                        />
-                    </VenstreKolonne>
-                )}
+                {({ mellomlagretFrittståendeBrev }) => {
+                    const skalViseFritekstbrev =
+                        mellomlagretFrittståendeBrev ||
+                        !toggles[ToggleName.sanitybrev_frittstående];
+                    return (
+                        <VenstreKolonne>
+                            {skalViseFritekstbrev ? (
+                                <FrittståendeBrev
+                                    oppdaterBrevressurs={oppdaterBrevressurs}
+                                    fagsakId={fagsakId}
+                                    mellomlagretFrittståendeBrev={mellomlagretFrittståendeBrev}
+                                    personopplysninger={personopplysninger}
+                                />
+                            ) : (
+                                <FrittståendeSanitybrev
+                                    fagsakId={fagsakId}
+                                    personopplysninger={personopplysninger}
+                                    brevRessurs={brevRessurs}
+                                    oppdaterBrevRessurs={oppdaterBrevressurs}
+                                />
+                            )}
+                        </VenstreKolonne>
+                    );
+                }}
             </DataViewer>
             <HøyreKolonne>
                 <PdfVisning pdfFilInnhold={brevRessurs} />

--- a/src/frontend/Komponenter/Behandling/Brev/FrittståendeBrevMedVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/FrittståendeBrevMedVisning.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo, useState } from 'react';
-import styled from 'styled-components';
 import { byggTomRessurs, Ressurs } from '../../../App/typer/ressurs';
 import PdfVisning from '../../../Felles/Pdf/PdfVisning';
 import { IFrittståendeBrev } from './BrevTyper';
@@ -12,28 +11,12 @@ import { useToggles } from '../../../App/context/TogglesContext';
 import { ToggleName } from '../../../App/context/toggles';
 import { FrittståendeSanitybrev } from './FrittståendeSanitybrev';
 
+import { HøyreKolonne, StyledBrev, VenstreKolonne } from './StyledBrev';
+
 type Props = {
     fagsakId: string;
     personopplysninger: IPersonopplysninger;
 };
-
-const BrevMedVisning = styled.div`
-    width: 100%;
-    padding-left: 2rem;
-    padding-right: 2rem;
-    display: flex;
-    column-gap: 4rem;
-    flex-flow: wrap;
-`;
-
-const VenstreKolonne = styled.div`
-    width: 48rem;
-`;
-
-const HøyreKolonne = styled.div`
-    flex-shrink: 0;
-    flex-grow: 1;
-`;
 
 const FrittståendeBrevMedVisning: React.FC<Props> = ({ fagsakId, personopplysninger }: Props) => {
     const [brevRessurs, oppdaterBrevressurs] = useState<Ressurs<string>>(byggTomRessurs());
@@ -52,7 +35,7 @@ const FrittståendeBrevMedVisning: React.FC<Props> = ({ fagsakId, personopplysni
     );
 
     return (
-        <BrevMedVisning>
+        <StyledBrev>
             <DataViewer response={{ mellomlagretFrittståendeBrev }}>
                 {({ mellomlagretFrittståendeBrev }) => {
                     const skalViseFritekstbrev =
@@ -82,7 +65,7 @@ const FrittståendeBrevMedVisning: React.FC<Props> = ({ fagsakId, personopplysni
             <HøyreKolonne>
                 <PdfVisning pdfFilInnhold={brevRessurs} />
             </HøyreKolonne>
-        </BrevMedVisning>
+        </StyledBrev>
     );
 };
 

--- a/src/frontend/Komponenter/Behandling/Brev/FrittståendeSanitybrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/FrittståendeSanitybrev.tsx
@@ -25,7 +25,6 @@ import Brevmottakere from '../Brevmottakere/Brevmottakere';
 import { ModalWrapper } from '../../../Felles/Modal/ModalWrapper';
 import { Knapp } from '../../../Felles/Knapper/HovedKnapp';
 import { Alert } from '@navikt/ds-react';
-import styled from 'styled-components';
 import { utledDokumenttittel } from './BrevUtils';
 
 type FrittståendeSanitybrevProps = {
@@ -34,13 +33,6 @@ type FrittståendeSanitybrevProps = {
     oppdaterBrevRessurs: (brevRessurs: Ressurs<string>) => void;
     brevRessurs: Ressurs<string>;
 };
-
-const StyledFrittståendeBrev = styled.div`
-    margin-top: 1rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-`;
 
 export const FrittståendeSanitybrev: React.FC<FrittståendeSanitybrevProps> = ({
     fagsakId,
@@ -119,22 +111,22 @@ export const FrittståendeSanitybrev: React.FC<FrittståendeSanitybrevProps> = (
     };
 
     return (
-        <StyledFrittståendeBrev>
+        <>
             <Brevmottakere
                 personopplysninger={personopplysninger}
                 mottakere={brevmottakere}
                 kallSettBrevmottakere={oppdaterBrevmottakere}
             />
-            <div>
-                <BrevmalSelect
-                    dokumentnavn={brevmaler}
-                    settBrevmal={settBrevmal}
-                    brevmal={brevMal}
-                    frittstående={true}
-                />
-                {brevMal && (
-                    <DataViewer response={{ brevStruktur, mellomlagretBrev }}>
-                        {({ brevStruktur, mellomlagretBrev }) => (
+            <BrevmalSelect
+                dokumentnavn={brevmaler}
+                settBrevmal={settBrevmal}
+                brevmal={brevMal}
+                frittstående={true}
+            />
+            {brevMal && (
+                <DataViewer response={{ brevStruktur, mellomlagretBrev }}>
+                    {({ brevStruktur, mellomlagretBrev }) => (
+                        <>
                             <BrevmenyVisning
                                 fagsakId={fagsakId}
                                 brevMal={brevMal}
@@ -148,20 +140,20 @@ export const FrittståendeSanitybrev: React.FC<FrittståendeSanitybrevProps> = (
                                 settBrevOppdatert={(laster) => settLaster(!laster)}
                                 brevverdier={brevverdier}
                             />
-                        )}
-                    </DataViewer>
-                )}
-                <Knapp
-                    disabled={
-                        brevRessurs.status !== RessursStatus.SUKSESS ||
-                        !brevmottakereValgt(brevmottakere)
-                    }
-                    onClick={() => settVisModal(true)}
-                    type={'button'}
-                >
-                    Send brev
-                </Knapp>
-            </div>
+                            <Knapp
+                                disabled={
+                                    brevRessurs.status !== RessursStatus.SUKSESS ||
+                                    !brevmottakereValgt(brevmottakere)
+                                }
+                                onClick={() => settVisModal(true)}
+                                type={'button'}
+                            >
+                                Send brev
+                            </Knapp>
+                        </>
+                    )}
+                </DataViewer>
+            )}
             <ModalWrapper
                 tittel={'Bekreft utsending av brev'}
                 visModal={visModal}
@@ -179,6 +171,6 @@ export const FrittståendeSanitybrev: React.FC<FrittståendeSanitybrevProps> = (
             >
                 {feilmelding && <Alert variant={'error'}>Utsending feilet. {feilmelding}</Alert>}
             </ModalWrapper>
-        </StyledFrittståendeBrev>
+        </>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Brev/FrittståendeSanitybrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/FrittståendeSanitybrev.tsx
@@ -25,7 +25,7 @@ import Brevmottakere from '../Brevmottakere/Brevmottakere';
 import { ModalWrapper } from '../../../Felles/Modal/ModalWrapper';
 import { Knapp } from '../../../Felles/Knapper/HovedKnapp';
 import { Alert } from '@navikt/ds-react';
-import { utledDokumenttittel } from './BrevUtils';
+import { finnDokumenttittelForBrevmal } from './BrevUtils';
 
 type FrittståendeSanitybrevProps = {
     fagsakId: string;
@@ -81,7 +81,7 @@ export const FrittståendeSanitybrev: React.FC<FrittståendeSanitybrevProps> = (
         settLaster(true);
         settFeilmelding('');
 
-        const dokumenttittel = utledDokumenttittel(brevmaler, brevMal);
+        const dokumenttittel = finnDokumenttittelForBrevmal(brevmaler, brevMal);
         if (!dokumenttittel) return;
 
         axiosRequest<null, FrittståendeSanitybrevDto>({

--- a/src/frontend/Komponenter/Behandling/Brev/FrittståendeSanitybrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/FrittståendeSanitybrev.tsx
@@ -1,0 +1,184 @@
+import React, { useEffect, useState } from 'react';
+import { IPersonopplysninger } from '../../../App/typer/personopplysninger';
+import {
+    byggSuksessRessurs,
+    byggTomRessurs,
+    Ressurs,
+    RessursFeilet,
+    RessursStatus,
+    RessursSuksess,
+} from '../../../App/typer/ressurs';
+import { BrevmalSelect } from './BrevmalSelect';
+import { useHentBrevmaler } from '../../../App/hooks/useHentBrevmaler';
+import DataViewer from '../../../Felles/DataViewer/DataViewer';
+import { useHentBrevStruktur } from '../../../App/hooks/useHentBrevStruktur';
+import BrevmenyVisning from './BrevmenyVisning';
+import { useMellomlagringFrittståendeSanitybrev } from '../../../App/hooks/useMellomlagringFrittståendeSanitybrev';
+import { IMellomlagretBrevResponse } from '../../../App/hooks/useMellomlagringBrev';
+import { lagTomBrevverdier } from '../../../App/hooks/useVerdierForBrev';
+import { brevmottakereValgt, mottakereEllerBruker } from '../Brevmottakere/brevmottakerUtils';
+import { Brevtype, FrittståendeSanitybrevDto } from './BrevTyper';
+import { EToast } from '../../../App/typer/toast';
+import { IBrevmottakere } from '../Brevmottakere/typer';
+import { useApp } from '../../../App/context/AppContext';
+import Brevmottakere from '../Brevmottakere/Brevmottakere';
+import { ModalWrapper } from '../../../Felles/Modal/ModalWrapper';
+import { Knapp } from '../../../Felles/Knapper/HovedKnapp';
+import { Alert } from '@navikt/ds-react';
+import styled from 'styled-components';
+import { utledDokumenttittel } from './BrevUtils';
+
+type FrittståendeSanitybrevProps = {
+    fagsakId: string;
+    personopplysninger: IPersonopplysninger;
+    oppdaterBrevRessurs: (brevRessurs: Ressurs<string>) => void;
+    brevRessurs: Ressurs<string>;
+};
+
+const StyledFrittståendeBrev = styled.div`
+    margin-top: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+`;
+
+export const FrittståendeSanitybrev: React.FC<FrittståendeSanitybrevProps> = ({
+    fagsakId,
+    oppdaterBrevRessurs,
+    personopplysninger,
+    brevRessurs,
+}) => {
+    const [brevMal, settBrevmal] = useState<string>();
+    const { brevmaler } = useHentBrevmaler();
+    const { brevStruktur } = useHentBrevStruktur(brevMal);
+    const [brevverdier] = useState(lagTomBrevverdier);
+    const { mellomlagreSanitybrev, mellomlagretBrev, settMellomlagretBrev } =
+        useMellomlagringFrittståendeSanitybrev(fagsakId);
+    const [laster, settLaster] = useState(false);
+    const [brevmottakere, settBrevmottakere] = useState<IBrevmottakere>(
+        mottakereEllerBruker(personopplysninger, undefined) // TODO: Legg til støtte for lagring av brevmottakere
+    );
+    const [feilmelding, settFeilmelding] = useState('');
+    const [visModal, settVisModal] = useState<boolean>(false);
+    const { axiosRequest, settToast } = useApp();
+
+    const lukkModal = () => {
+        settVisModal(false);
+        settFeilmelding('');
+    };
+
+    const oppdaterBrevmottakere = (brevmottakere: IBrevmottakere) => {
+        settBrevmottakere(brevmottakere);
+        return Promise.resolve(byggSuksessRessurs('ok'));
+    };
+
+    useEffect(() => {
+        if (
+            mellomlagretBrev.status === RessursStatus.SUKSESS &&
+            mellomlagretBrev.data?.brevtype === Brevtype.SANITYBREV
+        ) {
+            settBrevmal(mellomlagretBrev.data.brevmal);
+        }
+    }, [mellomlagretBrev]);
+
+    const sendBrev = () => {
+        if (laster) return;
+        if (!fagsakId) return;
+        if (!brevmottakereValgt(brevmottakere)) return;
+        if (brevRessurs.status !== RessursStatus.SUKSESS) return;
+        settLaster(true);
+        settFeilmelding('');
+
+        const dokumenttittel = utledDokumenttittel(brevmaler, brevMal);
+        if (!dokumenttittel) return;
+
+        axiosRequest<null, FrittståendeSanitybrevDto>({
+            method: 'POST',
+            url: `/familie-ef-sak/api/frittstaende-brev/send/${fagsakId}`,
+            data: {
+                pdf: brevRessurs.data,
+                tittel: dokumenttittel,
+                mottakere: brevmottakere,
+            },
+        }).then((respons: RessursSuksess<null> | RessursFeilet) => {
+            if (respons.status === RessursStatus.SUKSESS) {
+                nullstillBrev();
+                settToast(EToast.BREV_SENDT);
+                lukkModal();
+            } else {
+                settFeilmelding(respons.frontendFeilmelding);
+            }
+            settLaster(false);
+        });
+    };
+
+    const nullstillBrev = () => {
+        settBrevmal('');
+        oppdaterBrevRessurs(byggTomRessurs());
+        settMellomlagretBrev(byggTomRessurs());
+    };
+
+    return (
+        <StyledFrittståendeBrev>
+            <Brevmottakere
+                personopplysninger={personopplysninger}
+                mottakere={brevmottakere}
+                kallSettBrevmottakere={oppdaterBrevmottakere}
+            />
+            <div>
+                <BrevmalSelect
+                    dokumentnavn={brevmaler}
+                    settBrevmal={settBrevmal}
+                    brevmal={brevMal}
+                    frittstående={true}
+                />
+                {brevMal && (
+                    <DataViewer response={{ brevStruktur, mellomlagretBrev }}>
+                        {({ brevStruktur, mellomlagretBrev }) => (
+                            <BrevmenyVisning
+                                fagsakId={fagsakId}
+                                brevMal={brevMal}
+                                oppdaterBrevRessurs={oppdaterBrevRessurs}
+                                brevStruktur={brevStruktur}
+                                mellomlagreSanityBrev={mellomlagreSanitybrev}
+                                mellomlagretBrevVerdier={
+                                    (mellomlagretBrev as IMellomlagretBrevResponse)?.brevverdier
+                                }
+                                personopplysninger={personopplysninger}
+                                settBrevOppdatert={(laster) => settLaster(!laster)}
+                                brevverdier={brevverdier}
+                            />
+                        )}
+                    </DataViewer>
+                )}
+                <Knapp
+                    disabled={
+                        brevRessurs.status !== RessursStatus.SUKSESS ||
+                        !brevmottakereValgt(brevmottakere)
+                    }
+                    onClick={() => settVisModal(true)}
+                    type={'button'}
+                >
+                    Send brev
+                </Knapp>
+            </div>
+            <ModalWrapper
+                tittel={'Bekreft utsending av brev'}
+                visModal={visModal}
+                onClose={() => lukkModal()}
+                aksjonsknapper={{
+                    hovedKnapp: {
+                        onClick: () => sendBrev(),
+                        tekst: 'Send brev',
+                        disabled: laster,
+                    },
+                    lukkKnapp: { onClick: () => lukkModal(), tekst: 'Avbryt' },
+                    marginTop: 4,
+                }}
+                ariaLabel={'Bekreft ustending av frittstående brev'}
+            >
+                {feilmelding && <Alert variant={'error'}>Utsending feilet. {feilmelding}</Alert>}
+            </ModalWrapper>
+        </StyledFrittståendeBrev>
+    );
+};

--- a/src/frontend/Komponenter/Behandling/Brev/StyledBrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/StyledBrev.tsx
@@ -1,0 +1,20 @@
+import styled from 'styled-components';
+
+export const StyledBrev = styled.div`
+    background-color: #f2f2f2;
+    padding: 2rem 2rem 15rem 2rem;
+    display: flex;
+    flex-flow: wrap;
+    gap: 3rem;
+    justify-content: center;
+    height: 100%;
+`;
+export const VenstreKolonne = styled.div`
+    flex-basis: 450px;
+    flex-shrink: 1;
+    flex-grow: 1;
+`;
+export const HøyreKolonne = styled.div`
+    flex-shrink: 0;
+    flex-grow: 1;
+`;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
[Vi skal ta i bruk sanity for frittstående brev](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12119). Denne PRen implementerer genering, mellomlagring og utsending av brev. Har gjenbrukt det meste fra brev i behandlingsflyt. Dersom saksbehandler har et mellomlagret brev av den gamle typen vil de få opp den gamle brevbyggeren.

PRen er featuretogglet (med unntak av litt stylingendringer godkjent av Lars), så tenker Mirja og jeg må teste en del før prodsetting. 

**Hva gjenstår før prodsetting?**
 - Testing i preprod
 - Mirja må markere relevante maler i sanity
 - Mellomlagring av brevmottakere


### Bilder 📸 
**Ny branch med toggle påskrudd**
![image](https://github.com/navikt/familie-ef-sak-frontend/assets/21220467/95d45f43-1735-4772-b7bd-173eb7a1b806)
**Ny branch med toggle avskrudd**
![image](https://github.com/navikt/familie-ef-sak-frontend/assets/21220467/9e0a99ae-bbe5-426d-9956-d1439a065c4c)
**Før**
![image](https://github.com/navikt/familie-ef-sak-frontend/assets/21220467/c3ea235c-1d7e-48c0-b0da-602ac82ad4fa)

