### PR TITLE
Fjerner featuretoggle som er aktivert for både dev og prod

### DIFF
--- a/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Hovedtabellrad.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Hovedtabellrad.tsx
@@ -14,7 +14,6 @@ import { Utsendingsinfo } from '../Utsendingsinfo';
 import styled from 'styled-components';
 import { Journalposttype } from '@navikt/familie-typer';
 import { DownFilled, LeftFilled, RightFilled } from '@navikt/ds-icons';
-import { useToggles } from '../../../App/context/TogglesContext';
 import { skalViseLenke } from '../utils';
 import { PadlockLockedIcon } from '@navikt/aksel-icons';
 
@@ -50,7 +49,6 @@ const ikonForJournalposttype: Record<Journalposttype, React.ReactElement> = {
 export const HovedTabellrad: React.FC<{ dokument: Dokumentinfo; erKlikketId: string }> = ({
     dokument,
 }) => {
-    const { toggles } = useToggles();
     return (
         <TrHoveddokument>
             <Td>{formaterNullableIsoDatoTid(dokument.dato)}</Td>
@@ -61,7 +59,7 @@ export const HovedTabellrad: React.FC<{ dokument: Dokumentinfo; erKlikketId: str
                 </InnUt>
             </Td>
             <Td>
-                {skalViseLenke(dokument, toggles) ? (
+                {skalViseLenke(dokument) ? (
                     <>
                         <HovedLenke
                             key={dokument.journalpostId}

--- a/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Tabellrad.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Tabellrad.tsx
@@ -4,7 +4,6 @@ import { Td } from '../../../Felles/Personopplysninger/TabellWrapper';
 import { LogiskeVedlegg } from './LogiskeVedlegg';
 import { BodyShortSmall } from '../../../Felles/Visningskomponenter/Tekster';
 import styled from 'styled-components';
-import { useToggles } from '../../../App/context/TogglesContext';
 import { skalViseLenke } from '../utils';
 import { IkkeTilgang } from './Hovedtabellrad';
 import { PadlockLockedIcon } from '@navikt/aksel-icons';
@@ -20,13 +19,12 @@ const LenkeVenstreMargin = styled.a`
 export const Tabellrad: React.FC<{ dokument: Dokumentinfo; erKlikketId: string }> = ({
     dokument,
 }) => {
-    const { toggles } = useToggles();
     return (
         <tr>
             <Td></Td>
             <Td></Td>
             <Td>
-                {skalViseLenke(dokument, toggles) ? (
+                {skalViseLenke(dokument) ? (
                     <>
                         <LenkeVenstreMargin
                             href={`/dokument/journalpost/${dokument.journalpostId}/dokument-pdf/${dokument.dokumentinfoId}`}

--- a/src/frontend/Komponenter/Personoversikt/utils.ts
+++ b/src/frontend/Komponenter/Personoversikt/utils.ts
@@ -3,7 +3,6 @@ import { BehandlingStatus } from '../../App/typer/behandlingstatus';
 import { Behandlingstype } from '../../App/typer/behandlingstype';
 import { VedleggRequest } from './vedleggRequest';
 import { Dokumentinfo } from '../../App/typer/dokumentliste';
-import { ToggleName, Toggles } from '../../App/context/toggles';
 
 export const alleBehandlingerErFerdigstiltEllerSattPåVent = (fagsak: Fagsak) =>
     fagsak.behandlinger.every(
@@ -47,9 +46,6 @@ export const oppdaterVedleggFilter = (
     };
 };
 
-export const skalViseLenke = (dokument: Dokumentinfo, toggles: Toggles): boolean => {
-    return (
-        (toggles[ToggleName.dokumentoversiktLinkTilDokument] || dokument.tema === 'ENF') &&
-        dokument.harSaksbehandlerTilgang
-    );
+export const skalViseLenke = (dokument: Dokumentinfo): boolean => {
+    return dokument.tema === 'ENF' && dokument.harSaksbehandlerTilgang;
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det ble togglet om det skulle være lov til å åpne dokumenter i dokumentvisningen, for å sjekke at tilgangsstyringen er riktig.
Dette ble testet av Mirja før sommerferie og kan fjernes.