### PR TITLE
Skal kunne mellomlagre brevmottakere for frittstående brev

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/FrittståendeSanitybrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/FrittståendeSanitybrev.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { IPersonopplysninger } from '../../../App/typer/personopplysninger';
 import {
-    byggSuksessRessurs,
     byggTomRessurs,
     Ressurs,
     RessursFeilet,
@@ -16,16 +15,16 @@ import BrevmenyVisning from './BrevmenyVisning';
 import { useMellomlagringFrittståendeSanitybrev } from '../../../App/hooks/useMellomlagringFrittståendeSanitybrev';
 import { IMellomlagretBrevResponse } from '../../../App/hooks/useMellomlagringBrev';
 import { lagTomBrevverdier } from '../../../App/hooks/useVerdierForBrev';
-import { brevmottakereValgt, mottakereEllerBruker } from '../Brevmottakere/brevmottakerUtils';
+import { brevmottakereValgt } from '../Brevmottakere/brevmottakerUtils';
 import { Brevtype, FrittståendeSanitybrevDto } from './BrevTyper';
 import { EToast } from '../../../App/typer/toast';
 import { IBrevmottakere } from '../Brevmottakere/typer';
 import { useApp } from '../../../App/context/AppContext';
-import Brevmottakere from '../Brevmottakere/Brevmottakere';
 import { ModalWrapper } from '../../../Felles/Modal/ModalWrapper';
 import { Knapp } from '../../../Felles/Knapper/HovedKnapp';
 import { Alert } from '@navikt/ds-react';
 import { finnDokumenttittelForBrevmal } from './BrevUtils';
+import { BrevmottakereFrittståendeBrev } from '../Brevmottakere/BrevmottakereFrittståendeBrev';
 
 type FrittståendeSanitybrevProps = {
     fagsakId: string;
@@ -47,9 +46,7 @@ export const FrittståendeSanitybrev: React.FC<FrittståendeSanitybrevProps> = (
     const { mellomlagreSanitybrev, mellomlagretBrev, settMellomlagretBrev } =
         useMellomlagringFrittståendeSanitybrev(fagsakId);
     const [laster, settLaster] = useState(false);
-    const [brevmottakere, settBrevmottakere] = useState<IBrevmottakere>(
-        mottakereEllerBruker(personopplysninger, undefined) // TODO: Legg til støtte for lagring av brevmottakere
-    );
+    const [brevmottakere, settBrevmottakere] = useState<IBrevmottakere>();
     const [feilmelding, settFeilmelding] = useState('');
     const [visModal, settVisModal] = useState<boolean>(false);
     const { axiosRequest, settToast } = useApp();
@@ -57,11 +54,6 @@ export const FrittståendeSanitybrev: React.FC<FrittståendeSanitybrevProps> = (
     const lukkModal = () => {
         settVisModal(false);
         settFeilmelding('');
-    };
-
-    const oppdaterBrevmottakere = (brevmottakere: IBrevmottakere) => {
-        settBrevmottakere(brevmottakere);
-        return Promise.resolve(byggSuksessRessurs('ok'));
     };
 
     useEffect(() => {
@@ -76,7 +68,7 @@ export const FrittståendeSanitybrev: React.FC<FrittståendeSanitybrevProps> = (
     const sendBrev = () => {
         if (laster) return;
         if (!fagsakId) return;
-        if (!brevmottakereValgt(brevmottakere)) return;
+        if (!brevmottakere || !brevmottakereValgt(brevmottakere)) return;
         if (brevRessurs.status !== RessursStatus.SUKSESS) return;
         settLaster(true);
         settFeilmelding('');
@@ -112,10 +104,11 @@ export const FrittståendeSanitybrev: React.FC<FrittståendeSanitybrevProps> = (
 
     return (
         <>
-            <Brevmottakere
+            <BrevmottakereFrittståendeBrev
                 personopplysninger={personopplysninger}
+                fagsakId={fagsakId}
                 mottakere={brevmottakere}
-                kallSettBrevmottakere={oppdaterBrevmottakere}
+                settMottakere={settBrevmottakere}
             />
             <BrevmalSelect
                 dokumentnavn={brevmaler}

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/BrevmottakereFrittståendeBrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/BrevmottakereFrittståendeBrev.tsx
@@ -1,0 +1,69 @@
+import React, { Dispatch, FC, SetStateAction, useCallback, useEffect, useState } from 'react';
+import { IPersonopplysninger } from '../../../App/typer/personopplysninger';
+import { useApp } from '../../../App/context/AppContext';
+import { IBrevmottakere } from './typer';
+import {
+    byggTomRessurs,
+    RessursFeilet,
+    RessursStatus,
+    RessursSuksess,
+} from '../../../App/typer/ressurs';
+import DataViewer from '../../../Felles/DataViewer/DataViewer';
+import { AxiosRequestConfig } from 'axios';
+import Brevmottakere from './Brevmottakere';
+
+export const BrevmottakereFrittståendeBrev: FC<{
+    fagsakId: string;
+    personopplysninger: IPersonopplysninger;
+    mottakere: IBrevmottakere | undefined;
+    settMottakere: Dispatch<SetStateAction<IBrevmottakere | undefined>>;
+}> = ({ personopplysninger, fagsakId, mottakere, settMottakere }) => {
+    const { axiosRequest } = useApp();
+
+    const [mottakereRessurs, settMottakereRessurs] = useState(
+        byggTomRessurs<IBrevmottakere | undefined>()
+    );
+
+    const settBrevmottakere = (brevmottakere: IBrevmottakere) =>
+        axiosRequest<string, IBrevmottakere>({
+            url: `familie-ef-sak/api/brevmottakere/fagsak/${fagsakId}`,
+            method: 'POST',
+            data: brevmottakere,
+        }).then((res: RessursSuksess<string> | RessursFeilet) => {
+            if (res.status === RessursStatus.SUKSESS) {
+                settMottakere(brevmottakere);
+            }
+            return res;
+        });
+
+    const hentBrevmottakere = useCallback(() => {
+        const behandlingConfig: AxiosRequestConfig = {
+            method: 'GET',
+            url: `familie-ef-sak/api/brevmottakere/fagsak/${fagsakId}`,
+        };
+        return axiosRequest<IBrevmottakere | undefined, null>(behandlingConfig).then(
+            (res: RessursSuksess<IBrevmottakere | undefined> | RessursFeilet) => {
+                if (res.status === RessursStatus.SUKSESS && res.data) {
+                    settMottakere(res.data);
+                }
+                settMottakereRessurs(res);
+            }
+        );
+    }, [axiosRequest, fagsakId, settMottakere]);
+
+    useEffect(() => {
+        hentBrevmottakere();
+    }, [hentBrevmottakere]);
+
+    return (
+        <DataViewer response={{ mottakereRessurs }}>
+            {() => (
+                <Brevmottakere
+                    personopplysninger={personopplysninger}
+                    mottakere={mottakere}
+                    kallSettBrevmottakere={settBrevmottakere}
+                />
+            )}
+        </DataViewer>
+    );
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Relatert til https://github.com/navikt/familie-ef-sak/pull/2293
Hvis saksbehandler velger brevmottakere skal dette lagres, og ligge der også neste gang de åpner brevfanen.

Tidligere var dette håndtert som en del av mellomlagringen av frittstående brev, men ved overgang til sanitybrev må det håndteres for seg selv.

**Ny flyt**
- Brevmottakere hentes fra backend ved rendring av frittstående brev ✉️ 
- Staten i frontend populeres med resultatet fra backend 
- Ved endringer av mottakere: det går et kall mot backend når man trykker "Sett brevmottakere", hvis det går bra oppdatere state i frontend med tilsvarende 🔁 
- Ved utsending: staten med brevmottakere sendes med ved utsending 🏹 

Ingen endringer visuelt, men tar med bilder for å forklare flyten:
![image](https://github.com/navikt/familie-ef-sak-frontend/assets/21220467/802348e7-64c3-4128-8bd7-1131793d4b27)
![image](https://github.com/navikt/familie-ef-sak-frontend/assets/21220467/ad6a8e2b-ff58-496a-ba6a-933329f4a14a)

