### PR TITLE
Skal kunne opprette ny behandling ved journalføring av ettersending

### DIFF
--- a/src/frontend/App/hooks/useJournalføringState.ts
+++ b/src/frontend/App/hooks/useJournalføringState.ts
@@ -39,8 +39,6 @@ export interface JournalføringStateRequest {
     fullførJournalføring: () => void;
     visBekreftelsesModal: boolean;
     settVisBekreftelsesModal: Dispatch<SetStateAction<boolean>>;
-    visJournalføringIkkeMuligModal: boolean;
-    settJournalføringIkkeMuligModal: Dispatch<SetStateAction<boolean>>;
     barnSomSkalFødes: BarnSomSkalFødes[];
     settBarnSomSkalFødes: Dispatch<SetStateAction<BarnSomSkalFødes[]>>;
     ustrukturertDokumentasjonType: UstrukturertDokumentasjonType | undefined;
@@ -59,8 +57,6 @@ export const useJournalføringState = (
     const [dokumentTitler, settDokumentTitler] = useState<DokumentTitler>();
     const [innsending, settInnsending] = useState<Ressurs<string>>(byggTomRessurs());
     const [visBekreftelsesModal, settVisBekreftelsesModal] = useState<boolean>(false);
-    const [visJournalføringIkkeMuligModal, settJournalføringIkkeMuligModal] =
-        useState<boolean>(false);
     const [barnSomSkalFødes, settBarnSomSkalFødes] = useState<BarnSomSkalFødes[]>([]);
     const [ustrukturertDokumentasjonType, settUstrukturertDokumentasjonType] =
         useState<UstrukturertDokumentasjonType>(UstrukturertDokumentasjonType.IKKE_VALGT);
@@ -111,8 +107,6 @@ export const useJournalføringState = (
         fullførJournalføring,
         visBekreftelsesModal,
         settVisBekreftelsesModal,
-        visJournalføringIkkeMuligModal,
-        settJournalføringIkkeMuligModal,
         barnSomSkalFødes,
         settBarnSomSkalFødes,
         ustrukturertDokumentasjonType,

--- a/src/frontend/Komponenter/Journalføring/JournalføringApp.tsx
+++ b/src/frontend/Komponenter/Journalføring/JournalføringApp.tsx
@@ -171,11 +171,8 @@ const JournalføringAppContent: React.FC<JournalføringAppProps> = ({
             return !erNyBehandling;
         } else if (ustrukturertDokumentasjonType === UstrukturertDokumentasjonType.PAPIRSØKNAD) {
             return !erNyBehandling;
-        } else if (ustrukturertDokumentasjonType === UstrukturertDokumentasjonType.ETTERSENDING) {
-            return erNyBehandling;
         } else {
-            // Skal egentlige ikke komme hit pga validerJournalføringState
-            return erNyBehandling;
+            return false;
         }
     };
 
@@ -321,7 +318,6 @@ const JournalføringAppContent: React.FC<JournalføringAppProps> = ({
             <JournalføringIkkeMuligModal
                 visModal={journalpostState.visJournalføringIkkeMuligModal}
                 settVisModal={journalpostState.settJournalføringIkkeMuligModal}
-                erPapirSøknad={erPapirsøknad}
             />
         </>
     );
@@ -330,29 +326,18 @@ const JournalføringAppContent: React.FC<JournalføringAppProps> = ({
 const JournalføringIkkeMuligModal: React.FC<{
     visModal: boolean;
     settVisModal: Dispatch<SetStateAction<boolean>>;
-    erPapirSøknad: boolean;
-}> = ({ visModal, settVisModal, erPapirSøknad }) => {
+}> = ({ visModal, settVisModal }) => {
     return (
         <ModalWrapper
             tittel={'Journalføring ikke mulig'}
             visModal={visModal}
             onClose={() => settVisModal(false)}
         >
-            {erPapirSøknad ? (
-                <BodyLong>
-                    Foreløpig er det dessverre ikke mulig å journalføre på en eksisterende
-                    behandling via journalføringsbildet når det ikke er tilknyttet en digital søknad
-                    til journalposten.
-                </BodyLong>
-            ) : (
-                <BodyLong>
-                    Foreløpig er det dessverre ikke mulig å opprette en ny behandling via
-                    journalføringsbildet når det ikke er tilknyttet en digital søknad til
-                    journalposten. Gå inntil videre inn i behandlingsoversikten til bruker og
-                    opprett ny behandling derifra. Deretter kan du journalføre mot den nye
-                    behandlingen.
-                </BodyLong>
-            )}
+            <BodyLong>
+                Foreløpig er det dessverre ikke mulig å journalføre på en eksisterende behandling
+                via journalføringsbildet når det ikke er tilknyttet en digital søknad til
+                journalposten.
+            </BodyLong>
             <ModalKnapp variant={'tertiary'} onClick={() => settVisModal(false)}>
                 Tilbake
             </ModalKnapp>

--- a/src/frontend/Komponenter/Journalføring/JournalføringApp.tsx
+++ b/src/frontend/Komponenter/Journalføring/JournalføringApp.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { erAvTypeFeil, RessursStatus } from '../../App/typer/ressurs';
 import styled from 'styled-components';
@@ -44,11 +44,6 @@ import JournalføringPdfVisning from './JournalføringPdfVisning';
 import JournalpostTittelOgLenke from './JournalpostTittelOgLenke';
 import { ÅpneKlager } from '../Personoversikt/Klage/ÅpneKlager';
 import { alleBehandlingerErFerdigstiltEllerSattPåVent } from '../Personoversikt/utils';
-
-const ModalKnapp = styled(Button)`
-    margin-bottom: 1rem;
-    float: right;
-`;
 
 const ModalTekst = styled(BodyLong)`
     margin-top: 2rem;
@@ -162,15 +157,9 @@ const JournalføringAppContent: React.FC<JournalføringAppProps> = ({
         // eslint-disable-next-line
     }, [fagsak]);
 
-    const skalBeOmBekreftelse = (
-        erNyBehandling: boolean,
-        harStrukturertSøknad: boolean,
-        ustrukturertDokumentasjonType: UstrukturertDokumentasjonType | undefined
-    ) => {
-        if (harStrukturertSøknad) {
-            return !erNyBehandling;
-        } else if (ustrukturertDokumentasjonType === UstrukturertDokumentasjonType.PAPIRSØKNAD) {
-            return !erNyBehandling;
+    const skalBeOmBekreftelse = (erNyBehandling: boolean) => {
+        if (!erNyBehandling) {
+            return journalResponse.harStrukturertSøknad || erPapirsøknad;
         } else {
             return false;
         }
@@ -211,18 +200,8 @@ const JournalføringAppContent: React.FC<JournalføringAppProps> = ({
         );
         if (feilmeldingFraValidering) {
             settFeilMeldning(feilmeldingFraValidering);
-        } else if (
-            skalBeOmBekreftelse(
-                harValgtNyBehandling(journalpostState.behandling),
-                journalResponse.harStrukturertSøknad,
-                journalpostState.ustrukturertDokumentasjonType
-            )
-        ) {
-            if (journalResponse.harStrukturertSøknad) {
-                journalpostState.settVisBekreftelsesModal(true);
-            } else if (!journalResponse.harStrukturertSøknad) {
-                journalpostState.settJournalføringIkkeMuligModal(true);
-            }
+        } else if (skalBeOmBekreftelse(harValgtNyBehandling(journalpostState.behandling))) {
+            journalpostState.settVisBekreftelsesModal(true);
         } else {
             journalpostState.fullførJournalføring();
         }
@@ -315,33 +294,7 @@ const JournalføringAppContent: React.FC<JournalføringAppProps> = ({
                 </Høyrekolonne>
             </Kolonner>
             <BekreftJournalføringModal journalpostState={journalpostState} />
-            <JournalføringIkkeMuligModal
-                visModal={journalpostState.visJournalføringIkkeMuligModal}
-                settVisModal={journalpostState.settJournalføringIkkeMuligModal}
-            />
         </>
-    );
-};
-
-const JournalføringIkkeMuligModal: React.FC<{
-    visModal: boolean;
-    settVisModal: Dispatch<SetStateAction<boolean>>;
-}> = ({ visModal, settVisModal }) => {
-    return (
-        <ModalWrapper
-            tittel={'Journalføring ikke mulig'}
-            visModal={visModal}
-            onClose={() => settVisModal(false)}
-        >
-            <BodyLong>
-                Foreløpig er det dessverre ikke mulig å journalføre på en eksisterende behandling
-                via journalføringsbildet når det ikke er tilknyttet en digital søknad til
-                journalposten.
-            </BodyLong>
-            <ModalKnapp variant={'tertiary'} onClick={() => settVisModal(false)}>
-                Tilbake
-            </ModalKnapp>
-        </ModalWrapper>
     );
 };
 
@@ -369,8 +322,8 @@ const BekreftJournalføringModal: React.FC<{
             ariaLabel={'Bekreft journalføring av oppgave, eller avbryt'}
         >
             <ModalTekst>
-                Behandlingen du har valgt har allerede en digital søknad tilknyttet seg. Om du skal
-                gjennomføre en ny saksbehandling av søknaden må du opprette en ny behandling.
+                Journalposten har en søknad tilknyttet seg. Er du sikker på at du vil journalføre
+                uten å lage en ny behandling?
             </ModalTekst>
         </ModalWrapper>
     );


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Saksbehandler skal ha mulighet til å opprette en ny behandling dersom det er en ettersending som skal journalføres.

Dette trodde vi at fungerte, men ble skrudd av for et år siden pga bugs. Disse feilene antas å være rettet i mellomtiden, for nå fungerer det bra.
Må testes igjennom og verifiseres
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-14609)
