### PR TITLE
Skal fjerne avhukingen for feilregistrerte journalposter dersom man velger en annen journalpoststatus fra journalpoststatusvelgeren

### DIFF
--- a/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
@@ -103,9 +103,9 @@ const Dokumenter: React.FC<{ fagsakPerson: IFagsakPerson }> = ({ fagsakPerson })
             : !harFeilregistrerteEllerAvbrutte;
     };
 
-    const håndterEndreJournalpoststatus = () => {
+    const håndterOppdaterJournalpoststatus = (verdi: string) => {
         setVisFeilregistrerteOgAvbruttValgt(false);
-        return settVedlegg('journalpostStatus');
+        settVedlegg('journalpostStatus')(verdi);
     };
 
     return (
@@ -156,7 +156,7 @@ const Dokumenter: React.FC<{ fagsakPerson: IFagsakPerson }> = ({ fagsakPerson })
                     size={'medium'}
                 />
                 <CustomSelect
-                    onChange={håndterEndreJournalpoststatus}
+                    onChange={håndterOppdaterJournalpoststatus}
                     options={gyldigeJournalstatuserTilTekst}
                     label={'Velg journalpoststatus'}
                     hideLabel={true}

--- a/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
@@ -103,6 +103,11 @@ const Dokumenter: React.FC<{ fagsakPerson: IFagsakPerson }> = ({ fagsakPerson })
             : !harFeilregistrerteEllerAvbrutte;
     };
 
+    const håndterEndreJournalpoststatus = () => {
+        setVisFeilregistrerteOgAvbruttValgt(false);
+        return settVedlegg('journalpostStatus');
+    };
+
     return (
         <Container>
             <Heading size={'large'} level={'1'}>
@@ -151,7 +156,7 @@ const Dokumenter: React.FC<{ fagsakPerson: IFagsakPerson }> = ({ fagsakPerson })
                     size={'medium'}
                 />
                 <CustomSelect
-                    onChange={settVedlegg('journalpostStatus')}
+                    onChange={håndterEndreJournalpoststatus}
                     options={gyldigeJournalstatuserTilTekst}
                     label={'Velg journalpoststatus'}
                     hideLabel={true}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
I dag fungerer det ikke å bruke nedtrekslisten for journalpoststatus om man har huket av "Vis feilregistrete/avbrutte". Men denne endringen vil avhukingen fjernes når man velger en journalpoststatus i nedtreksslisten.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-14429)

### 🎥 
![Aug-15-2023 13-26-39](https://github.com/navikt/familie-ef-sak-frontend/assets/21220467/0008a47e-b977-4b25-b091-9d45a8a4927f)
