### PR TITLE
Redis aiven

### DIFF
--- a/build_n_deploy/naiserator/dev.yaml
+++ b/build_n_deploy/naiserator/dev.yaml
@@ -62,3 +62,8 @@ spec:
       value: "{{version}}"
     - name: ENV
       value: preprod
+  redis:
+    - instance: sessions
+      access: readwrite
+    - instance: lookup
+      access: read

--- a/build_n_deploy/naiserator/prod.yaml
+++ b/build_n_deploy/naiserator/prod.yaml
@@ -61,3 +61,8 @@ spec:
       value: "{{version}}"
     - name: ENV
       value: production
+  redis:
+    - instance: sessions
+      access: readwrite
+    - instance: lookup
+      access: read

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@navikt/ds-react": "2.9.x",
     "@navikt/ds-react-internal": "2.9.x",
     "@navikt/ds-tokens": "2.9.x",
-    "@navikt/familie-backend": "10.0.7-alpha.2+20a5264",
+    "@navikt/familie-backend": "10.0.7",
     "@navikt/familie-dokumentliste": "^8.1.0",
     "@navikt/familie-endringslogg": "^8.1.0",
     "@navikt/familie-form-elements": "^10.1.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@navikt/ds-react": "2.9.x",
     "@navikt/ds-react-internal": "2.9.x",
     "@navikt/ds-tokens": "2.9.x",
-    "@navikt/familie-backend": "10.0.7-alpha.0+00bd582",
+    "@navikt/familie-backend": "10.0.7-alpha.1+db3efed",
     "@navikt/familie-dokumentliste": "^8.1.0",
     "@navikt/familie-endringslogg": "^8.1.0",
     "@navikt/familie-form-elements": "^10.1.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@navikt/ds-react": "2.9.x",
     "@navikt/ds-react-internal": "2.9.x",
     "@navikt/ds-tokens": "2.9.x",
-    "@navikt/familie-backend": "10.0.7-alpha.1+db3efed",
+    "@navikt/familie-backend": "10.0.7-alpha.2+20a5264",
     "@navikt/familie-dokumentliste": "^8.1.0",
     "@navikt/familie-endringslogg": "^8.1.0",
     "@navikt/familie-form-elements": "^10.1.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@navikt/ds-react": "2.9.x",
     "@navikt/ds-react-internal": "2.9.x",
     "@navikt/ds-tokens": "2.9.x",
-    "@navikt/familie-backend": "10.0.6",
+    "@navikt/familie-backend": "10.0.7-alpha.0+00bd582",
     "@navikt/familie-dokumentliste": "^8.1.0",
     "@navikt/familie-endringslogg": "^8.1.0",
     "@navikt/familie-form-elements": "^10.1.2",

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -119,7 +119,7 @@ export const sessionConfig: ISessionKonfigurasjon = {
     redisUrl: env.redisUrl,
     redisFullUrl: process.env.REDIS_URI_SESSIONS,
     redisBrukernavn: process.env.REDIS_USERNAME_SESSIONS,
-    redisPassord: process.env.REDIS_PASSWORD,
+    redisPassord: process.env.REDIS_PASSWORD_SESSIONS,
     secureCookie: !(
         process.env.ENV === 'local' ||
         process.env.ENV === 'e2e' ||

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -115,9 +115,11 @@ const env = Environment();
 
 export const sessionConfig: ISessionKonfigurasjon = {
     cookieSecret: [`${process.env.COOKIE_KEY1}`, `${process.env.COOKIE_KEY2}`],
-    navn: 'familie-ef-sak-v1',
-    redisPassord: process.env.REDIS_PASSWORD,
+    navn: 'familie-ef-sak-v2',
     redisUrl: env.redisUrl,
+    redisFullUrl: process.env.REDIS_URI_SESSIONS,
+    redisBrukernavn: process.env.REDIS_USERNAME_SESSIONS,
+    redisPassord: process.env.REDIS_PASSWORD,
     secureCookie: !(
         process.env.ENV === 'local' ||
         process.env.ENV === 'e2e' ||

--- a/yarn.lock
+++ b/yarn.lock
@@ -3287,10 +3287,10 @@
   resolved "https://npm.pkg.github.com/download/@navikt/ds-tokens/2.9.3/660add888226b08389958f153e3fb6acbb88a8ee#660add888226b08389958f153e3fb6acbb88a8ee"
   integrity sha512-VvUE32dwhLz01EhgBB2VrvcQboHhQ/z9i95hkO/OM7Vgz6NxsnEZTMHiaeR324Wu1aCEknZxh1hZGaOZgqRqSQ==
 
-"@navikt/familie-backend@10.0.7-alpha.2+20a5264":
-  version "10.0.7-alpha.2"
-  resolved "https://npm.pkg.github.com/download/@navikt/familie-backend/10.0.7-alpha.2/4d34b96f9aa5deb16e32d5d7e1474fa269a7e1c1#4d34b96f9aa5deb16e32d5d7e1474fa269a7e1c1"
-  integrity sha512-UjpzAWQVSvZtVCnmr7mz8kCC4ezj+Q+DsCg9jQwU8UgGlcNWYmDcCQ9a1FU0Q/TZJML8EN0zmY2WIFnMnDTorw==
+"@navikt/familie-backend@10.0.7":
+  version "10.0.7"
+  resolved "https://npm.pkg.github.com/download/@navikt/familie-backend/10.0.7/13895e10ffca5656b069985950d8224c9fd1e2db#13895e10ffca5656b069985950d8224c9fd1e2db"
+  integrity sha512-XDII70qTkKrOq/Ap8qkqpIKEBVKahUcH7bdeG5Y1216FkEgBrtitViqRlyPl5HvCRJJZBumU/q+3smoBRxwdbA==
   dependencies:
     "@navikt/familie-logging" "^6.0.0"
     "@types/cookie-parser" "^1.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3287,10 +3287,10 @@
   resolved "https://npm.pkg.github.com/download/@navikt/ds-tokens/2.9.3/660add888226b08389958f153e3fb6acbb88a8ee#660add888226b08389958f153e3fb6acbb88a8ee"
   integrity sha512-VvUE32dwhLz01EhgBB2VrvcQboHhQ/z9i95hkO/OM7Vgz6NxsnEZTMHiaeR324Wu1aCEknZxh1hZGaOZgqRqSQ==
 
-"@navikt/familie-backend@10.0.7-alpha.1+db3efed":
-  version "10.0.7-alpha.1"
-  resolved "https://npm.pkg.github.com/download/@navikt/familie-backend/10.0.7-alpha.1/24aec6569e64d4b4e0ec484946950681232335c2#24aec6569e64d4b4e0ec484946950681232335c2"
-  integrity sha512-8dgDinFevZHXlH+HtzvJlOd8vWrRpPn82A71SzKMgU8xjPC5Dl2fzFTLePds7c0dH6grAqxIsGJ7lnZsdCsRsQ==
+"@navikt/familie-backend@10.0.7-alpha.2+20a5264":
+  version "10.0.7-alpha.2"
+  resolved "https://npm.pkg.github.com/download/@navikt/familie-backend/10.0.7-alpha.2/4d34b96f9aa5deb16e32d5d7e1474fa269a7e1c1#4d34b96f9aa5deb16e32d5d7e1474fa269a7e1c1"
+  integrity sha512-UjpzAWQVSvZtVCnmr7mz8kCC4ezj+Q+DsCg9jQwU8UgGlcNWYmDcCQ9a1FU0Q/TZJML8EN0zmY2WIFnMnDTorw==
   dependencies:
     "@navikt/familie-logging" "^6.0.0"
     "@types/cookie-parser" "^1.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3287,10 +3287,10 @@
   resolved "https://npm.pkg.github.com/download/@navikt/ds-tokens/2.9.3/660add888226b08389958f153e3fb6acbb88a8ee#660add888226b08389958f153e3fb6acbb88a8ee"
   integrity sha512-VvUE32dwhLz01EhgBB2VrvcQboHhQ/z9i95hkO/OM7Vgz6NxsnEZTMHiaeR324Wu1aCEknZxh1hZGaOZgqRqSQ==
 
-"@navikt/familie-backend@10.0.6":
-  version "10.0.6"
-  resolved "https://npm.pkg.github.com/download/@navikt/familie-backend/10.0.6/80226ffa2af59b80b67b6528cff8207f94447596#80226ffa2af59b80b67b6528cff8207f94447596"
-  integrity sha512-d3POmLBIosjoykM1w8MXYOiHIrlLOMJFTD7R3qnMpf76JSlG6Ssfuy+iwryQJGraabbEUKwSQWsLmrJx83QIHw==
+"@navikt/familie-backend@10.0.7-alpha.0+00bd582":
+  version "10.0.7-alpha.0"
+  resolved "https://npm.pkg.github.com/download/@navikt/familie-backend/10.0.7-alpha.0/bd4ce2d5da037e0bfccdb471eb25e69fb17cfb0b#bd4ce2d5da037e0bfccdb471eb25e69fb17cfb0b"
+  integrity sha512-flu7CGi96EdQ8p78rJz971jLlfgR1ehD37O4yie5R/D7mw+Yn/P9dmCbxlOrCLO4NKXuUYfn8maH4Ozr4hROdw==
   dependencies:
     "@navikt/familie-logging" "^6.0.0"
     "@types/cookie-parser" "^1.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3287,10 +3287,10 @@
   resolved "https://npm.pkg.github.com/download/@navikt/ds-tokens/2.9.3/660add888226b08389958f153e3fb6acbb88a8ee#660add888226b08389958f153e3fb6acbb88a8ee"
   integrity sha512-VvUE32dwhLz01EhgBB2VrvcQboHhQ/z9i95hkO/OM7Vgz6NxsnEZTMHiaeR324Wu1aCEknZxh1hZGaOZgqRqSQ==
 
-"@navikt/familie-backend@10.0.7-alpha.0+00bd582":
-  version "10.0.7-alpha.0"
-  resolved "https://npm.pkg.github.com/download/@navikt/familie-backend/10.0.7-alpha.0/bd4ce2d5da037e0bfccdb471eb25e69fb17cfb0b#bd4ce2d5da037e0bfccdb471eb25e69fb17cfb0b"
-  integrity sha512-flu7CGi96EdQ8p78rJz971jLlfgR1ehD37O4yie5R/D7mw+Yn/P9dmCbxlOrCLO4NKXuUYfn8maH4Ozr4hROdw==
+"@navikt/familie-backend@10.0.7-alpha.1+db3efed":
+  version "10.0.7-alpha.1"
+  resolved "https://npm.pkg.github.com/download/@navikt/familie-backend/10.0.7-alpha.1/24aec6569e64d4b4e0ec484946950681232335c2#24aec6569e64d4b4e0ec484946950681232335c2"
+  integrity sha512-8dgDinFevZHXlH+HtzvJlOd8vWrRpPn82A71SzKMgU8xjPC5Dl2fzFTLePds7c0dH6grAqxIsGJ7lnZsdCsRsQ==
   dependencies:
     "@navikt/familie-logging" "^6.0.0"
     "@types/cookie-parser" "^1.4.3"


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å få nedetidsfri håndtering av sesjoner må vi kjøre mot Aiven Redis, og ikke "hjemmesnekra" redis. 

Må justere litt på konfigurasjonen ettersom vi nå får andre miljøvariabler inn. 

Har justert `familie-felles-frontend -> familie-backend` til å ta imot disse parameterne. 

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-13503)