### PR TITLE
Skal vise låsikon foran dokumenttittel som bruker ikke har tilgang til

### DIFF
--- a/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Hovedtabellrad.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Hovedtabellrad.tsx
@@ -16,6 +16,7 @@ import { Journalposttype } from '@navikt/familie-typer';
 import { DownFilled, LeftFilled, RightFilled } from '@navikt/ds-icons';
 import { useToggles } from '../../../App/context/TogglesContext';
 import { skalViseLenke } from '../utils';
+import { PadlockLockedIcon } from '@navikt/aksel-icons';
 
 const TrHoveddokument = styled.tr`
     background-color: #f7f7f7;
@@ -32,6 +33,12 @@ const InnUt = styled.div`
         vertical-align: -0.2em;
         margin-right: 0.5rem;
     }
+`;
+
+export const IkkeTilgang = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
 `;
 
 const ikonForJournalposttype: Record<Journalposttype, React.ReactElement> = {
@@ -67,7 +74,10 @@ export const HovedTabellrad: React.FC<{ dokument: Dokumentinfo; erKlikketId: str
                         <LogiskeVedlegg logiskeVedlegg={dokument.logiskeVedlegg} />
                     </>
                 ) : (
-                    <BodyShortSmall>{dokument.tittel}</BodyShortSmall>
+                    <IkkeTilgang>
+                        <PadlockLockedIcon title="Mangler tilgang til dokument" />
+                        <BodyShortSmall>{dokument.tittel}</BodyShortSmall>
+                    </IkkeTilgang>
                 )}
             </Td>
             <Td>{utledAvsenderMottakerDetaljer(dokument)}</Td>

--- a/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Tabellrad.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Tabellrad.tsx
@@ -6,6 +6,8 @@ import { BodyShortSmall } from '../../../Felles/Visningskomponenter/Tekster';
 import styled from 'styled-components';
 import { useToggles } from '../../../App/context/TogglesContext';
 import { skalViseLenke } from '../utils';
+import { IkkeTilgang } from './Hovedtabellrad';
+import { PadlockLockedIcon } from '@navikt/aksel-icons';
 
 const LenkeVenstreMargin = styled.a`
     margin-left: 2rem;
@@ -36,7 +38,10 @@ export const Tabellrad: React.FC<{ dokument: Dokumentinfo; erKlikketId: string }
                         <LogiskeVedlegg logiskeVedlegg={dokument.logiskeVedlegg} />
                     </>
                 ) : (
-                    <BodyShortSmall>{dokument.tittel}</BodyShortSmall>
+                    <IkkeTilgang>
+                        <PadlockLockedIcon title="Mangler tilgang til dokument" />
+                        <BodyShortSmall>{dokument.tittel}</BodyShortSmall>
+                    </IkkeTilgang>
                 )}
             </Td>
             <Td></Td>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er noen dokumenter saksbehandler ikke har tilgang til å åpne. For disse vil vi vise et lås-ikon foran dokumenttittelen.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-13845)


![image](https://github.com/navikt/familie-ef-sak-frontend/assets/21220467/fcb88a85-7edd-4dac-a7fd-243ff3a99ade)
