### PR TITLE
skal kunne legge til skoleår med feilvalidering. Dersom man bekrefter…

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/Delårsperioder.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/Delårsperioder.tsx
@@ -1,0 +1,188 @@
+import React from 'react';
+import {
+    ESkolepengerStudietype,
+    IPeriodeSkolepenger,
+    skolepengerStudietypeTilTekst,
+    studietyper,
+} from '../../../../../App/typer/vedtak';
+import MånedÅrPeriode, { PeriodeVariant } from '../../../../../Felles/Input/MånedÅr/MånedÅrPeriode';
+import { harTallverdi, tilHeltall, tilTallverdi } from '../../../../../App/utils/utils';
+import styled from 'styled-components';
+import { tomSkoleårsperiode, ValideringsPropsMedOppdatering } from '../typer';
+import InputUtenSpinner from '../../../../../Felles/Visningskomponenter/InputUtenSpinner';
+import { kalkulerAntallMåneder } from '../../../../../App/utils/dato';
+import { Label } from '@navikt/ds-react';
+import { EnsligFamilieSelect } from '../../../../../Felles/Input/EnsligFamilieSelect';
+import FjernKnapp from '../../../../../Felles/Knapper/FjernKnapp';
+import { BodyShortSmall } from '../../../../../Felles/Visningskomponenter/Tekster';
+import LeggTilKnapp from '../../../../../Felles/Knapper/LeggTilKnapp';
+
+const Grid = styled.div<{
+    skoleårErFjernet?: boolean;
+}>`
+    display: grid;
+    grid-template-columns: repeat(7, max-content);
+    gap: 0.25rem 1.5rem;
+    text-decoration: ${(props) => (props.skoleårErFjernet ? 'line-through' : 'inherit')};
+    align-items: start;
+    .ny-rad {
+        grid-column: 1;
+    }
+`;
+
+const AntallMåneder = styled(BodyShortSmall)`
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    padding-top: 0.75rem;
+`;
+
+const Input = styled(InputUtenSpinner)`
+    width: 8rem;
+    text-align: right;
+`;
+
+const Delårsperioder: React.FC<ValideringsPropsMedOppdatering<IPeriodeSkolepenger>> = ({
+    data,
+    oppdater,
+    erOpphør,
+    skoleårErFjernet,
+    behandlingErRedigerbar,
+    valideringsfeil,
+    settValideringsFeil,
+}) => {
+    const oppdaterUtgiftsPeriode = (
+        index: number,
+        property: keyof IPeriodeSkolepenger,
+        value: string | number | undefined
+    ) => {
+        oppdater(
+            data.map((periode, i) => (index === i ? { ...periode, [property]: value } : periode))
+        );
+    };
+
+    const fjernDelårsperiode = (index: number) => {
+        oppdater([...data.slice(0, index), ...data.slice(index + 1)]);
+        settValideringsFeil((valideringsfeil || []).filter((_, i) => i !== index));
+    };
+
+    const oppdaterStudietype = (studietype: ESkolepengerStudietype) => {
+        oppdater(data.map((periode) => ({ ...periode, studietype })));
+    };
+
+    const periodeVariantTilUtgiftsperiodeProperty = (
+        periodeVariant: PeriodeVariant
+    ): keyof IPeriodeSkolepenger => {
+        switch (periodeVariant) {
+            case PeriodeVariant.ÅR_MÅNED_FRA:
+                return 'årMånedFra';
+            case PeriodeVariant.ÅR_MÅNED_TIL:
+                return 'årMånedTil';
+        }
+    };
+
+    const erLesevisning: boolean = !behandlingErRedigerbar || skoleårErFjernet === true;
+
+    return (
+        <>
+            <Grid skoleårErFjernet={skoleårErFjernet}>
+                <Label>Studietype</Label>
+                <Label>Studiebelastning</Label>
+                <Label>Periode fra og med</Label>
+                <Label>Periode til og med</Label>
+                <Label>Antall måneder</Label>
+                {data.map((periode, index) => {
+                    const { studietype, årMånedFra, årMånedTil, studiebelastning } = periode;
+                    const skalViseFjernKnapp =
+                        behandlingErRedigerbar &&
+                        index === data.length - 1 &&
+                        index !== 0 &&
+                        !skoleårErFjernet;
+                    return (
+                        <React.Fragment key={index}>
+                            <EnsligFamilieSelect
+                                className={'ny-rad'}
+                                label="Periodetype"
+                                hideLabel
+                                value={studietype}
+                                error={valideringsfeil && valideringsfeil[index]?.studietype}
+                                onChange={(e) => {
+                                    oppdaterStudietype(e.target.value as ESkolepengerStudietype);
+                                }}
+                                erLesevisning={erLesevisning || erOpphør || index !== 0}
+                                lesevisningVerdi={
+                                    index === 0
+                                        ? studietype && skolepengerStudietypeTilTekst[studietype]
+                                        : ''
+                                }
+                            >
+                                <option value="">Velg</option>
+                                {studietyper.map((type) => (
+                                    <option value={type} key={type}>
+                                        {skolepengerStudietypeTilTekst[type]}
+                                    </option>
+                                ))}
+                            </EnsligFamilieSelect>
+                            <Input
+                                label={'Studiebelastning'}
+                                hideLabel
+                                onKeyPress={tilHeltall}
+                                type="number"
+                                error={valideringsfeil && valideringsfeil[index]?.studiebelastning}
+                                value={harTallverdi(studiebelastning) ? studiebelastning : ''}
+                                formatValue={(k) => k + ' %'}
+                                onChange={(e) =>
+                                    oppdaterUtgiftsPeriode(
+                                        index,
+                                        'studiebelastning',
+                                        tilTallverdi(e.target.value)
+                                    )
+                                }
+                                erLesevisning={erLesevisning}
+                            />
+                            <MånedÅrPeriode
+                                årMånedFraInitiell={årMånedFra}
+                                årMånedTilInitiell={årMånedTil}
+                                index={index}
+                                onEndre={(verdi, periodeVariant) =>
+                                    oppdaterUtgiftsPeriode(
+                                        index,
+                                        periodeVariantTilUtgiftsperiodeProperty(periodeVariant),
+                                        verdi
+                                    )
+                                }
+                                feilmelding={valideringsfeil && valideringsfeil[index]?.årMånedFra}
+                                erLesevisning={erLesevisning}
+                            />
+                            <AntallMåneder>
+                                {kalkulerAntallMåneder(årMånedFra, årMånedTil)}
+                            </AntallMåneder>
+                            {!erLesevisning && !erOpphør && (
+                                <LeggTilKnapp
+                                    onClick={() =>
+                                        oppdater([
+                                            ...data,
+                                            {
+                                                ...tomSkoleårsperiode,
+                                                studietype: data[0].studietype,
+                                            },
+                                        ])
+                                    }
+                                    variant="tertiary"
+                                />
+                            )}
+                            {skalViseFjernKnapp && (
+                                <FjernKnapp
+                                    onClick={() => fjernDelårsperiode(index)}
+                                    ikontekst={'Fjern delårsperiode'}
+                                />
+                            )}
+                        </React.Fragment>
+                    );
+                })}
+            </Grid>
+        </>
+    );
+};
+
+export default Delårsperioder;

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/Delårsperioder.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/Delårsperioder.tsx
@@ -84,104 +84,102 @@ const Delårsperioder: React.FC<ValideringsPropsMedOppdatering<IPeriodeSkolepeng
     const erLesevisning: boolean = !behandlingErRedigerbar || skoleårErFjernet === true;
 
     return (
-        <>
-            <Grid skoleårErFjernet={skoleårErFjernet}>
-                <Label>Studietype</Label>
-                <Label>Studiebelastning</Label>
-                <Label>Periode fra og med</Label>
-                <Label>Periode til og med</Label>
-                <Label>Antall måneder</Label>
-                {data.map((periode, index) => {
-                    const { studietype, årMånedFra, årMånedTil, studiebelastning } = periode;
-                    const skalViseFjernKnapp =
-                        behandlingErRedigerbar &&
-                        index === data.length - 1 &&
-                        index !== 0 &&
-                        !skoleårErFjernet;
-                    return (
-                        <React.Fragment key={index}>
-                            <EnsligFamilieSelect
-                                className={'ny-rad'}
-                                label="Periodetype"
-                                hideLabel
-                                value={studietype}
-                                error={valideringsfeil && valideringsfeil[index]?.studietype}
-                                onChange={(e) => {
-                                    oppdaterStudietype(e.target.value as ESkolepengerStudietype);
-                                }}
-                                erLesevisning={erLesevisning || erOpphør || index !== 0}
-                                lesevisningVerdi={
-                                    index === 0
-                                        ? studietype && skolepengerStudietypeTilTekst[studietype]
-                                        : ''
+        <Grid skoleårErFjernet={skoleårErFjernet}>
+            <Label>Studietype</Label>
+            <Label>Studiebelastning</Label>
+            <Label>Periode fra og med</Label>
+            <Label>Periode til og med</Label>
+            <Label>Antall måneder</Label>
+            {data.map((periode, index) => {
+                const { studietype, årMånedFra, årMånedTil, studiebelastning } = periode;
+                const skalViseFjernKnapp =
+                    behandlingErRedigerbar &&
+                    index === data.length - 1 &&
+                    index !== 0 &&
+                    !skoleårErFjernet;
+                return (
+                    <React.Fragment key={index}>
+                        <EnsligFamilieSelect
+                            className={'ny-rad'}
+                            label="Periodetype"
+                            hideLabel
+                            value={studietype}
+                            error={valideringsfeil && valideringsfeil[index]?.studietype}
+                            onChange={(e) => {
+                                oppdaterStudietype(e.target.value as ESkolepengerStudietype);
+                            }}
+                            erLesevisning={erLesevisning || erOpphør || index !== 0}
+                            lesevisningVerdi={
+                                index === 0
+                                    ? studietype && skolepengerStudietypeTilTekst[studietype]
+                                    : ''
+                            }
+                        >
+                            <option value="">Velg</option>
+                            {studietyper.map((type) => (
+                                <option value={type} key={type}>
+                                    {skolepengerStudietypeTilTekst[type]}
+                                </option>
+                            ))}
+                        </EnsligFamilieSelect>
+                        <Input
+                            label={'Studiebelastning'}
+                            hideLabel
+                            onKeyPress={tilHeltall}
+                            type="number"
+                            error={valideringsfeil && valideringsfeil[index]?.studiebelastning}
+                            value={harTallverdi(studiebelastning) ? studiebelastning : ''}
+                            formatValue={(k) => k + ' %'}
+                            onChange={(e) =>
+                                oppdaterUtgiftsPeriode(
+                                    index,
+                                    'studiebelastning',
+                                    tilTallverdi(e.target.value)
+                                )
+                            }
+                            erLesevisning={erLesevisning}
+                        />
+                        <MånedÅrPeriode
+                            årMånedFraInitiell={årMånedFra}
+                            årMånedTilInitiell={årMånedTil}
+                            index={index}
+                            onEndre={(verdi, periodeVariant) =>
+                                oppdaterUtgiftsPeriode(
+                                    index,
+                                    periodeVariantTilUtgiftsperiodeProperty(periodeVariant),
+                                    verdi
+                                )
+                            }
+                            feilmelding={valideringsfeil && valideringsfeil[index]?.årMånedFra}
+                            erLesevisning={erLesevisning}
+                        />
+                        <AntallMåneder>
+                            {kalkulerAntallMåneder(årMånedFra, årMånedTil)}
+                        </AntallMåneder>
+                        {!erLesevisning && !erOpphør && (
+                            <LeggTilKnapp
+                                onClick={() =>
+                                    oppdater([
+                                        ...data,
+                                        {
+                                            ...tomSkoleårsperiode,
+                                            studietype: data[0].studietype,
+                                        },
+                                    ])
                                 }
-                            >
-                                <option value="">Velg</option>
-                                {studietyper.map((type) => (
-                                    <option value={type} key={type}>
-                                        {skolepengerStudietypeTilTekst[type]}
-                                    </option>
-                                ))}
-                            </EnsligFamilieSelect>
-                            <Input
-                                label={'Studiebelastning'}
-                                hideLabel
-                                onKeyPress={tilHeltall}
-                                type="number"
-                                error={valideringsfeil && valideringsfeil[index]?.studiebelastning}
-                                value={harTallverdi(studiebelastning) ? studiebelastning : ''}
-                                formatValue={(k) => k + ' %'}
-                                onChange={(e) =>
-                                    oppdaterUtgiftsPeriode(
-                                        index,
-                                        'studiebelastning',
-                                        tilTallverdi(e.target.value)
-                                    )
-                                }
-                                erLesevisning={erLesevisning}
+                                variant="tertiary"
                             />
-                            <MånedÅrPeriode
-                                årMånedFraInitiell={årMånedFra}
-                                årMånedTilInitiell={årMånedTil}
-                                index={index}
-                                onEndre={(verdi, periodeVariant) =>
-                                    oppdaterUtgiftsPeriode(
-                                        index,
-                                        periodeVariantTilUtgiftsperiodeProperty(periodeVariant),
-                                        verdi
-                                    )
-                                }
-                                feilmelding={valideringsfeil && valideringsfeil[index]?.årMånedFra}
-                                erLesevisning={erLesevisning}
+                        )}
+                        {skalViseFjernKnapp && (
+                            <FjernKnapp
+                                onClick={() => fjernDelårsperiode(index)}
+                                ikontekst={'Fjern delårsperiode'}
                             />
-                            <AntallMåneder>
-                                {kalkulerAntallMåneder(årMånedFra, årMånedTil)}
-                            </AntallMåneder>
-                            {!erLesevisning && !erOpphør && (
-                                <LeggTilKnapp
-                                    onClick={() =>
-                                        oppdater([
-                                            ...data,
-                                            {
-                                                ...tomSkoleårsperiode,
-                                                studietype: data[0].studietype,
-                                            },
-                                        ])
-                                    }
-                                    variant="tertiary"
-                                />
-                            )}
-                            {skalViseFjernKnapp && (
-                                <FjernKnapp
-                                    onClick={() => fjernDelårsperiode(index)}
-                                    ikontekst={'Fjern delårsperiode'}
-                                />
-                            )}
-                        </React.Fragment>
-                    );
-                })}
-            </Grid>
-        </>
+                        )}
+                    </React.Fragment>
+                );
+            })}
+        </Grid>
     );
 };
 

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/Skoleårsperiode.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/Skoleårsperiode.tsx
@@ -1,11 +1,64 @@
-import React from 'react';
-import { FormErrors, Valideringsfunksjon } from '../../../../../App/hooks/felles/useFormState';
 import {
     IPeriodeSkolepenger,
     ISkoleårsperiodeSkolepenger,
     SkolepengerUtgift,
 } from '../../../../../App/typer/vedtak';
-import { InnvilgeVedtakForm } from './Vedtaksform';
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import { useBehandling } from '../../../../../App/context/BehandlingContext';
+import { FormErrors, Valideringsfunksjon } from '../../../../../App/hooks/felles/useFormState';
+import UtgiftsperiodeSkolepenger from './UtgiftsperiodeSkolepenger';
+import { ABlue200 } from '@navikt/ds-tokens/dist/tokens';
+import { HorizontalScroll } from '../../Felles/HorizontalScroll';
+import Delårsperioder from './Delårsperioder';
+import { BodyLongSmall } from '../../../../../Felles/Visningskomponenter/Tekster';
+import { Knapp } from '../../../../../Felles/Knapper/HovedKnapp';
+import { Alert } from '@navikt/ds-react';
+import { InnvilgeVedtakForm } from './VedtaksformSkolepenger';
+import { validerKunSkoleårsperioder } from './vedtaksvalidering';
+
+const DashedBorder = styled.div`
+    border: 4px dashed ${ABlue200};
+    padding: 1rem;
+    border-radius: 0.5rem;
+`;
+
+const Container = styled(HorizontalScroll)`
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+`;
+
+const InfoStripe = styled(Alert)`
+    .navds-alert__wrapper {
+        max-width: max-content;
+    }
+`;
+
+const FlexColumn = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+`;
+
+const FlexRow = styled.div`
+    display: flex;
+    gap: 1rem;
+    justify-content: flex-end;
+`;
+
+enum Visningsmodus {
+    INITIELL = 'INITIELL',
+    REDIGERING = 'REDIGERING',
+    VISNING = 'VISNING',
+}
+
+const utledVisningmodus = (behandlingErRedigerbar: boolean) => {
+    if (!behandlingErRedigerbar) {
+        return Visningsmodus.VISNING;
+    }
+    return Visningsmodus.INITIELL;
+};
 
 interface Props {
     customValidate: (fn: Valideringsfunksjon<InnvilgeVedtakForm>) => boolean;
@@ -23,8 +76,95 @@ interface Props {
     valideringsfeil: FormErrors<ISkoleårsperiodeSkolepenger> | undefined;
 }
 
-const Skoleårsperiode: React.FC<Props> = () => {
-    return <div></div>;
+const Skoleårsperiode: React.FC<Props> = ({
+    customValidate,
+    fjernSkoleårsperiode,
+    låsteUtgiftIder,
+    oppdaterSkoleårsperiode,
+    oppdaterValideringsfeil,
+    skoleårsperiode,
+    valideringsfeil,
+}) => {
+    const { behandlingErRedigerbar, åpenHøyremeny } = useBehandling();
+
+    const [visningsmodus, settVisninsmodus] = useState<Visningsmodus>(
+        utledVisningmodus(behandlingErRedigerbar)
+    );
+
+    const variabel = false;
+
+    const oppdaterVisningsmodus = () => {
+        if (customValidate(validerKunSkoleårsperioder)) {
+            settVisninsmodus(Visningsmodus.REDIGERING);
+        }
+    };
+
+    switch (visningsmodus) {
+        case Visningsmodus.INITIELL:
+            return (
+                <DashedBorder>
+                    <Container
+                        synligVedLukketMeny={'1035px'}
+                        synligVedÅpenMeny={'1330px'}
+                        åpenHøyremeny={åpenHøyremeny}
+                    >
+                        <Delårsperioder
+                            behandlingErRedigerbar={behandlingErRedigerbar}
+                            data={skoleårsperiode.perioder}
+                            oppdater={(perioder) => oppdaterSkoleårsperiode('perioder', perioder)}
+                            settValideringsFeil={(oppdaterteFeil) =>
+                                oppdaterValideringsfeil('perioder', oppdaterteFeil)
+                            }
+                            valideringsfeil={valideringsfeil && valideringsfeil.perioder}
+                        />
+                        <InfoStripe variant="info">
+                            <FlexColumn>
+                                <BodyLongSmall>
+                                    Et normalt skoleår defineres som fra august/september år A til
+                                    Juni/Juli år B. F.eks. september 2023 til og med juni 2024. Hvis
+                                    bruker studerer på tvers av 2 skoleår f.eks. fra januar 2023 til
+                                    og med desember 2023 må dette fordeles over 2 skoleår.
+                                </BodyLongSmall>
+                                <BodyLongSmall>
+                                    Hvis bruker innad i et skoleår har perioder med ulik
+                                    studiebelastning kan det legges til en ekstra rad for dette.
+                                </BodyLongSmall>
+                            </FlexColumn>
+                        </InfoStripe>
+                        <FlexRow>
+                            <Knapp onClick={fjernSkoleårsperiode} type="button" variant="tertiary">
+                                Avbryt
+                            </Knapp>
+                            <Knapp
+                                onClick={oppdaterVisningsmodus}
+                                type="button"
+                                variant="secondary"
+                            >
+                                Legg til skoleår
+                            </Knapp>
+                        </FlexRow>
+                        {variabel && (
+                            <UtgiftsperiodeSkolepenger
+                                data={skoleårsperiode.utgiftsperioder}
+                                oppdater={(utgiftsperioder) =>
+                                    oppdaterSkoleårsperiode('utgiftsperioder', utgiftsperioder)
+                                }
+                                behandlingErRedigerbar={behandlingErRedigerbar}
+                                valideringsfeil={valideringsfeil && valideringsfeil.utgiftsperioder}
+                                settValideringsFeil={(oppdaterteFeil) =>
+                                    oppdaterValideringsfeil('utgiftsperioder', oppdaterteFeil)
+                                }
+                                låsteUtgiftIder={låsteUtgiftIder}
+                            />
+                        )}
+                    </Container>
+                </DashedBorder>
+            );
+        case Visningsmodus.REDIGERING:
+            return <p>😊</p>;
+        case Visningsmodus.VISNING:
+            return <p>😊</p>;
+    }
 };
 
 export default Skoleårsperiode;

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/VedtaksformSkolepenger.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/VedtaksformSkolepenger.tsx
@@ -18,10 +18,7 @@ import { FieldState } from '../../../../../App/hooks/felles/useFieldState';
 import { useApp } from '../../../../../App/context/AppContext';
 import { byggTomRessurs, Ressurs, RessursStatus } from '../../../../../App/typer/ressurs';
 import { UtregningstabellSkolepenger } from '../UtregnignstabellSkolepenger';
-import {
-    validerInnvilgetVedtakForm,
-    validerInnvilgetVedtakFormBeregning,
-} from './vedtaksvalidering';
+import { validerInnvilgetVedtakForm, validerSkoleårsperioder } from './vedtaksvalidering';
 import { tomSkoleårsperiodeSkolepenger } from '../typer';
 import SkoleårsperioderSkolepenger from './SkoleårsperioderSkolepenger';
 import OpphørSkolepenger from '../OpphørSkolepenger/OpphørSkolepenger';
@@ -150,7 +147,7 @@ export const VedtaksformSkolepenger: React.FC<{
     const beregnSkolepenger = () => {
         settHarUtførtBeregning(false);
         settVisFeilmelding(false);
-        if (formState.customValidate(validerInnvilgetVedtakFormBeregning)) {
+        if (formState.customValidate(validerSkoleårsperioder)) {
             axiosRequest<IBeregningSkolepengerResponse, IBeregningsrequestSkolepenger>({
                 method: 'POST',
                 url: `/familie-ef-sak/api/beregning/skolepenger`,

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/vedtaksvalidering.ts
@@ -37,7 +37,7 @@ export const validerInnvilgetVedtakForm = ({
     };
 };
 
-export const validerInnvilgetVedtakFormBeregning = ({
+export const validerSkoleårsperioder = ({
     skoleårsperioder,
 }: InnvilgeVedtakForm): FormErrors<InnvilgeVedtakForm> => {
     return {
@@ -46,13 +46,34 @@ export const validerInnvilgetVedtakFormBeregning = ({
     };
 };
 
-const validerSkoleårsperioderSkolepenger = (
+export const validerKunSkoleårsperioder = ({
+    skoleårsperioder,
+}: InnvilgeVedtakForm): FormErrors<InnvilgeVedtakForm> => {
+    return {
+        skoleårsperioder: validerSkoleårsperioderUtenUtgiftsperioder(skoleårsperioder),
+        begrunnelse: undefined,
+    };
+};
+
+export const validerSkoleårsperioderSkolepenger = (
     perioder: ISkoleårsperiodeSkolepenger[]
 ): FormErrors<ISkoleårsperiodeSkolepenger[]> => {
     return perioder.map((periode) => {
         const utgiftsperiodeFeil: FormErrors<ISkoleårsperiodeSkolepenger> = {
             perioder: validerDelperiodeSkoleår(periode.perioder),
             utgiftsperioder: validerUtgifter(periode.utgiftsperioder),
+        };
+        return utgiftsperiodeFeil;
+    });
+};
+
+export const validerSkoleårsperioderUtenUtgiftsperioder = (
+    perioder: ISkoleårsperiodeSkolepenger[]
+): FormErrors<ISkoleårsperiodeSkolepenger[]> => {
+    return perioder.map((periode) => {
+        const utgiftsperiodeFeil: FormErrors<ISkoleårsperiodeSkolepenger> = {
+            perioder: validerDelperiodeSkoleår(periode.perioder),
+            utgiftsperioder: [],
         };
         return utgiftsperiodeFeil;
     });


### PR DESCRIPTION
… skoleåret skal man få opp inputen i en form for visningsmodus. Dette kommer i neste PR.

### Hvorfor er denne endringen nødvendig? ✨
I skolepenger 2.0 skal det være mulig å legge til et skoleår på likt vis som før, med samme form for feilvalidering. Denne PRen implementerer initiell redigeringsmodus og feilvalidering av skoleperioder. 

**Initiell redigeringsmodus**
<img width="1426" alt="Skjermbilde 2023-06-30 kl  12 30 21" src="https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/1222158c-70b2-4b5a-bbab-4024efffdcf7">

**Dersom man bekrefter valgene sine blir foreløpig kun dette rendret: (kommer visning i senere PR)**
<img width="1423" alt="Skjermbilde 2023-06-30 kl  12 30 39" src="https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/46b8600d-4962-4daf-86e7-6556ffd33ab9">

Denne visningen er foreløpig feature togglet.


