### PR TITLE
skal vise inputfelter på oppgaebenken på en hensiktsmessig måte. Flex…

### DIFF
--- a/src/frontend/Komponenter/Oppgavebenk/DatoPeriode.tsx
+++ b/src/frontend/Komponenter/Oppgavebenk/DatoPeriode.tsx
@@ -39,7 +39,7 @@ const DatoPeriode: React.FC<Props> = ({
 }) => {
     return (
         <FlexDiv>
-            <div className="skjemaelement flex-item">
+            <div className="skjemaelement">
                 <DatolabelStyle className="skjemaelement__label" htmlFor="regdatoFra">
                     {datoFraTekst}
                 </DatolabelStyle>
@@ -48,7 +48,7 @@ const DatoPeriode: React.FC<Props> = ({
                     <Datepicker onChange={settDatoFra} value={valgtDatoFra} />
                 </DatepickerWrapper>
             </div>
-            <div className="skjemaelement flex-item">
+            <div className="skjemaelement">
                 <DatolabelStyle className="skjemaelement__label" htmlFor="regdatoTil">
                     {datoTilTekst}
                 </DatolabelStyle>

--- a/src/frontend/Komponenter/Oppgavebenk/OppgaveFiltrering.tsx
+++ b/src/frontend/Komponenter/Oppgavebenk/OppgaveFiltrering.tsx
@@ -20,15 +20,11 @@ import { harEgenAnsattRolle, harStrengtFortroligRolle } from '../../App/utils/ro
 import { ModalWrapper } from '../../Felles/Modal/ModalWrapper';
 import { Alert, Button, Select, TextField } from '@navikt/ds-react';
 
-export const FlexDiv = styled.div<{ flexDirection?: 'row' | 'column' }>`
+export const FlexDiv = styled.div`
     display: flex;
-    flex-direction: ${(props) => props.flexDirection ?? 'row'};
     flex-wrap: wrap;
-    justify-content: space-between;
-
-    .flex-item {
-        padding-right: 1.5rem;
-    }
+    column-gap: 1.5rem;
+    row-gap: 1rem;
 `;
 
 const KnappWrapper = styled.div`
@@ -217,10 +213,8 @@ const OppgaveFiltrering: React.FC<IOppgaveFiltrering> = ({
                     value={oppgaveRequest.mappeId}
                     erUtenMappe={oppgaveRequest.erUtenMappe}
                 />
-
                 <Select
                     value={saksbehandlerTekst}
-                    className="flex-item"
                     label="Saksbehandler"
                     onChange={(event) => {
                         event.persist();
@@ -261,7 +255,6 @@ const OppgaveFiltrering: React.FC<IOppgaveFiltrering> = ({
                         </option>
                     )}
                 </Select>
-
                 <TextField
                     value={oppgaveRequest.ident || ''}
                     label="Personident"
@@ -277,7 +270,6 @@ const OppgaveFiltrering: React.FC<IOppgaveFiltrering> = ({
                     autoComplete="off"
                 />
             </FlexDiv>
-
             <KnappWrapper>
                 <FiltreringKnapp onClick={sjekkFeilOgHentOppgaver} type={'submit'}>
                     Hent oppgaver


### PR DESCRIPTION
…-between ble lagt til ved en feil tidligere

### Hvorfor er denne endringen nødvendig? ✨
Tidligere ble det ved en feil lagt til `space-between` på `flexbox` elementet som wrapper alle inputfeltene på oppgavebenken. Dette er nå utbedret.

før:
<img width="1785" alt="Skjermbilde 2023-07-07 kl  10 07 32" src="https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/59d47fc0-b8a4-4f08-814b-9b04a90374ab">

etter:
<img width="1786" alt="Skjermbilde 2023-07-07 kl  10 07 18" src="https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/1c4a831f-d15b-4847-9f15-ed97650fab24">
