### PR TITLE
Skal vise "Enslig forsørger" øverst i lista over arkivtemaer

### DIFF
--- a/src/frontend/App/typer/arkivtema.ts
+++ b/src/frontend/App/typer/arkivtema.ts
@@ -138,3 +138,7 @@ export const arkivtemaerAsISelectOptions = Object.entries(arkivtemaerTilTekst).m
         };
     }
 );
+export const arkivtemaerMedENFFørst = [
+    { value: Arkivtema.ENF, label: arkivtemaerTilTekst[Arkivtema.ENF] },
+    ...arkivtemaerAsISelectOptions.filter((tema) => tema.value !== Arkivtema.ENF),
+];

--- a/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
@@ -13,11 +13,7 @@ import {
     journalposttypeTilTekst,
 } from '../../App/typer/journalføring';
 import { VedleggRequest } from './vedleggRequest';
-import {
-    Arkivtema,
-    arkivtemaerAsISelectOptions,
-    arkivtemaerTilTekst,
-} from '../../App/typer/arkivtema';
+import { Arkivtema, arkivtemaerMedENFFørst, arkivtemaerTilTekst } from '../../App/typer/arkivtema';
 import CustomSelect from '../Oppgavebenk/CustomSelect';
 import { FamilieReactSelect, MultiValue, SingleValue } from '@navikt/familie-form-elements';
 import { oppdaterVedleggFilter } from './utils';
@@ -120,7 +116,7 @@ const Dokumenter: React.FC<{ fagsakPerson: IFagsakPerson }> = ({ fagsakPerson })
                     <ArkivtemaVelger
                         placeholder={'Alle'}
                         label={''}
-                        options={arkivtemaerAsISelectOptions}
+                        options={arkivtemaerMedENFFørst}
                         creatable={false}
                         isMulti={true}
                         classNamePrefix={'react-select'}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Saksbehandler kan nå filtrere på tema i dokumentoversikten. Fordi "Enslig forsørger" er mest relevant er det ønskelig at den alltid ligger øverst i lista. Ellers er lista alfabetisk sortert.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-13845)

![image](https://github.com/navikt/familie-ef-sak-frontend/assets/21220467/eec6f1f6-e6c9-44d3-957d-a67428c795e7)
