### PR TITLE
Ta-av-vent - sett oppgave på saksbehandleren

### DIFF
--- a/src/frontend/App/typer/toast.ts
+++ b/src/frontend/App/typer/toast.ts
@@ -27,5 +27,5 @@ export const toastTilTekst: Record<EToast, string> = {
     REDIRECT_ANNEN_RELASJON_FEILET:
         'Kan ikke åpne personopplysninger for denne personen. En uventet feil oppstod',
     BEHANDLING_SATT_PÅ_VENT: 'Oppgaven er oppdatert og behandlingen er satt på vent',
-    BEHANDLING_TATT_AV_VENT: 'Behandlingen er tatt av vent',
+    BEHANDLING_TATT_AV_VENT: 'Behandlingen er tatt av vent. Du er satt som ansvarlig saksbehandler',
 };

--- a/src/frontend/Komponenter/Behandling/SettPåVent/TaAvVentBekreftModal.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/TaAvVentBekreftModal.tsx
@@ -1,0 +1,31 @@
+import React, { FC } from 'react';
+import { ModalWrapper } from '../../../Felles/Modal/ModalWrapper';
+
+export const TaAvVentBekreftModal: FC<{
+    håndterFortsettBehandling: () => void;
+    avbryt: () => void;
+    ansvarligSaksbehandler: string;
+    visModal: boolean;
+}> = ({ håndterFortsettBehandling, avbryt, ansvarligSaksbehandler, visModal }) => {
+    return (
+        <ModalWrapper
+            tittel={'Ta av vent'}
+            visModal={visModal}
+            onClose={avbryt}
+            aksjonsknapper={{
+                hovedKnapp: {
+                    onClick: håndterFortsettBehandling,
+                    tekst: 'Ta av vent',
+                },
+                lukkKnapp: {
+                    onClick: avbryt,
+                    tekst: 'Avbryt',
+                },
+            }}
+            ariaLabel={'Ta av vent'}
+        >
+            {ansvarligSaksbehandler} står som ansvarlig saksbehandler på denne oppgaven. Hvis du tar
+            den av vent blir du satt som ansvarlig saksbehandler
+        </ModalWrapper>
+    );
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Når en saksbehandler tar en behandling av vent så skal oppgaven settes til den saksbehandleren. Skal vise en modal dersom noen andre står på oppgaven. Toasten skal si noe om at oppgaven blir satt på saksbehandleren

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-13714)


<img width="1506" alt="Skjermbilde 2023-07-20 kl  13 54 28" src="https://github.com/navikt/familie-ef-sak-frontend/assets/402915/6b4e2602-d5c1-48fe-84a0-c597d53bb2d3">
<img width="603" alt="Skjermbilde 2023-07-20 kl  13 54 15" src="https://github.com/navikt/familie-ef-sak-frontend/assets/402915/bc35a6c9-8994-40a0-a163-136c590a0f19">


PS: Må merges samtidig som backend for at tekstene skal henge på greip... 