### PR TITLE
Ikke relast iframe unødig

### DIFF
--- a/src/frontend/Komponenter/Journalføring/JournalføringPdfVisning.tsx
+++ b/src/frontend/Komponenter/Journalføring/JournalføringPdfVisning.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useMemo } from 'react';
 import { HentDokumentResponse } from '../../App/hooks/useHentDokument';
 import styled from 'styled-components';
 import DataViewer from '../../Felles/DataViewer/DataViewer';
@@ -17,8 +17,8 @@ const JournalføringPdfVisning: React.FC<{ hentDokumentResponse: HentDokumentRes
         hentFørsteDokument();
     }, [hentFørsteDokument]);
 
-    return (
-        <Container>
+    const dokumentMemo = useMemo(() => {
+        return (
             <DataViewer response={{ valgtDokument }}>
                 {({ valgtDokument }) => {
                     const blob = base64toBlob(valgtDokument, 'application/pdf');
@@ -29,8 +29,9 @@ const JournalføringPdfVisning: React.FC<{ hentDokumentResponse: HentDokumentRes
                     );
                 }}
             </DataViewer>
-        </Container>
-    );
+        );
+    }, [valgtDokument]);
+    return <Container>{dokumentMemo}</Container>;
 };
 
 export default JournalføringPdfVisning;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal ikke relaste iframe-dokumentvisning hver eneste gang en state eller prop endrer seg i journalføringsbildet - kun når man har valgt et annet dokument

Før:
https://www.awesomescreenshot.com/video/20197504?key=77e2c37df500e40619c5775d4e7b4c42

Etter:
https://www.awesomescreenshot.com/video/20197558?key=a1ef679f164c3398e56cf33b3dcdcedb