### PR TITLE
Skal kun gi warning for unused vars

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,6 +30,7 @@
         "prettier/prettier": "warn",
         "@typescript-eslint/interface-name-prefix": "off",
         "@typescript-eslint/no-var-requires": "warn",
+        "@typescript-eslint/no-unused-vars": "warn",
         "@typescript-eslint/explicit-function-return-type": "off",
         "jsx-a11y/interactive-supports-focus": "off",
         "jsx-a11y/click-events-have-key-events": "off",


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ubrukte imports eller variabler i koden gir feil som bundle ikke er fornøyd med ved kjøring lokalt. Man må derfor fikse alle ubrukte vars før man kan se endringen lokalt. 

Ønsker at dette heller skal være en warning fordi det er ikke et problem som gjør at koden ikke kan kompilere og det vil fortsatt ikke være mulig å committe før det fikses 🤠 

Oppdaget av at jeg brukte minst 15 min på å ikke skjønne hvorfor ingen av endringene jeg gjorde ble plukket opp 😢 