### PR TITLE
Skal vise resultat, tid og mer info dersom en klage er feilregistrert

### DIFF
--- a/src/frontend/App/typer/klage.ts
+++ b/src/frontend/App/typer/klage.ts
@@ -21,10 +21,12 @@ export interface KlageinstansResultat {
     type: KlageinstansEventType;
     utfall: KlageinstansUtfall;
     mottattEllerAvsluttetTidspunkt: string | undefined;
+    årsakFeilregistrert?: string;
 }
 
 export enum KlageinstansEventType {
     KLAGEBEHANDLING_AVSLUTTET = 'KLAGEBEHANDLING_AVSLUTTET',
+    BEHANDLING_FEILREGISTRERT = 'BEHANDLING_FEILREGISTRERT',
     ANKEBEHANDLING_OPPRETTET = 'ANKEBEHANDLING_OPPRETTET',
     ANKEBEHANDLING_AVSLUTTET = 'ANKEBEHANDLING_AVSLUTTET',
 }

--- a/src/frontend/Komponenter/Personoversikt/BehandlingsoversiktTabell.tsx
+++ b/src/frontend/Komponenter/Personoversikt/BehandlingsoversiktTabell.tsx
@@ -177,9 +177,18 @@ export const BehandlingsoversiktTabell: React.FC<{
             if (klageBehandlingAvsluttetUtfall) {
                 return klageinstansUtfallTilTekst[klageBehandlingAvsluttetUtfall];
             }
+            if (erKlageFeilregistrertAvKA(behandling)) {
+                return 'Feilregistrert (KA)';
+            }
         }
         return behandling.resultat ? behandlingResultatTilTekst[behandling.resultat] : 'Ikke satt';
     };
+
+    const erKlageFeilregistrertAvKA = (behandling: BehandlingsoversiktTabellBehandling) =>
+        behandling.applikasjon === BehandlingApplikasjon.KLAGE &&
+        behandling.klageinstansResultat?.some(
+            (resultat) => resultat.type == KlageinstansEventType.BEHANDLING_FEILREGISTRERT
+        );
 
     const ankeHarEksistertPåBehandling = (behandling: BehandlingsoversiktTabellBehandling) => {
         return (
@@ -247,6 +256,15 @@ export const BehandlingsoversiktTabell: React.FC<{
                                         {ankeHarEksistertPåBehandling(behandling) && (
                                             <Tooltip content="Det finnes informasjon om anke på denne klagen. Gå inn på klagebehandlingens resultatside for å se detaljer.">
                                                 <AdvarselIkon title={'Har anke informasjon'} />
+                                            </Tooltip>
+                                        )}
+                                        {erKlageFeilregistrertAvKA(behandling) && (
+                                            <Tooltip content="Klagen er feilregistrert av NAV klageinstans. Gå inn på klagebehandlingens resultatside for å se detaljer">
+                                                <AdvarselIkon
+                                                    title={
+                                                        'Behandling feilregistrert av NAV klageinstans'
+                                                    }
+                                                />
                                             </Tooltip>
                                         )}
                                     </>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Når en klage blir satt som feilregistrert i kabal av KA så må vi vise frem at klagen er ferdigbehandlet i vår løsning.
<img width="1116" alt="Skjermbilde 2023-06-23 kl  10 29 42" src="https://github.com/navikt/familie-ef-sak-frontend/assets/402915/876ea262-e871-4998-af10-ac81665ff40e">

