### PR TITLE
Fjerne maxLength for beskjed til lokalkontor når man setter en behand…

### DIFF
--- a/src/frontend/Komponenter/Behandling/SettPåVent/LokalkontorOppgavevalg.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/LokalkontorOppgavevalg.tsx
@@ -124,7 +124,6 @@ export const LokalkontorOppgavevalg: FC<Props> = ({
                                 <Textarea
                                     label={''}
                                     size={'small'}
-                                    maxLength={400}
                                     value={innstillingsoppgaveBeskjed}
                                     onChange={(e) => settInnstillingsoppgaveBeskjed(e.target.value)}
                                 />


### PR DESCRIPTION
…ling på vent

### Hvorfor er denne endringen nødvendig? ✨

Vi ønsker å fjerne "maxLength" på tekstfelt for beskjed til lokalkontor når man skal sette en oppgave på vent. Feltet ser nå sånn ut : 

<img width="854" alt="Screenshot 2023-08-22 at 15 07 59" src="https://github.com/navikt/familie-ef-sak-frontend/assets/56258085/d25fcb4b-96d2-4fa6-9734-401e315c802a">

Testet ok i preprod ✅ 

Favro : https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-13813

