### PR TITLE
Feilmelding når gruppetilgang ikke kan hentes

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -35,6 +35,7 @@ import {
 import UlagretDataModal from './Felles/Visningskomponenter/UlagretDataModal';
 import { loggBesøkEvent } from './App/utils/amplitude/amplitudeLoggEvents';
 import { BesøkEvent } from './App/utils/amplitude/typer';
+import Innloggingsfeilmelding from './Felles/Varsel/Innloggingsfeilmelding';
 
 // @ts-ignore
 Modal.setAppElement(document.getElementById('modal-a11y-wrapper'));
@@ -152,6 +153,7 @@ const AppInnhold: React.FC<{ innloggetSaksbehandler: ISaksbehandler }> = ({
     return (
         <>
             <HeaderMedSøk innloggetSaksbehandler={innloggetSaksbehandler} />
+            <Innloggingsfeilmelding innloggetSaksbehandler={innloggetSaksbehandler} />
             <ScrollToTop />
             <Outlet />
             <Toast />

--- a/src/frontend/Felles/Varsel/Innloggingsfeilmelding.tsx
+++ b/src/frontend/Felles/Varsel/Innloggingsfeilmelding.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { ISaksbehandler } from '../../App/typer/saksbehandler';
+import { AlertError } from '../Visningskomponenter/Alerts';
+
+interface IProps {
+    innloggetSaksbehandler: ISaksbehandler;
+}
+
+const Innloggingsfeilmelding: React.FC<IProps> = ({ innloggetSaksbehandler }) => {
+    const { groups } = innloggetSaksbehandler;
+    if (groups && groups.length > 0) {
+        return undefined;
+    } else {
+        return (
+            <AlertError>
+                En feil har oppstått ved uthenting av tilgangene dine. Vennligst logg ut og logg inn
+                på nytt.
+            </AlertError>
+        );
+    }
+};
+
+export default Innloggingsfeilmelding;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal vise en feilmelding med info om å logge inn på nytt dersom vi ikke får hentet ut riktig gruppetilgang. Manglende gruppetilgang gjør at saksbehandler blir ansett som "Veileder" i deler av løsningen vår, noe som blir uheldig for arbeidshverdagen. Det er ikke intuitivt å skjønne at løsningen er å logge av/på. 

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-14498)

<img width="1784" alt="Skjermbilde 2023-08-21 kl  13 30 03" src="https://github.com/navikt/familie-ef-sak-frontend/assets/402915/e3d57ae5-84e7-4756-9033-e8b5acbefa41">