### PR TITLE
Skal ikke bruke nytt gui dersom resultat er opphør for skolepenger

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/VedtakOgBeregningSkolepenger.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/VedtakOgBeregningSkolepenger.tsx
@@ -64,7 +64,7 @@ const VedtakOgBeregningSkolepenger: FC<Props> = ({ behandling, vilkår }) => {
                             // eslint-disable-next-line no-case-declarations
                             const erOpphør = resultatType === EBehandlingResultat.OPPHØRT;
                             {
-                                return toggles[ToggleName.visNyttGuiSkolepenger] ? (
+                                return toggles[ToggleName.visNyttGuiSkolepenger] && !erOpphør ? (
                                     <Vedtaksform />
                                 ) : (
                                     <VedtaksformSkolepenger


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi kommer ikke til å implementere nytt GUI for opphør skolepenger med det første. Sannsynligheten for opphør er lav, så nytt gui for dette løses evt. senere