### PR TITLE
skal kunne legge til flere skoleårsperioder. Per nå er ikke hver dist…

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/Skoleårsperiode.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/Skoleårsperiode.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { FormErrors, Valideringsfunksjon } from '../../../../../App/hooks/felles/useFormState';
+import {
+    IPeriodeSkolepenger,
+    ISkoleårsperiodeSkolepenger,
+    SkolepengerUtgift,
+} from '../../../../../App/typer/vedtak';
+import { InnvilgeVedtakForm } from './Vedtaksform';
+
+interface Props {
+    customValidate: (fn: Valideringsfunksjon<InnvilgeVedtakForm>) => boolean;
+    fjernSkoleårsperiode: () => void;
+    låsteUtgiftIder: string[];
+    oppdaterSkoleårsperiode: (
+        property: keyof ISkoleårsperiodeSkolepenger,
+        value: ISkoleårsperiodeSkolepenger[keyof ISkoleårsperiodeSkolepenger]
+    ) => void;
+    oppdaterValideringsfeil: (
+        property: keyof ISkoleårsperiodeSkolepenger,
+        oppdaterteFeil: FormErrors<SkolepengerUtgift>[] | FormErrors<IPeriodeSkolepenger>[]
+    ) => void;
+    skoleårsperiode: ISkoleårsperiodeSkolepenger;
+    valideringsfeil: FormErrors<ISkoleårsperiodeSkolepenger> | undefined;
+}
+
+const Skoleårsperiode: React.FC<Props> = () => {
+    return <div></div>;
+};
+
+export default Skoleårsperiode;

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/Skoleårsperiode.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/Skoleårsperiode.tsx
@@ -17,7 +17,7 @@ interface Props {
     ) => void;
     oppdaterValideringsfeil: (
         property: keyof ISkoleårsperiodeSkolepenger,
-        oppdaterteFeil: FormErrors<SkolepengerUtgift>[] | FormErrors<IPeriodeSkolepenger>[]
+        oppdaterteFeil: FormErrors<SkolepengerUtgift | IPeriodeSkolepenger>[]
     ) => void;
     skoleårsperiode: ISkoleårsperiodeSkolepenger;
     valideringsfeil: FormErrors<ISkoleårsperiodeSkolepenger> | undefined;

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/Skoleårsperioder.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/Skoleårsperioder.tsx
@@ -1,8 +1,4 @@
-import {
-    IPeriodeSkolepenger,
-    ISkoleårsperiodeSkolepenger,
-    SkolepengerUtgift,
-} from '../../../../../App/typer/vedtak';
+import { ISkoleårsperiodeSkolepenger } from '../../../../../App/typer/vedtak';
 import React, { Dispatch, SetStateAction } from 'react';
 import { useBehandling } from '../../../../../App/context/BehandlingContext';
 import { ListState } from '../../../../../App/hooks/felles/useListState';
@@ -30,6 +26,7 @@ const Skoleårsperioder: React.FC<Props> = ({
     valideringsfeil,
     settValideringsFeil,
     oppdaterHarUtførtBeregning,
+    låsteUtgiftIder,
 }) => {
     const { behandlingErRedigerbar } = useBehandling();
     const { settIkkePersistertKomponent } = useApp();
@@ -65,6 +62,7 @@ const Skoleårsperioder: React.FC<Props> = ({
                 //     behandlingErRedigerbar && index !== 0 && !inneholderLåsteUtgifter;
                 return (
                     <Skoleårsperiode
+                        låsteUtgiftIder={låsteUtgiftIder}
                         customValidate={customValidate}
                         fjernSkoleårsperiode={() => fjernSkoleårsperiode(index)}
                         key={index}
@@ -75,9 +73,7 @@ const Skoleårsperioder: React.FC<Props> = ({
                         ) => oppdaterSkoleårsperiode(index, property, value)}
                         oppdaterValideringsfeil={(
                             property: keyof ISkoleårsperiodeSkolepenger,
-                            oppdaterteFeil:
-                                | FormErrors<SkolepengerUtgift>[]
-                                | FormErrors<IPeriodeSkolepenger>[]
+                            oppdaterteFeil
                         ) =>
                             oppdaterValideringsfeil(
                                 settValideringsFeil,

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/Skoleårsperioder.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/Skoleårsperioder.tsx
@@ -1,7 +1,104 @@
-import React from 'react';
+import {
+    IPeriodeSkolepenger,
+    ISkoleårsperiodeSkolepenger,
+    SkolepengerUtgift,
+} from '../../../../../App/typer/vedtak';
+import React, { Dispatch, SetStateAction } from 'react';
+import { useBehandling } from '../../../../../App/context/BehandlingContext';
+import { ListState } from '../../../../../App/hooks/felles/useListState';
+import { FormErrors, Valideringsfunksjon } from '../../../../../App/hooks/felles/useFormState';
+import { InnvilgeVedtakForm } from './VedtaksformSkolepenger';
+import { useApp } from '../../../../../App/context/AppContext';
+import { VEDTAK_OG_BEREGNING } from '../../Felles/konstanter';
+import { tomSkoleårsperiodeSkolepenger } from '../typer';
+import { oppdaterValideringsfeil } from '../utils';
+import LeggTilKnapp from '../../../../../Felles/Knapper/LeggTilKnapp';
+import Skoleårsperiode from './Skoleårsperiode';
 
-const Skoleårsperioder: React.FC = () => {
-    return <></>;
+interface Props {
+    customValidate: (fn: Valideringsfunksjon<InnvilgeVedtakForm>) => boolean;
+    skoleårsperioder: ListState<ISkoleårsperiodeSkolepenger>;
+    låsteUtgiftIder: string[];
+    valideringsfeil?: FormErrors<InnvilgeVedtakForm>['skoleårsperioder'];
+    settValideringsFeil: Dispatch<SetStateAction<FormErrors<InnvilgeVedtakForm>>>;
+    oppdaterHarUtførtBeregning: (beregningUtført: boolean) => void;
+}
+
+const Skoleårsperioder: React.FC<Props> = ({
+    customValidate,
+    skoleårsperioder,
+    valideringsfeil,
+    settValideringsFeil,
+    oppdaterHarUtførtBeregning,
+}) => {
+    const { behandlingErRedigerbar } = useBehandling();
+    const { settIkkePersistertKomponent } = useApp();
+
+    const fjernSkoleårsperiode = (index: number) => {
+        skoleårsperioder.remove(index);
+        settValideringsFeil((prevState: FormErrors<InnvilgeVedtakForm>) => ({
+            ...prevState,
+            skoleårsperioder: (prevState.skoleårsperioder || []).filter((_, i) => index !== i),
+        }));
+        settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
+        oppdaterHarUtførtBeregning(false);
+    };
+
+    const oppdaterSkoleårsperiode = <T extends ISkoleårsperiodeSkolepenger>(
+        index: number,
+        property: keyof T,
+        value: T[keyof T]
+    ) => {
+        const skoleårsperiode = skoleårsperioder.value[index];
+        skoleårsperioder.update({ ...skoleårsperiode, [property]: value }, index);
+        settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
+        oppdaterHarUtførtBeregning(false);
+    };
+
+    return (
+        <>
+            {skoleårsperioder.value.map((skoleårsperiode, index) => {
+                // const inneholderLåsteUtgifter = skoleårsperiode.utgiftsperioder.some(
+                //     (utgift) => låsteUtgiftIder.indexOf(utgift.id) > -1
+                // );
+                // const skalViseFjernKnapp =
+                //     behandlingErRedigerbar && index !== 0 && !inneholderLåsteUtgifter;
+                return (
+                    <Skoleårsperiode
+                        customValidate={customValidate}
+                        fjernSkoleårsperiode={() => fjernSkoleårsperiode(index)}
+                        key={index}
+                        skoleårsperiode={skoleårsperiode}
+                        oppdaterSkoleårsperiode={(
+                            property: keyof ISkoleårsperiodeSkolepenger,
+                            value: ISkoleårsperiodeSkolepenger[keyof ISkoleårsperiodeSkolepenger]
+                        ) => oppdaterSkoleårsperiode(index, property, value)}
+                        oppdaterValideringsfeil={(
+                            property: keyof ISkoleårsperiodeSkolepenger,
+                            oppdaterteFeil:
+                                | FormErrors<SkolepengerUtgift>[]
+                                | FormErrors<IPeriodeSkolepenger>[]
+                        ) =>
+                            oppdaterValideringsfeil(
+                                settValideringsFeil,
+                                index,
+                                property,
+                                oppdaterteFeil
+                            )
+                        }
+                        valideringsfeil={valideringsfeil && valideringsfeil[index]}
+                    />
+                );
+            })}
+            {behandlingErRedigerbar && (
+                <LeggTilKnapp
+                    onClick={() => skoleårsperioder.push(tomSkoleårsperiodeSkolepenger())}
+                    knappetekst="Legg til nytt skoleår"
+                    variant="tertiary"
+                />
+            )}
+        </>
+    );
 };
 
 export default Skoleårsperioder;

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/VisEllerEndreSkoleårsperioder.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/VisEllerEndreSkoleårsperioder.tsx
@@ -35,7 +35,14 @@ interface Props {
     oppdaterHarUtførtBeregning: (beregningUtført: boolean) => void;
 }
 
-const VisEllerEndreSkoleårsperioder: React.FC<Props> = ({ skoleårsperioder }) => {
+const VisEllerEndreSkoleårsperioder: React.FC<Props> = ({
+    customValidate,
+    skoleårsperioder,
+    låsteUtgiftIder,
+    valideringsfeil,
+    settValideringsFeil,
+    oppdaterHarUtførtBeregning,
+}) => {
     const { behandlingErRedigerbar } = useBehandling();
     const antallSkoleår = skoleårsperioder.value.length;
 
@@ -60,7 +67,16 @@ const VisEllerEndreSkoleårsperioder: React.FC<Props> = ({ skoleårsperioder }) 
                 </Container>
             );
         case Visningsmodus.VISNING:
-            return <Skoleårsperioder />;
+            return (
+                <Skoleårsperioder
+                    customValidate={customValidate}
+                    skoleårsperioder={skoleårsperioder}
+                    låsteUtgiftIder={låsteUtgiftIder}
+                    valideringsfeil={valideringsfeil}
+                    settValideringsFeil={settValideringsFeil}
+                    oppdaterHarUtførtBeregning={oppdaterHarUtførtBeregning}
+                />
+            );
     }
 };
 

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/utils.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/utils.ts
@@ -37,7 +37,7 @@ export const oppdaterValideringsfeil = <
     index: number,
     property: keyof T,
     // @ts-ignore
-    formErrors: FormErrors<T2 extends Array<infer U> ? U[] : T2>
+    formErrors: T2 extends Array<infer U> ? FormErrors<U>[] : FormErrors<T2>
 ) => {
     settValideringsFeil((prevState: FormErrors<InnvilgeVedtakForm>) => {
         const skoleårsperioder = (prevState.skoleårsperioder ?? []).map((p, i) =>


### PR DESCRIPTION
…inkte skoleårsperiode-komponent synlig

### Hvorfor er denne endringen nødvendig? ✨
I nytt GUI for skolepenger skal det være mulig å opprette flere skoleårsperioder. Denne PRen lar oss velge flere skoleårsperioder, men hver distinkte periode er fortsatt usynlig i GUIet. Neste PR vil implementere visning for Skoleperiode-komponenten.

Under har man valgt å legge til flere skoleperioder, men siden visning foreløpig ikke er implementert blir det kun lagt til litt spacing for hver Skoleperiode:
<img width="1458" alt="Skjermbilde 2023-06-28 kl  15 17 25" src="https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/7dc817ea-8029-46b6-a0cc-2eba33c71014">

Denne komponenten er featureTogglet og vises kun for utvalgte saksbehandlere.