### PR TITLE
bugfix: Skal vise tidligere adresse først og deretter ny adresse ved …

### DIFF
--- a/src/frontend/Komponenter/Behandling/Endring/EndringPersonopplysninger.tsx
+++ b/src/frontend/Komponenter/Behandling/Endring/EndringPersonopplysninger.tsx
@@ -25,7 +25,7 @@ const OppdaterGrunnlagKnapp = styled(Button)`
 
 const skalViseDetaljer = (ny: string, tidligere: string) => tidligere != '' || ny != '';
 
-const visEndringsdetaljer = (ny: string, tidligere: string) =>
+const visEndringsdetaljer = (tidligere: string, ny: string) =>
     skalViseDetaljer(tidligere, ny) && (
         <>
             - <strong>Tidligere:</strong> {tidligere} <strong>Ny:</strong> {ny}


### PR DESCRIPTION
…endringer i personopplysninger

### Hvorfor er denne endringen nødvendig? ✨
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-14624)

Vi har hatt en visningbug ved visning av oppdaterte personopplysninger. Gammel opplysning har blitt vist som ny og ny har blitt vist som gammel. Dette gjelder kun for personopplysninger-komponenten. Visning av personopplysninger ellers i løsningen blir vist korrekt.

Før:
![Skjermbilde 2023-08-28 kl  13 59 46](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/3d062b30-c1da-4e00-b868-b4bf0b9591ff)

Etter:
![Skjermbilde 2023-08-28 kl  13 59 24](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/1dd7478b-fddd-4b70-ab06-373dd744ff82)
