### PR TITLE
Validere at inntektsperiode ikke er etter vedtaksperiode

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/vedtaksvalidering.ts
@@ -216,6 +216,10 @@ const validerInntektsperiode = (
     if (erMånedÅrEtter(attenMånederFremITiden, årMånedFra)) {
         return `Startdato (${årMånedFra}) mer enn 18mnd frem i tid`;
     }
+    const sisteMånedIVedtaksperiode = perioder[perioder.length - 1]?.årMånedTil;
+    if (sisteMånedIVedtaksperiode && erMånedÅrEtter(sisteMånedIVedtaksperiode, årMånedFra)) {
+        return `Startdato (${årMånedFra}) er etter vedtaksperioden`;
+    }
 
     return undefined;
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal ikke kunne sette inntektsperiode utenfor vedtaksperioden. Det gir ikke mening å sette dette, og kan bli kilde til feil når vi skal gjøre gomregning med inntektsjustering. 

Det finnes to behandlinger som har dette i databasen, men begge har fått forkortet vedtaksperiode, men de har valgt å la inntektsperioden ligge. Det går nok fint i praksis, men vil gi feilmelding hvis de revurderes og saksbehandleren må følgelig fjerne ugyldige inntektsperioder

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12290)
