### PR TITLE
Ikke vise søknadsopplysninger under aleneomsorg ved revurdering med nye opplysninger

### DIFF
--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/AleneomsorgInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/AleneomsorgInfo.tsx
@@ -137,7 +137,7 @@ const AleneomsorgInfo: FC<{
                                 forelderRegister={registergrunnlag.forelder}
                             />
                         )}
-                        {!registergrunnlag.forelder?.dødsfall && (
+                        {skalViseSøknadsdata && !registergrunnlag.forelder?.dødsfall && (
                             <Samvær søknadsgrunnlag={søknadsgrunnlag} />
                         )}
                     </>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Søknadsopplysninger fra forrige behandling skal ikke vises for at ikke feil opplysninger legges til grunn i vurderingen.

![Screenshot 2023-06-19 at 12 45 42](https://github.com/navikt/familie-ef-sak-frontend/assets/42737566/b3c15ac4-f74c-4573-be25-4ed27f34ee0e)

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12795)