### PR TITLE
Validere beløp og utgifter

### DIFF
--- a/src/frontend/App/hooks/useInntektsendringAvslagFlettefelt.ts
+++ b/src/frontend/App/hooks/useInntektsendringAvslagFlettefelt.ts
@@ -53,7 +53,7 @@ export const useInntektsendringAvslagFlettefelt = (
                             vedtaksData.inntekter[vedtaksData.inntekter.length - 1]
                                 .forventetInntekt;
 
-                        if (nåværendeInntekt) {
+                        if (nåværendeInntekt && typeof nåværendeInntekt === 'number') {
                             const tiProsentØkning =
                                 beregnTiProsentØkningIMånedsinntekt(nåværendeInntekt);
                             const tiProsentReduksjon =

--- a/src/frontend/App/typer/vedtak.ts
+++ b/src/frontend/App/typer/vedtak.ts
@@ -189,12 +189,16 @@ export type IvedtakForBarnetilsyn = IInnvilgeVedtakForBarnetilsyn;
 
 export type IvedtakForSkolepenger = IVedtakForSkolepenger;
 
+/**
+ * Inntektsverdier kan bli string hvis de er ugyldige tall
+ * Dette valideres før det sendes til backend
+ */
 export interface IInntektsperiode {
     årMånedFra?: string;
-    dagsats?: number;
-    månedsinntekt?: number;
-    forventetInntekt?: number;
-    samordningsfradrag?: number;
+    dagsats?: number | string;
+    månedsinntekt?: number | string;
+    forventetInntekt?: number | string;
+    samordningsfradrag?: number | string;
     endretKey?: string; // intern for re-rendring
     harSaksbehandlerManueltTastetHundreBeløp?: boolean;
 }

--- a/src/frontend/App/utils/utils.ts
+++ b/src/frontend/App/utils/utils.ts
@@ -72,15 +72,26 @@ export const harIkkeVerdi = (str: string | undefined | null): boolean => !harVer
 export const harVerdi = (str: string | undefined | null): boolean =>
     str !== undefined && str !== '' && str !== null;
 
-export const harTallverdi = (verdi: number | undefined | null): boolean =>
+export const harTallverdi = (verdi: number | undefined | null | string): boolean =>
     verdi !== undefined && verdi !== null;
 
-export const tilTallverdi = (verdi: number | string | undefined): number | undefined => {
+const erPågåendeDesimaltall = (verdi: string) => {
+    return (
+        (verdi.indexOf(',') > 0 && verdi.indexOf(',') == verdi.length - 1) ||
+        (verdi.indexOf('.') > 0 && verdi.indexOf('.') == verdi.length - 1)
+    );
+};
+
+export const tilTallverdi = (verdi: number | string | undefined): number | undefined | string => {
     if (verdi === '' || verdi === undefined || verdi === null) {
         return undefined;
     }
     if (typeof verdi === 'string') {
-        return Number(verdi.replace(/\s/g, ''));
+        if (erPågåendeDesimaltall(verdi)) {
+            return verdi;
+        }
+        const formatertVerdi = Number(verdi.replace(/\s/g, '').replace(/,/g, '.'));
+        return isNaN(formatertVerdi) ? verdi : formatertVerdi;
     }
     return Number(verdi);
 };
@@ -89,6 +100,10 @@ export const tilHeltall = (event: KeyboardEvent<HTMLDivElement>) => {
     if (!/[0-9]/.test(event.key)) {
         event.preventDefault();
     }
+};
+
+export const erDesimaltall = (verdi: number) => {
+    return verdi % 1 !== 0;
 };
 
 export const range = (start: number, end: number): number[] =>

--- a/src/frontend/Felles/Visningskomponenter/InputMedTusenskille.tsx
+++ b/src/frontend/Felles/Visningskomponenter/InputMedTusenskille.tsx
@@ -4,7 +4,15 @@ import InputUtenSpinner, { PropsInputUtenSpinner } from './InputUtenSpinner';
 const InputMedTusenSkille: React.FC<PropsInputUtenSpinner & { className?: string }> = (props) => {
     const formaterVerdi = (verdi: number | string | undefined) => {
         if (verdi) {
-            return Number(verdi).toLocaleString('no-NO', { currency: 'NOK' });
+            const formatertVerdi = Number(
+                typeof verdi === 'string' ? verdi.replace(/,/g, '.') : verdi
+            );
+
+            return isNaN(formatertVerdi)
+                ? verdi
+                : formatertVerdi.toLocaleString('no-NO', {
+                      currency: 'NOK',
+                  });
         }
         return verdi;
     };

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/KontantstøtteValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/KontantstøtteValg.tsx
@@ -178,6 +178,10 @@ const KontantstøtteValg: React.FC<Props> = ({
                                             type="number"
                                             size={'small'}
                                             onKeyPress={tilHeltall}
+                                            error={
+                                                valideringsfeil?.kontantstøtteperioder &&
+                                                valideringsfeil?.kontantstøtteperioder[index]?.beløp
+                                            }
                                             value={harTallverdi(beløp) ? beløp : ''}
                                             onChange={(e) => {
                                                 settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/Tilleggsstønadsvalg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/Tilleggsstønadsvalg.tsx
@@ -195,6 +195,11 @@ const TilleggsstønadValg: React.FC<Props> = ({
                                             erLesevisning={erLesevisning}
                                             hideLabel
                                             label={'Stønadsreduksjon'}
+                                            error={
+                                                valideringsfeil.tilleggsstønadsperioder &&
+                                                valideringsfeil.tilleggsstønadsperioder[index]
+                                                    ?.beløp
+                                            }
                                             onChange={(e) => {
                                                 settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
                                                 oppdaterTilleggsstønadPeriode(

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/UtgiftsperiodeValg.tsx
@@ -307,6 +307,10 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
                                         type="number"
                                         size={'small'}
                                         value={harTallverdi(utgifter) ? utgifter : ''}
+                                        error={
+                                            errorState.utgiftsperioder &&
+                                            errorState.utgiftsperioder[index]?.utgifter
+                                        }
                                         disabled={opphørEllerSanksjon}
                                         onChange={(e) => {
                                             oppdaterUtgiftsperiode(

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/Vedtaksform.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/Vedtaksform.tsx
@@ -170,7 +170,8 @@ export const Vedtaksform: React.FC<{
     useEffect(() => {
         if (
             behandlingErRedigerbar &&
-            finnesKontantstøtteUtbetaling === FinnesKontantstøtteUtbetaling.NEI
+            finnesKontantstøtteUtbetaling === FinnesKontantstøtteUtbetaling.NEI &&
+            kontantstøtteState.value === ERadioValg.IKKE_SATT
         ) {
             kontantstøtteState.setValue(ERadioValg.NEI);
         }

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/vedtaksvalidering.ts
@@ -8,7 +8,7 @@ import {
 } from '../../../../App/typer/vedtak';
 import { erMånedÅrEtter, erMånedÅrEtterEllerLik } from '../../../../App/utils/dato';
 import { erOpphørEllerSanksjon } from './utils';
-import { erDesimaltall } from '../../../../App/utils/utils';
+import { validerGyldigTallverdi } from '../Felles/utils';
 
 export const validerInnvilgetVedtakForm = ({
     utgiftsperioder,
@@ -277,14 +277,4 @@ export const validerTilleggsstønadPerioder = (
 
 const harVerdi = (begrunnelse?: string) => {
     return begrunnelse !== '' && begrunnelse !== undefined;
-};
-
-const validerGyldigTallverdi = (verdi: string | number | undefined | null) => {
-    const ugyldigVerdiFeilmelding = `Ugyldig verdi - kun heltall tillatt`;
-    if (typeof verdi === 'number') {
-        return isNaN(verdi) || erDesimaltall(verdi) ? ugyldigVerdiFeilmelding : undefined;
-    }
-    if (typeof verdi === 'string') {
-        return !/^[0-9]+$/.test(verdi) ? ugyldigVerdiFeilmelding : undefined;
-    }
 };

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/vedtaksvalidering.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../../App/typer/vedtak';
 import { erMånedÅrEtter, erMånedÅrEtterEllerLik } from '../../../../App/utils/dato';
 import { erOpphørEllerSanksjon } from './utils';
+import { erDesimaltall } from '../../../../App/utils/utils';
 
 export const validerInnvilgetVedtakForm = ({
     utgiftsperioder,
@@ -84,14 +85,15 @@ export const validerUtgiftsperioder = ({
     utgiftsperioder: IUtgiftsperiode[];
 }): FormErrors<{ utgiftsperioder: IUtgiftsperiode[] }> => {
     const feilIUtgiftsperioder = utgiftsperioder.map((utgiftsperiode, index) => {
-        const { periodetype, aktivitetstype, årMånedFra, årMånedTil, barn } = utgiftsperiode;
+        const { periodetype, aktivitetstype, årMånedFra, årMånedTil, barn, utgifter } =
+            utgiftsperiode;
         const utgiftsperiodeFeil: FormErrors<IUtgiftsperiode> = {
             periodetype: undefined,
             aktivitetstype: undefined,
             årMånedFra: undefined,
             årMånedTil: undefined,
             barn: [],
-            utgifter: undefined,
+            utgifter: validerGyldigTallverdi(utgifter),
         };
         const erSistePeriode = index === utgiftsperioder.length - 1;
 
@@ -183,7 +185,7 @@ export const validerKontantstøttePerioder = (
         const kontantstøtteperiodeFeil: FormErrors<IPeriodeMedBeløp> = {
             årMånedFra: undefined,
             årMånedTil: undefined,
-            beløp: undefined,
+            beløp: validerGyldigTallverdi(periode.beløp),
         };
 
         if (!årMånedTil || !årMånedFra) {
@@ -241,7 +243,7 @@ export const validerTilleggsstønadPerioder = (
         const tilleggsstønadPeriodeFeil: FormErrors<IPeriodeMedBeløp> = {
             årMånedFra: undefined,
             årMånedTil: undefined,
-            beløp: undefined,
+            beløp: validerGyldigTallverdi(periode.beløp),
         };
 
         if (!årMånedTil || !årMånedFra) {
@@ -275,4 +277,14 @@ export const validerTilleggsstønadPerioder = (
 
 const harVerdi = (begrunnelse?: string) => {
     return begrunnelse !== '' && begrunnelse !== undefined;
+};
+
+const validerGyldigTallverdi = (verdi: string | number | undefined | null) => {
+    const ugyldigVerdiFeilmelding = `Ugyldig verdi - kun heltall tillatt`;
+    if (typeof verdi === 'number') {
+        return isNaN(verdi) || erDesimaltall(verdi) ? ugyldigVerdiFeilmelding : undefined;
+    }
+    if (typeof verdi === 'string') {
+        return !/^[0-9]+$/.test(verdi) ? ugyldigVerdiFeilmelding : undefined;
+    }
 };

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
@@ -17,6 +17,7 @@ import {
     IVedtakType,
 } from '../../../../App/typer/vedtak';
 import { Ressurs, RessursStatus } from '../../../../App/typer/ressurs';
+import { erDesimaltall } from '../../../../App/utils/utils';
 
 export const mapVilkårtypeTilResultat = (
     vurderinger: IVurdering[]
@@ -182,4 +183,14 @@ export const skalFerdigstilleUtenBeslutter = (vedtak?: IVedtak | undefined): boo
         vedtak.resultatType === EBehandlingResultat.AVSLÅ &&
         vedtak.avslåÅrsak === EAvslagÅrsak.MINDRE_INNTEKTSENDRINGER
     );
+};
+
+export const validerGyldigTallverdi = (verdi: string | number | undefined | null) => {
+    const ugyldigVerdiFeilmelding = `Ugyldig verdi - kun heltall tillatt`;
+    if (typeof verdi === 'number') {
+        return isNaN(verdi) || erDesimaltall(verdi) ? ugyldigVerdiFeilmelding : undefined;
+    }
+    if (typeof verdi === 'string') {
+        return !/^[0-9]+$/.test(verdi) ? ugyldigVerdiFeilmelding : undefined;
+    }
 };

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
@@ -291,6 +291,10 @@ const InntektsperiodeValg: React.FC<Props> = ({
                                             <StyledInput
                                                 label={'Dagsats'}
                                                 hideLabel
+                                                error={
+                                                    errorState?.inntekter &&
+                                                    errorState?.inntekter[index]?.dagsats
+                                                }
                                                 erLesevisning={!behandlingErRedigerbar}
                                                 value={harTallverdi(rad.dagsats) ? rad.dagsats : ''}
                                                 onChange={(e) => {
@@ -308,6 +312,10 @@ const InntektsperiodeValg: React.FC<Props> = ({
                                                 label={'Månedsinntekt'}
                                                 hideLabel
                                                 erLesevisning={!behandlingErRedigerbar}
+                                                error={
+                                                    errorState?.inntekter &&
+                                                    errorState?.inntekter[index]?.månedsinntekt
+                                                }
                                                 value={
                                                     harTallverdi(rad.månedsinntekt)
                                                         ? rad.månedsinntekt
@@ -326,6 +334,10 @@ const InntektsperiodeValg: React.FC<Props> = ({
                                                 label={'Årsinntekt'}
                                                 hideLabel
                                                 type="number"
+                                                error={
+                                                    errorState?.inntekter &&
+                                                    errorState?.inntekter[index]?.forventetInntekt
+                                                }
                                                 value={
                                                     harTallverdi(rad.forventetInntekt)
                                                         ? rad.forventetInntekt
@@ -335,6 +347,7 @@ const InntektsperiodeValg: React.FC<Props> = ({
                                                     const verdi = tilTallverdi(e.target.value);
                                                     const saksbehandlerHarAvrundetÅrsinntektTilNærmesteHundre =
                                                         verdi !== undefined &&
+                                                        typeof verdi === 'number' &&
                                                         verdi % 100 === 0 &&
                                                         verdi % 1000 !== 0;
 
@@ -356,6 +369,11 @@ const InntektsperiodeValg: React.FC<Props> = ({
                                                     label={'Samordningsfradrag (mnd)'}
                                                     hideLabel
                                                     type="number"
+                                                    error={
+                                                        errorState?.inntekter &&
+                                                        errorState?.inntekter[index]
+                                                            ?.samordningsfradrag
+                                                    }
                                                     value={
                                                         harTallverdi(rad.samordningsfradrag)
                                                             ? rad.samordningsfradrag

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
@@ -216,10 +216,7 @@ const validerInntektsperiode = (
     if (erMånedÅrEtter(attenMånederFremITiden, årMånedFra)) {
         return `Startdato (${årMånedFra}) mer enn 18mnd frem i tid`;
     }
-    const sisteInntektsperiode = perioder[perioder.length - 1].årMånedTil;
-    if (sisteInntektsperiode && erMånedÅrEtter(sisteInntektsperiode, årMånedFra)) {
-        return `Startdato (${årMånedFra}) mer etter siste inntektsperiode`;
-    }
+
     return undefined;
 };
 

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
@@ -16,7 +16,7 @@ import {
 import { InnvilgeVedtakForm } from './InnvilgeVedtak/Vedtaksform';
 import { FormErrors } from '../../../../App/hooks/felles/useFormState';
 import { SanksjonereVedtakForm } from '../../Sanksjon/Sanksjonsfastsettelse';
-import { erDesimaltall } from '../../../../App/utils/utils';
+import { validerGyldigTallverdi } from '../Felles/utils';
 
 const attenMånederFremITiden = tilÅrMåned(plusMåneder(new Date(), 18));
 const syvMånederFremITiden = tilÅrMåned(plusMåneder(new Date(), 7));
@@ -223,15 +223,6 @@ const validerInntektsperiode = (
     return undefined;
 };
 
-const validerGyldigTallverdi = (verdi: string | number | undefined | null) => {
-    const ugyldigVerdiFeilmelding = `Ugyldig verdi - kun heltall tillatt`;
-    if (typeof verdi === 'number') {
-        return isNaN(verdi) || erDesimaltall(verdi) ? ugyldigVerdiFeilmelding : undefined;
-    }
-    if (typeof verdi === 'string') {
-        return !/^[0-9]+$/.test(verdi) ? ugyldigVerdiFeilmelding : undefined;
-    }
-};
 export const validerSanksjonereVedtakForm = ({
     sanksjonsårsak,
     internBegrunnelse,

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/vedtaksvalidering.ts
@@ -12,6 +12,7 @@ import {
     overlapper,
 } from '../../../../../App/utils/dato';
 import { beregnSkoleår, validerSkoleår } from '../skoleår';
+import { erDesimaltall } from '../../../../../App/utils/utils';
 
 const periodeSkolepengerFeil: FormErrors<IPeriodeSkolepenger> = {
     studietype: undefined,
@@ -184,8 +185,21 @@ const validerUtgifsperioder = (perioder: SkolepengerUtgift[]): FormErrors<Skolep
                 stønad: 'Mangelfull utfylling av beløp',
             };
         }
-        return periodeUtgiftFeil;
+        return {
+            ...periodeUtgiftFeil,
+            stønad: validerGyldigTallverdi(stønad),
+        };
     });
+};
+
+const validerGyldigTallverdi = (verdi: string | number | undefined | null) => {
+    const ugyldigVerdiFeilmelding = `Ugyldig verdi - kun heltall tillatt`;
+    if (typeof verdi === 'number') {
+        return isNaN(verdi) || erDesimaltall(verdi) ? ugyldigVerdiFeilmelding : undefined;
+    }
+    if (typeof verdi === 'string') {
+        return !/^[0-9]+$/.test(verdi) ? ugyldigVerdiFeilmelding : undefined;
+    }
 };
 
 const harVerdi = (begrunnelse?: string) => {

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/vedtaksvalidering.ts
@@ -12,7 +12,7 @@ import {
     overlapper,
 } from '../../../../../App/utils/dato';
 import { beregnSkoleår, validerSkoleår } from '../skoleår';
-import { erDesimaltall } from '../../../../../App/utils/utils';
+import { validerGyldigTallverdi } from '../../Felles/utils';
 
 const periodeSkolepengerFeil: FormErrors<IPeriodeSkolepenger> = {
     studietype: undefined,
@@ -190,16 +190,6 @@ const validerUtgifsperioder = (perioder: SkolepengerUtgift[]): FormErrors<Skolep
             stønad: validerGyldigTallverdi(stønad),
         };
     });
-};
-
-const validerGyldigTallverdi = (verdi: string | number | undefined | null) => {
-    const ugyldigVerdiFeilmelding = `Ugyldig verdi - kun heltall tillatt`;
-    if (typeof verdi === 'number') {
-        return isNaN(verdi) || erDesimaltall(verdi) ? ugyldigVerdiFeilmelding : undefined;
-    }
-    if (typeof verdi === 'string') {
-        return !/^[0-9]+$/.test(verdi) ? ugyldigVerdiFeilmelding : undefined;
-    }
 };
 
 const harVerdi = (begrunnelse?: string) => {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal ikke kunne sende inn desimaltall eller ugyldige tallverdier til backend, må følgelig validere verdiene. 
Det er mulig å skrive inn/lime inn ugyldige verdier, men viser en feilmelding. Dette er bedre enn å forsøke å endre til heltall underveis mens saksbehandler skriver/limer inn - da dette kan forvirre og i verste fall gjøre beløpene altfor store. Særlig hvis de prøver å legge inn desimaltall uten at punktum eller komma blir med i tastingen...

### [Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12411)

### Overgangsstønad
<img width="1266" alt="Skjermbilde 2023-07-17 kl  09 23 58" src="https://github.com/navikt/familie-ef-sak-frontend/assets/402915/78b49195-fc3e-4b0c-90ec-70949d200d88">

### Barnetilsyn
<img width="787" alt="Skjermbilde 2023-07-17 kl  10 43 15" src="https://github.com/navikt/familie-ef-sak-frontend/assets/402915/81a4360e-0118-40cc-a53d-aa3bd3812346">

### Skolepenger
<img width="974" alt="Skjermbilde 2023-07-17 kl  10 43 52" src="https://github.com/navikt/familie-ef-sak-frontend/assets/402915/caa13d5f-dee2-4617-b984-8df9118c04c2">
