### PR TITLE
💄 Penere visning av flere barnepassordninger i vlilkårsvurdering av aktivitet

### DIFF
--- a/src/frontend/Komponenter/Behandling/Aktivitet/DokumentasjonTilsynsutgifter/Barnepassordning.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/DokumentasjonTilsynsutgifter/Barnepassordning.tsx
@@ -1,0 +1,54 @@
+import React, { FC } from 'react';
+import {
+    BarnepassordningDto,
+    typeBarnepassordningTilTekst,
+} from '../../Inngangsvilkår/Aleneomsorg/typer';
+import { formaterNullableIsoDato } from '../../../../App/utils/formatter';
+import { VilkårInfoIkon } from '../../Vilkårpanel/VilkårInformasjonKomponenter';
+import Informasjonsrad from '../../Vilkårpanel/Informasjonsrad';
+import styled from 'styled-components';
+import { Label } from '@navikt/ds-react';
+
+const PassordningWrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+`;
+
+const Barnepassordning: FC<{
+    barnepassordning: BarnepassordningDto;
+}> = ({ barnepassordning }) => {
+    return (
+        <PassordningWrapper>
+            <Informasjonsrad
+                ikon={VilkårInfoIkon.SØKNAD}
+                label="Barnepassordning"
+                verdi={
+                    <Label size="small">
+                        {typeBarnepassordningTilTekst[barnepassordning.type]}
+                    </Label>
+                }
+                verdiSomString={false}
+            />
+            <Informasjonsrad
+                label="Navn passordning"
+                verdi={barnepassordning.navn}
+                boldLabel={false}
+            />
+            <Informasjonsrad
+                label="Periode passordning"
+                verdi={`${formaterNullableIsoDato(
+                    barnepassordning.fra
+                )} - ${formaterNullableIsoDato(barnepassordning.til)}`}
+                boldLabel={false}
+            />
+            <Informasjonsrad
+                label="Utgifter"
+                verdi={barnepassordning.beløp + ',-'}
+                boldLabel={false}
+            />
+        </PassordningWrapper>
+    );
+};
+
+export default Barnepassordning;

--- a/src/frontend/Komponenter/Behandling/Aktivitet/DokumentasjonTilsynsutgifter/TilsynsutgifterBarnInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/DokumentasjonTilsynsutgifter/TilsynsutgifterBarnInfo.tsx
@@ -1,37 +1,15 @@
 import React, { FC } from 'react';
-import {
-    IBarnMedSamvær,
-    typeBarnepassordningTilTekst,
-} from '../../Inngangsvilkår/Aleneomsorg/typer';
-import { formaterNullableIsoDato } from '../../../../App/utils/formatter';
+import { IBarnMedSamvær } from '../../Inngangsvilkår/Aleneomsorg/typer';
 import { utledNavnOgAlder } from '../../Inngangsvilkår/utils';
-import { BarneInfoWrapper, VilkårInfoIkon } from '../../Vilkårpanel/VilkårInformasjonKomponenter';
+import { BarneInfoWrapper } from '../../Vilkårpanel/VilkårInformasjonKomponenter';
 import Informasjonsrad from '../../Vilkårpanel/Informasjonsrad';
+import Barnepassordning from './Barnepassordning';
 
 const TilsynsutgifterBarnInfo: FC<{
     gjeldendeBarn: IBarnMedSamvær;
 }> = ({ gjeldendeBarn }) => {
     const { registergrunnlag, barnepass } = gjeldendeBarn;
     const harPassordning = barnepass && barnepass.barnepassordninger;
-    const passordningTittel =
-        harPassordning && barnepass?.barnepassordninger.length > 1
-            ? 'Barnepassordninger'
-            : 'Barnepassordning';
-
-    if (!gjeldendeBarn.barnepass?.skalHaBarnepass) {
-        return (
-            <BarneInfoWrapper
-                navnOgAlderPåBarn={utledNavnOgAlder(
-                    registergrunnlag.navn,
-                    registergrunnlag.fødselsdato,
-                    registergrunnlag.dødsdato
-                )}
-                dødsdato={registergrunnlag.dødsdato}
-            >
-                <Informasjonsrad label="Ingen søknadsopplysninger" />
-            </BarneInfoWrapper>
-        );
-    }
 
     return (
         <BarneInfoWrapper
@@ -42,39 +20,13 @@ const TilsynsutgifterBarnInfo: FC<{
             )}
             dødsdato={registergrunnlag.dødsdato}
         >
-            {harPassordning && (
-                <>
-                    <Informasjonsrad
-                        ikon={VilkårInfoIkon.SØKNAD}
-                        label={passordningTittel}
-                        verdi={barnepass?.barnepassordninger.map((ordning) => {
-                            return typeBarnepassordningTilTekst[ordning.type]; //TODO: Ta hensyn til at barn kan ha flere passordninger
-                        })}
-                    />
-                    <Informasjonsrad
-                        ikon={VilkårInfoIkon.SØKNAD}
-                        label="Navn passordning"
-                        verdi={barnepass?.barnepassordninger.map((ordning) => {
-                            return ordning.navn; //TODO: Ta hensyn til at barn kan ha flere passordninger
-                        })}
-                    />
-                    <Informasjonsrad
-                        ikon={VilkårInfoIkon.SØKNAD}
-                        label="Periode passordning"
-                        verdi={barnepass?.barnepassordninger.map((ordning) => {
-                            return `${formaterNullableIsoDato(
-                                ordning.fra
-                            )} - ${formaterNullableIsoDato(ordning.til)}`; //TODO: Ta hensyn til at barn kan ha flere passordninger
-                        })}
-                    />
-                    <Informasjonsrad
-                        ikon={VilkårInfoIkon.SØKNAD}
-                        label="Utgifter"
-                        verdi={barnepass?.barnepassordninger.map((ordning) => {
-                            return ordning.beløp + ',-'; //TODO: Ta hensyn til at barn kan ha flere passordninger
-                        })}
-                    />
-                </>
+            {!gjeldendeBarn.barnepass?.skalHaBarnepass ? (
+                <Informasjonsrad label="Ingen søknadsopplysninger" />
+            ) : (
+                harPassordning &&
+                barnepass.barnepassordninger.map((ordning) => (
+                    <Barnepassordning barnepassordning={ordning} />
+                ))
             )}
         </BarneInfoWrapper>
     );

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/OppsummeringAvBarn.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/OppsummeringAvBarn.tsx
@@ -19,13 +19,17 @@ const Container = styled.div`
     gap: 1rem;
     padding: 1rem;
     background-color: ${AGray50};
-    width: 26rem;
+    min-width: 26rem;
 `;
 
 const Grid = styled.div`
     display: grid;
-    grid-template-columns: repeat(2, max-content);
-    grid-gap: 0.75rem 1rem;
+    grid-template-columns: 14px repeat(2, max-content);
+    grid-gap: 0.5rem 1rem;
+
+    .label {
+        grid-column: 2;
+    }
 `;
 
 const Divider = styled.div`
@@ -86,45 +90,37 @@ export const OppsummeringAvBarn: React.FC<{
                     <BodyShortSmall>Ingen søknadsinformasjon</BodyShortSmall>
                 </FlexCenter>
             )}
-            {barnepassordninger.map((barnepassordning, index) => {
-                return (
-                    <React.Fragment key={index}>
-                        {søkesOmBarnetilsynForBarn ? (
-                            <Grid>
-                                <IkonOgTekstWrapper>
-                                    <Søknadsgrunnlag />
-                                    <Label size="small">Barnepassordning</Label>
-                                </IkonOgTekstWrapper>
-                                <Label size="small">
-                                    {typeBarnepassordningTilTekst[barnepassordning.type]}
-                                </Label>
-                                <IkonOgTekstWrapper>
-                                    <Søknadsgrunnlag />
-                                    <BodyShortSmall>Navn passordning</BodyShortSmall>
-                                </IkonOgTekstWrapper>
-                                <BodyShortSmall>{barnepassordning.navn}</BodyShortSmall>
-                                <IkonOgTekstWrapper>
-                                    <Søknadsgrunnlag />
-                                    <BodyShortSmall>Periode passordning</BodyShortSmall>
-                                </IkonOgTekstWrapper>
-                                <BodyShortSmall>
-                                    {formaterIsoDato(barnepassordning.fra)} -{' '}
-                                    {formaterIsoDato(barnepassordning.til)}
-                                </BodyShortSmall>
-                                <IkonOgTekstWrapper>
-                                    <Søknadsgrunnlag />
-                                    <BodyShortSmall>Utgifter per måned</BodyShortSmall>
-                                </IkonOgTekstWrapper>
-                                <BodyShortSmall>{barnepassordning.beløp},-</BodyShortSmall>
-                            </Grid>
-                        ) : (
-                            <FlexCenter>
-                                <BodyShortSmall>Ikke søkt</BodyShortSmall>
-                            </FlexCenter>
-                        )}
-                    </React.Fragment>
-                );
-            })}
+            {barnepassordninger.map((barnepassordning, index) => (
+                <React.Fragment key={index}>
+                    {søkesOmBarnetilsynForBarn ? (
+                        <Grid>
+                            <Søknadsgrunnlag />
+                            <Label size="small" className="label">
+                                Barnepassordning
+                            </Label>
+                            <Label size="small">
+                                {typeBarnepassordningTilTekst[barnepassordning.type]}
+                            </Label>
+
+                            <BodyShortSmall className="label">Navn passordning</BodyShortSmall>
+                            <BodyShortSmall>{barnepassordning.navn}</BodyShortSmall>
+
+                            <BodyShortSmall className="label">Periode passordning</BodyShortSmall>
+                            <BodyShortSmall>
+                                {formaterIsoDato(barnepassordning.fra)} -{' '}
+                                {formaterIsoDato(barnepassordning.til)}
+                            </BodyShortSmall>
+
+                            <BodyShortSmall className="label">Utgifter per måned</BodyShortSmall>
+                            <BodyShortSmall>{barnepassordning.beløp},-</BodyShortSmall>
+                        </Grid>
+                    ) : (
+                        <FlexCenter>
+                            <BodyShortSmall>Ikke søkt</BodyShortSmall>
+                        </FlexCenter>
+                    )}
+                </React.Fragment>
+            ))}
             <Divider />
             <FlexSpaceAround>
                 <IkonOgTekstWrapper>

--- a/src/frontend/Komponenter/Behandling/Vilkårpanel/Informasjonsrad.tsx
+++ b/src/frontend/Komponenter/Behandling/Vilkårpanel/Informasjonsrad.tsx
@@ -10,6 +10,7 @@ interface Props {
     label: string;
     verdi?: ReactNode;
     verdiSomString?: boolean;
+    boldLabel?: boolean;
 }
 
 const InformasjonsradContainer = styled.div<{ harVerdi: boolean }>`
@@ -22,13 +23,23 @@ const InformasjonsradContainer = styled.div<{ harVerdi: boolean }>`
     }
 `;
 
-const Informasjonsrad: FC<Props> = ({ ikon, label, verdi, verdiSomString = true }) => {
+const Informasjonsrad: FC<Props> = ({
+    ikon,
+    label,
+    verdi,
+    verdiSomString = true,
+    boldLabel = true,
+}) => {
     return (
         <InformasjonsradContainer harVerdi={!!verdi}>
             {ikon && mapIkon(ikon)}
-            <Label size="small" as="h3" className="label">
-                {label}
-            </Label>
+            {boldLabel ? (
+                <Label size="small" as="h3" className="label">
+                    {label}
+                </Label>
+            ) : (
+                <BodyShortSmall className="label">{label}</BodyShortSmall>
+            )}
             {verdiSomString ? <BodyShortSmall>{verdi}</BodyShortSmall> : verdi}
         </InformasjonsradContainer>
     );


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Hvis bruker sender inn flere barnepassordninger for ett barn legger dette seg etter hverandre i en seksjon, i stedet for å deles opp slik det gjøres i vedtak og beregning. [FAVRO](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-14330)

### Hva er gjort? 🤓 

- Laget egen komponent for informasjonen som skal vises for en barnepassordning. Denne kunne ikke gjenbrukes på vilkår og beregning fordi det ble for mye space mellom label og verdi i `Informasjonsrad`
- Oppdatert `InformasjonsRad` så det er mulig å ha labels som ikke er bold. 
- Fjernet ikonene for hver rad på vilkår og beregningssiden og litt rydding

### Bilder ✨ 

| Før      | Etter |
| ----------- | ----------- |
| ![image](https://github.com/navikt/familie-ef-sak-frontend/assets/46678893/5198e82f-e7be-4bd6-8d09-eb5023f228f1)|![image](https://github.com/navikt/familie-ef-sak-frontend/assets/46678893/3c3bf780-96d3-44b2-8a53-cfb4319d583e)|
| ![image](https://github.com/navikt/familie-ef-sak-frontend/assets/46678893/8cc37810-c564-4ddf-bf34-a9d5496209a2)|![image](https://github.com/navikt/familie-ef-sak-frontend/assets/46678893/95015caa-6bac-4648-bb81-1f295c0b2141) |

Vedtak og beregning med flere barnepassordninger: 
![image](https://github.com/navikt/familie-ef-sak-frontend/assets/46678893/76735a95-92c3-468a-880b-98cf1ffc729e)
