### PR TITLE
Fjerner CPU-limit

### DIFF
--- a/build_n_deploy/naiserator/dev.yaml
+++ b/build_n_deploy/naiserator/dev.yaml
@@ -11,7 +11,6 @@ spec:
   replicas:
     min: 2
     max: 2
-    cpuThresholdPercentage: 50
   port: 8000
   liveness:
     path: /isAlive
@@ -39,7 +38,6 @@ spec:
           - id: "ea930b6b-9397-44d9-b9e6-f4cf527a632a" # 0000-GA-Fortrolig_Adresse
   resources:
     limits:
-      cpu: 2000m
       memory: 1024Mi
     requests:
       memory: 512Mi

--- a/build_n_deploy/naiserator/prod.yaml
+++ b/build_n_deploy/naiserator/prod.yaml
@@ -11,7 +11,6 @@ spec:
   replicas:
     min: 2
     max: 2
-    cpuThresholdPercentage: 50
   port: 8000
   liveness:
     path: /isAlive
@@ -39,7 +38,6 @@ spec:
           - id: "9ec6487d-f37a-4aad-a027-cd221c1ac32b" # 0000-GA-Fortrolig_Adresse
   resources:
     limits:
-      cpu: 2000m
       memory: 1024Mi
     requests:
       memory: 512Mi


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Anbefaling fra NAIS om at CPU throttle fjernes fra pod, men beholdes for requests: https://nav-it.slack.com/archives/C01DE3M9YBV/p1680172494569329

Artikkelen som det refereres til i meldingen fra NAIS beskriver hvorfor:
https://home.robusta.dev/blog/stop-using-cpu-limits

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12306)