### PR TITLE
Skal aligne elementer og begrense maxbredde for frittstående brev

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/BrevInnhold.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevInnhold.tsx
@@ -26,7 +26,7 @@ const StyledSelect = styled(Select)`
 `;
 
 const Innholdsrad = styled(Panel)`
-    width: 95%;
+    width: 100%;
     margin-top: 1rem;
     display: flex;
     flex-direction: column;

--- a/src/frontend/Komponenter/Behandling/Brev/StyledBrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/StyledBrev.tsx
@@ -13,6 +13,7 @@ export const VenstreKolonne = styled.div`
     flex-basis: 450px;
     flex-shrink: 1;
     flex-grow: 1;
+    max-width: 55rem;
 `;
 export const HøyreKolonne = styled.div`
     flex-shrink: 0;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Brakk litt styling for vanlig frittstående brev da jeg merget frittstående sanitybrev (fortsatt featuretogglet)

I prod nå:
![image](https://github.com/navikt/familie-ef-sak-frontend/assets/21220467/eeb47f2f-c5fc-49bc-be0e-1c842bc63aeb)

Med fix:
![Skjermbilde 2023-06-22 kl  08 56 38](https://github.com/navikt/familie-ef-sak-frontend/assets/21220467/0d2b91b4-0c5e-4a3a-b5d3-a6b939b56943)
