### PR TITLE
Oppdaterer til distroless image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM navikt/node-express:18
+FROM ghcr.io/navikt/baseimages/node-express:18
 
 ADD ./ /var/server/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ WORKDIR /var/server
 ADD ./ .
 
 EXPOSE 8000
-CMD ["npm", "run", "start"]
+CMD ["/usr/bin/npm", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM ghcr.io/navikt/baseimages/node-express:18
+FROM cgr.dev/chainguard/node:18
 
-ADD ./ /var/server/
+WORKDIR /var/server
+
+ADD ./ .
 
 EXPOSE 8000
-CMD ["yarn", "start"]
+CMD ["npm", "run", "start"]


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
navikt/ sin blir ikke vedlikeholdt, og det anbefales å bruke distroless

https://nav-it.slack.com/archives/C60FFACN5/p1687344001574929
https://nav-it.slack.com/archives/C71GRG335/p1687519626532689?thread_ts=1687518423.343899&cid=C71GRG335