### PR TITLE
Skal vise varseltekst om klage hos NAV klageinstans eller anke på behandlingsoversikt

### DIFF
--- a/src/frontend/Komponenter/Personoversikt/Klage/KlageInfo.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Klage/KlageInfo.tsx
@@ -1,41 +1,19 @@
 import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
-import { Stønadstype, stønadstypeTilTekst } from '../../../App/typer/behandlingstema';
+import { stønadstypeTilTekst } from '../../../App/typer/behandlingstema';
 import { Alert } from '@navikt/ds-react';
 import { useHentKlagebehandlinger } from '../../../App/hooks/useHentKlagebehandlinger';
-import {
-    KlageBehandling,
-    Klagebehandlinger,
-    KlagebehandlingStatus,
-} from '../../../App/typer/klage';
 import { RessursStatus } from '../../../App/typer/ressurs';
+import {
+    personHarÅpenAnke,
+    stønadstyperMedÅpenSakNavKlageinstans,
+    stønasatyperMedÅpenKlage,
+} from './klageInfoUtils';
 
 const AdvarselVisning = styled(Alert)`
     margin-top: 0.5rem;
 `;
-
-const erKlageUnderArbeid = (klagebehandling: KlageBehandling) => {
-    return (
-        klagebehandling.status == KlagebehandlingStatus.OPPRETTET ||
-        klagebehandling.status == KlagebehandlingStatus.UTREDES
-    );
-};
-
-const åpneKlager = (klagebehandlinger: Klagebehandlinger): Stønadstype[] => {
-    const stønadstyperMedÅpenKlage: Stønadstype[] = [];
-    if (klagebehandlinger.overgangsstønad.some(erKlageUnderArbeid)) {
-        stønadstyperMedÅpenKlage.push(Stønadstype.OVERGANGSSTØNAD);
-    }
-    if (klagebehandlinger.barnetilsyn.some(erKlageUnderArbeid)) {
-        stønadstyperMedÅpenKlage.push(Stønadstype.BARNETILSYN);
-    }
-    if (klagebehandlinger.skolepenger.some(erKlageUnderArbeid)) {
-        stønadstyperMedÅpenKlage.push(Stønadstype.SKOLEPENGER);
-    }
-
-    return stønadstyperMedÅpenKlage;
-};
 
 const KlageInfo: React.FunctionComponent<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
     const { hentKlagebehandlinger, klagebehandlinger } = useHentKlagebehandlinger();
@@ -47,18 +25,45 @@ const KlageInfo: React.FunctionComponent<{ fagsakPersonId: string }> = ({ fagsak
     return (
         <DataViewer response={{ klagebehandlinger }}>
             {({ klagebehandlinger }) => {
-                const åpneKlagerPerStønadstype = åpneKlager(klagebehandlinger);
-                if (åpneKlagerPerStønadstype.length === 0) {
+                const åpneKlagerPerStønadstype = stønasatyperMedÅpenKlage(klagebehandlinger);
+                const åpneKlagerNavKlageinstans =
+                    stønadstyperMedÅpenSakNavKlageinstans(klagebehandlinger);
+
+                if (
+                    åpneKlagerPerStønadstype.length === 0 &&
+                    åpneKlagerNavKlageinstans.length === 0 &&
+                    !personHarÅpenAnke(klagebehandlinger)
+                ) {
                     return null;
                 }
 
                 const åpneKlagerTekst = åpneKlagerPerStønadstype
                     .map((stønadstype) => stønadstypeTilTekst[stønadstype])
                     .join(', ');
+
+                const åpneKlagerNavKlageinstansTekst = åpneKlagerNavKlageinstans
+                    .map((stønadstype) => stønadstypeTilTekst[stønadstype])
+                    .join(', ');
                 return (
-                    <AdvarselVisning variant={'warning'} size={'small'}>
-                        Merk at det ligger en åpen klage på stønadstype: {åpneKlagerTekst}
-                    </AdvarselVisning>
+                    <>
+                        {åpneKlagerNavKlageinstans.length > 0 && (
+                            <AdvarselVisning variant={'warning'} size={'small'}>
+                                Merk at en klage er til behandling hos NAV Klageinstans på
+                                stønadstype: {åpneKlagerNavKlageinstansTekst}
+                            </AdvarselVisning>
+                        )}
+                        {åpneKlagerPerStønadstype.length > 0 && (
+                            <AdvarselVisning variant={'warning'} size={'small'}>
+                                Merk at det ligger en åpen klage på stønadstype: {åpneKlagerTekst}
+                            </AdvarselVisning>
+                        )}
+                        {personHarÅpenAnke(klagebehandlinger) && (
+                            <AdvarselVisning variant={'warning'} size={'small'}>
+                                Det finnes informasjon om anke på denne brukeren. Gå inn på
+                                klagebehandlingens resultatside for å se detaljer.
+                            </AdvarselVisning>
+                        )}
+                    </>
                 );
             }}
         </DataViewer>

--- a/src/frontend/Komponenter/Personoversikt/Klage/klageInfoUtils.ts
+++ b/src/frontend/Komponenter/Personoversikt/Klage/klageInfoUtils.ts
@@ -1,0 +1,68 @@
+import {
+    KlageBehandling,
+    Klagebehandlinger,
+    KlagebehandlingResultat,
+    KlagebehandlingStatus,
+    KlageinstansEventType,
+} from '../../../App/typer/klage';
+import { Stønadstype } from '../../../App/typer/behandlingstema';
+
+const erKlageUnderArbeid = (klagebehandling: KlageBehandling) => {
+    return (
+        klagebehandling.status == KlagebehandlingStatus.OPPRETTET ||
+        klagebehandling.status == KlagebehandlingStatus.UTREDES
+    );
+};
+
+export const stønasatyperMedÅpenKlage = (klagebehandlinger: Klagebehandlinger): Stønadstype[] => {
+    const stønadstyperMedÅpenKlage: Stønadstype[] = [];
+    if (klagebehandlinger.overgangsstønad.some(erKlageUnderArbeid)) {
+        stønadstyperMedÅpenKlage.push(Stønadstype.OVERGANGSSTØNAD);
+    }
+    if (klagebehandlinger.barnetilsyn.some(erKlageUnderArbeid)) {
+        stønadstyperMedÅpenKlage.push(Stønadstype.BARNETILSYN);
+    }
+    if (klagebehandlinger.skolepenger.some(erKlageUnderArbeid)) {
+        stønadstyperMedÅpenKlage.push(Stønadstype.SKOLEPENGER);
+    }
+
+    return stønadstyperMedÅpenKlage;
+};
+
+export const stønadstyperMedÅpenSakNavKlageinstans = (
+    klagebehandlinger: Klagebehandlinger
+): Stønadstype[] => {
+    const stønadstyperMedÅpenKlageNavKlageinstans: Stønadstype[] = [];
+
+    const erKlageTilBehandlingNavKlageinstans = (klagebehandling: KlageBehandling) =>
+        klagebehandling.status === KlagebehandlingStatus.VENTER &&
+        klagebehandling.resultat === KlagebehandlingResultat.IKKE_MEDHOLD;
+
+    if (klagebehandlinger.overgangsstønad.some(erKlageTilBehandlingNavKlageinstans)) {
+        stønadstyperMedÅpenKlageNavKlageinstans.push(Stønadstype.OVERGANGSSTØNAD);
+    }
+    if (klagebehandlinger.barnetilsyn.some(erKlageTilBehandlingNavKlageinstans)) {
+        stønadstyperMedÅpenKlageNavKlageinstans.push(Stønadstype.SKOLEPENGER);
+    }
+    if (klagebehandlinger.skolepenger.some(erKlageTilBehandlingNavKlageinstans)) {
+        stønadstyperMedÅpenKlageNavKlageinstans.push(Stønadstype.SKOLEPENGER);
+    }
+
+    return stønadstyperMedÅpenKlageNavKlageinstans;
+};
+
+export const personHarÅpenAnke = (klagebehandlinger: Klagebehandlinger) =>
+    harÅpenAnke(klagebehandlinger.overgangsstønad) ||
+    harÅpenAnke(klagebehandlinger.barnetilsyn) ||
+    harÅpenAnke(klagebehandlinger.skolepenger);
+
+const harÅpenAnke = (klagebehandlinger: KlageBehandling[]) =>
+    klagebehandlinger.some(
+        (klagebehandling) =>
+            klagebehandling.status !== KlagebehandlingStatus.FERDIGSTILT &&
+            klagebehandling.klageinstansResultat.some(
+                (resultat) =>
+                    resultat.type === KlageinstansEventType.ANKEBEHANDLING_OPPRETTET ||
+                    resultat.type === KlageinstansEventType.ANKE_I_TRYGDERETTENBEHANDLING_OPPRETTET
+            )
+    );


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi har tidligere kun vist varsel på behandlingsoversikten dersom det er en åpen klagebehandling i familie-klage. Vi ønsker å vise tilsvarende varsel dersom en sak er til behandling hos NAV klageinstans, eller det finnes en åpen ankesak.


[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-13830)

#### Bilder 📷 
<img width="1771" alt="image" src="https://github.com/navikt/familie-ef-sak-frontend/assets/21220467/232007b8-54c3-424c-af6b-804fd64db63d">

<img width="1787" alt="image" src="https://github.com/navikt/familie-ef-sak-frontend/assets/21220467/09179fcc-6931-4739-96b6-71229f032660">

