### PR TITLE
Skal kunne fjerne skoleårsperiode dersom den ikke inneholder låste utgifter

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/Skoleårsperiode.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/Skoleårsperiode.tsx
@@ -71,7 +71,6 @@ export enum Visningsmodus {
 
 type Props = {
     customValidate: (fn: Valideringsfunksjon<InnvilgeVedtakForm>) => boolean;
-    erFørstePeriode: boolean;
     fjernSkoleårsperiode: () => void;
     låsteUtgiftIder: string[];
     oppdaterSkoleårsperiode: (
@@ -88,7 +87,6 @@ type Props = {
 
 const Skoleårsperiode: React.FC<Props> = ({
     customValidate,
-    erFørstePeriode,
     fjernSkoleårsperiode,
     låsteUtgiftIder,
     oppdaterSkoleårsperiode,
@@ -140,7 +138,7 @@ const Skoleårsperiode: React.FC<Props> = ({
         (utgift) => låsteUtgiftIder.indexOf(utgift.id) > -1
     );
 
-    const skalViseFjernKnapp = !erLesevisning && !erFørstePeriode && !inneholderLåsteUtgifter;
+    const skalViseFjernKnapp = !erLesevisning && !inneholderLåsteUtgifter;
     const erLesevisningForDelårsperioder = erLesevisning || kanRedigereUtgiftsperiode;
     const utgiftsperioderErKlikkbar = kanRedigereUtgiftsperiode || erLesevisning;
 

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/Skoleårsperioder.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgetSkolepenger/Skoleårsperioder.tsx
@@ -59,7 +59,6 @@ const Skoleårsperioder: React.FC<Props> = ({
                     <Skoleårsperiode
                         låsteUtgiftIder={låsteUtgiftIder}
                         customValidate={customValidate}
-                        erFørstePeriode={index === 0}
                         fjernSkoleårsperiode={() => fjernSkoleårsperiode(index)}
                         key={index}
                         skoleårsperiode={skoleårsperiode}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Dersom man legger til en skoleårsperiode i en revurdering før den eksisterende perioden, vil man etter lagring ikke få mulighet til å fjerne den nye perioden sånn koden har vært frem til nå. Med denne endringen vil man kunne fjerne perioden så lenge den ikke inneholder låste utgifter.