### PR TITLE
fjerner toggle for visVurderHenvendelseOppgaver som ble påskrudd i pr…

### DIFF
--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -13,6 +13,5 @@ export enum ToggleName {
     visSatsendring = 'familie.ef.sak.frontend-vis-satsendring',
     visInntektPersonoversikt = 'familie.ef.sak.frontend.vis-inntekt-personoversikt',
     årsakRevurderingBeskrivelse = 'familie.ef.sak.arsak-revurdering-beskrivelse',
-    visVurderHenvendelseOppgaver = 'familie.ef.sak.automatiske-oppgaver-lokalkontor',
     fremleggsoppgave = 'familie.ef.sak.automatiske-oppgaver.fremleggsoppgave',
 }

--- a/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVent.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/SettPåVent.tsx
@@ -11,8 +11,6 @@ import { useApp } from '../../../App/context/AppContext';
 import { Alert, Button, Heading, Textarea } from '@navikt/ds-react';
 import styled from 'styled-components';
 import { ADeepblue50 } from '@navikt/ds-tokens/dist/tokens';
-import { ToggleName } from '../../../App/context/toggles';
-import { useToggles } from '../../../App/context/TogglesContext';
 import { IOppgave } from '../../Oppgavebenk/typer/oppgave';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { Prioritet } from '../../Oppgavebenk/typer/oppgavetema';
@@ -89,7 +87,6 @@ export const SettPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
     const erOvergangsstønadEllerSkolepenger =
         erOvergangsstønad || behandling.stønadstype === Stønadstype.SKOLEPENGER;
     const { visSettPåVent, settVisSettPåVent, hentBehandling } = useBehandling();
-    const { toggles } = useToggles();
     const { axiosRequest, settToast, innloggetSaksbehandler } = useApp();
 
     const [oppgave, settOppgave] = useState<Ressurs<IOppgave>>(byggTomRessurs<IOppgave>());
@@ -300,20 +297,17 @@ export const SettPåVent: FC<{ behandling: Behandling }> = ({ behandling }) => {
                                     onChange={(e) => settBeskrivelse(e.target.value)}
                                 />
                             )}
-                            {toggles[ToggleName.visVurderHenvendelseOppgaver] &&
-                                erOvergangsstønadEllerSkolepenger && (
-                                    <LokalkontorOppgavevalg
-                                        aktuelleOppgaver={aktuelleOppgaver}
-                                        sendteOppgaver={sendteOppgaver}
-                                        settOppgaverMotLokalkontor={settOppgaverMotLokalkontor}
-                                        oppgaverMotLokalkontor={oppgaverMotLokalkontor}
-                                        erBehandlingPåVent={erBehandlingPåVent}
-                                        settInnstillingsoppgaveBeskjed={
-                                            settInnstillingsoppgaveBeskjed
-                                        }
-                                        innstillingsoppgaveBeskjed={innstillingsoppgaveBeskjed}
-                                    />
-                                )}
+                            {erOvergangsstønadEllerSkolepenger && (
+                                <LokalkontorOppgavevalg
+                                    aktuelleOppgaver={aktuelleOppgaver}
+                                    sendteOppgaver={sendteOppgaver}
+                                    settOppgaverMotLokalkontor={settOppgaverMotLokalkontor}
+                                    oppgaverMotLokalkontor={oppgaverMotLokalkontor}
+                                    erBehandlingPåVent={erBehandlingPåVent}
+                                    settInnstillingsoppgaveBeskjed={settInnstillingsoppgaveBeskjed}
+                                    innstillingsoppgaveBeskjed={innstillingsoppgaveBeskjed}
+                                />
+                            )}
                         </FlexColumnDiv>
                         <KnappeWrapper>
                             {!erBehandlingPåVent && (


### PR DESCRIPTION
…od 04.05. og har stått urørt siden

### Hvorfor er denne endringen nødvendig? ✨
Feature-toggelen `familie.ef.sak.automatiske-oppgaver-lokalkontor` har stått ubrukt siden jeg aktiverte den i prod 04.05. Tillater meg derfor å fjerne den fra koden nå, deaktiverer den Unleash senere.

[Unleash-toggle](https://unleash.nais.io/#/features/history/familie.ef.sak.automatiske-oppgaver-lokalkontor)

Backend-PR:
* https://github.com/navikt/familie-ef-sak/pull/2367