### PR TITLE
Terminbarn uten registeropplysninger ble brukt i SøknadsgrunnlagNyttB…

### DIFF
--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/NyttBarnSammePartner/NyttBarnSammePartnerInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/NyttBarnSammePartner/NyttBarnSammePartnerInfo.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 import { IBarnMedSamvær } from '../Aleneomsorg/typer';
 import { mapTilRegistergrunnlagNyttBarn, mapTilSøknadsgrunnlagNyttBarn } from './utils';
 import RegistergrunnlagNyttBarn from './RegistergrunnlagNyttBarn';
-import SøknadgrunnlagNyttBarn from './SøknadsgrunnlagNyttBarn';
+import SøknadgrunnlagTerminbarn from './SøknadsgrunnlagTerminbarn';
 import TidligereVedtaksperioderSøkerOgAndreForeldre from './TidligereVedtaksperioderSøkerOgAndreForeldre';
 import { ITidligereVedtaksperioder } from '../../TidligereVedtaksperioder/typer';
 import { BodyShortSmall } from '../../../../Felles/Visningskomponenter/Tekster';
@@ -42,7 +42,7 @@ const NyttBarnSammePartnerInfo: FC<Props> = ({
             <UnderseksjonWrapper underoverskrift="Brukers fremtidige barn lagt til i søknad">
                 {søknadsgrunnlagNyttBarn.length ? (
                     søknadsgrunnlagNyttBarn.map((barn) => (
-                        <SøknadgrunnlagNyttBarn key={barn.barnId} barn={barn} />
+                        <SøknadgrunnlagTerminbarn key={barn.barnId} barn={barn} />
                     ))
                 ) : (
                     <BodyShortSmall>

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/NyttBarnSammePartner/SøknadsgrunnlagTerminbarn.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/NyttBarnSammePartner/SøknadsgrunnlagTerminbarn.tsx
@@ -14,11 +14,8 @@ interface Props {
     barn: SøknadsgrunnlagNyttBarn;
 }
 
-const SøknadgrunnlagNyttBarn: FC<Props> = ({ barn }) => {
-    const annenForelder =
-        barn.annenForelderRegister && barn.annenForelderSoknad
-            ? barn.annenForelderRegister
-            : barn.annenForelderSoknad;
+const SøknadgrunnlagTerminbarn: FC<Props> = ({ barn }) => {
+    const annenForelder = barn.annenForelderSoknad;
 
     const ikkeOppgittAnnenForelderBegrunnelse = barn.ikkeOppgittAnnenForelderBegrunnelse;
 
@@ -57,4 +54,4 @@ const SøknadgrunnlagNyttBarn: FC<Props> = ({ barn }) => {
     );
 };
 
-export default SøknadgrunnlagNyttBarn;
+export default SøknadgrunnlagTerminbarn;


### PR DESCRIPTION
…arn - følgelig vil det kun være søknadsdata om annen forelder for dette barnet. Renamer komponenten til å entydig presisere at dette er snakk om terminbarn

### Hvorfor er denne endringen nødvendig? ✨
Teknisk gjeld 

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-9501)
