### PR TITLE
Skal vise varsel om anke dersom det finnes klageresultat ANKE_I_TRYGD…

### DIFF
--- a/src/frontend/App/typer/klage.ts
+++ b/src/frontend/App/typer/klage.ts
@@ -29,6 +29,7 @@ export enum KlageinstansEventType {
     BEHANDLING_FEILREGISTRERT = 'BEHANDLING_FEILREGISTRERT',
     ANKEBEHANDLING_OPPRETTET = 'ANKEBEHANDLING_OPPRETTET',
     ANKEBEHANDLING_AVSLUTTET = 'ANKEBEHANDLING_AVSLUTTET',
+    ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET = 'ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET',
 }
 
 export enum KlageinstansUtfall {
@@ -40,6 +41,8 @@ export enum KlageinstansUtfall {
     STADFESTELSE = 'STADFESTELSE',
     UGUNST = 'UGUNST',
     AVVIST = 'AVVIST',
+    INNSTILLING_STADFESTELSE = 'INNSTILLING_STADFESTELSE',
+    INNSTILLING_AVVIST = 'INNSTILLING_AVVIST',
 }
 
 export const klageinstansUtfallTilTekst: Record<KlageinstansUtfall, string> = {
@@ -51,6 +54,8 @@ export const klageinstansUtfallTilTekst: Record<KlageinstansUtfall, string> = {
     STADFESTELSE: 'Stadfestelse KA',
     UGUNST: 'Ugunst (Ugyldig) KA',
     AVVIST: 'Avvist KA',
+    INNSTILLING_STADFESTELSE: 'Instilling om stadfestelse til trygderetten fra KA',
+    INNSTILLING_AVVIST: 'Instilling om avist til trygderetten fra KA',
 };
 
 export enum KlagebehandlingResultat {

--- a/src/frontend/App/typer/klage.ts
+++ b/src/frontend/App/typer/klage.ts
@@ -54,8 +54,8 @@ export const klageinstansUtfallTilTekst: Record<KlageinstansUtfall, string> = {
     STADFESTELSE: 'Stadfestelse KA',
     UGUNST: 'Ugunst (Ugyldig) KA',
     AVVIST: 'Avvist KA',
-    INNSTILLING_STADFESTELSE: 'Instilling om stadfestelse til trygderetten fra KA',
-    INNSTILLING_AVVIST: 'Instilling om avist til trygderetten fra KA',
+    INNSTILLING_STADFESTELSE: 'Innstilling om stadfestelse til trygderetten fra KA',
+    INNSTILLING_AVVIST: 'Innstilling om avist til trygderetten fra KA',
 };
 
 export enum KlagebehandlingResultat {

--- a/src/frontend/Komponenter/Personoversikt/BehandlingsoversiktTabell.tsx
+++ b/src/frontend/Komponenter/Personoversikt/BehandlingsoversiktTabell.tsx
@@ -196,7 +196,8 @@ export const BehandlingsoversiktTabell: React.FC<{
             behandling.klageinstansResultat?.some(
                 (resultat) =>
                     resultat.type === KlageinstansEventType.ANKEBEHANDLING_OPPRETTET ||
-                    resultat.type === KlageinstansEventType.ANKEBEHANDLING_AVSLUTTET
+                    resultat.type === KlageinstansEventType.ANKEBEHANDLING_AVSLUTTET ||
+                    resultat.type === KlageinstansEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET
             )
         );
     };


### PR DESCRIPTION
…ERETTENBEHANDLING_OPPRETTET for klagebehandling

### Hvorfor er denne endringen nødvendig? ✨
Vi har fått en ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET-event fra kabal på en av sakene våre. Vi trenger derfor å vise dette på behandlingsoversikten.

Varselet blir likt som for vanlig anke opprettet:
![image](https://github.com/navikt/familie-ef-sak-frontend/assets/21220467/9d1e1ac0-11bb-4ae7-8b00-dca70e481c8e)

