### PR TITLE
Fjerne eldre feature toggles

### DIFF
--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -12,5 +12,4 @@ export enum ToggleName {
     visAutomatiskUtfylleVilkår = 'familie.ef.sak.frontend-automatisk-utfylle-vilkar', // Miljø-toggle
     visSatsendring = 'familie.ef.sak.frontend-vis-satsendring',
     visInntektPersonoversikt = 'familie.ef.sak.frontend.vis-inntekt-personoversikt',
-    fremleggsoppgave = 'familie.ef.sak.automatiske-oppgaver.fremleggsoppgave',
 }

--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -3,13 +3,16 @@ export interface Toggles {
 }
 
 export enum ToggleName {
-    visValgmulighetForKorrigering = 'familie.ef.sak.behandling-korrigering', // Permission-toggle
-
-    visIkkePubliserteBrevmaler = 'familie.ef.sak.frontend-vis-ikke-publiserte-brevmaler', // Miljø-toggle
-    kanMigrereFagsak = 'familie.ef.sak.migrering',
+    // Permission-toggles - la stå
+    visValgmulighetForKorrigering = 'familie.ef.sak.behandling-korrigering',
+    opprettBehandlingForFerdigstiltJournalpost = 'familie.ef.sak.opprett-behandling-for-ferdigstilt-journalpost',
     kanMigrereBarnetilsyn = 'familie.ef.sak.migrering.barnetilsyn',
-    opprettBehandlingForFerdigstiltJournalpost = 'familie.ef.sak.opprett-behandling-for-ferdigstilt-journalpost', // Permission-toggle
-    visAutomatiskUtfylleVilkår = 'familie.ef.sak.frontend-automatisk-utfylle-vilkar', // Miljø-toggle
+
+    // Miljø-toggles - la stå
+    visIkkePubliserteBrevmaler = 'familie.ef.sak.frontend-vis-ikke-publiserte-brevmaler',
+    visAutomatiskUtfylleVilkår = 'familie.ef.sak.frontend-automatisk-utfylle-vilkar',
+
+    // Midlertidige toggles - kan fjernes etterhvert
     visSatsendring = 'familie.ef.sak.frontend-vis-satsendring',
     visInntektPersonoversikt = 'familie.ef.sak.frontend.vis-inntekt-personoversikt',
 }

--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -12,6 +12,5 @@ export enum ToggleName {
     visAutomatiskUtfylleVilkår = 'familie.ef.sak.frontend-automatisk-utfylle-vilkar', // Miljø-toggle
     visSatsendring = 'familie.ef.sak.frontend-vis-satsendring',
     visInntektPersonoversikt = 'familie.ef.sak.frontend.vis-inntekt-personoversikt',
-    årsakRevurderingBeskrivelse = 'familie.ef.sak.arsak-revurdering-beskrivelse',
     fremleggsoppgave = 'familie.ef.sak.automatiske-oppgaver.fremleggsoppgave',
 }

--- a/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brev.tsx
@@ -14,8 +14,6 @@ import { skalFerdigstilleUtenBeslutter } from '../VedtakOgBeregning/Felles/utils
 import { useHentOppgaverForOpprettelse } from '../../../App/hooks/useHentOppgaverForOpprettelse';
 import { AlertInfo } from '../../../Felles/Visningskomponenter/Alerts';
 import { oppgaveSomSkalOpprettesTilTekst } from '../Totrinnskontroll/oppgaveForOpprettelseTyper';
-import { ToggleName } from '../../../App/context/toggles';
-import { useToggles } from '../../../App/context/TogglesContext';
 import { HøyreKolonne, StyledBrev, VenstreKolonne } from './StyledBrev';
 
 const InfostripeGruppe = styled.div`
@@ -42,8 +40,6 @@ const Brev: React.FC<Props> = ({ behandlingId }) => {
     const [kanSendesTilBeslutter, settKanSendesTilBeslutter] = useState<boolean>(false);
     const { hentVedtak, vedtak } = useHentVedtak(behandlingId);
     const oppgaverForOpprettelse = useHentOppgaverForOpprettelse(behandlingId);
-
-    const { toggles } = useToggles();
 
     useEffect(() => {
         hentVedtak();
@@ -92,7 +88,7 @@ const Brev: React.FC<Props> = ({ behandlingId }) => {
                                 behandlingId={behandling.id}
                                 personopplysninger={personopplysningerResponse}
                             />
-                            {!behandlingErRedigerbar && toggles[ToggleName.fremleggsoppgave] && (
+                            {!behandlingErRedigerbar && (
                                 <InfostripeGruppe>
                                     {oppgaverForOpprettelse.oppgavetyperSomSkalOpprettes.map(
                                         (oppgaveType) => (

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutterFooter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutterFooter.tsx
@@ -14,8 +14,6 @@ import OppgaverForOpprettelse from './OppgaverForOpprettelse';
 import { Behandling } from '../../../App/typer/fagsak';
 import { IOppgaverForOpprettelse } from '../../../App/hooks/useHentOppgaverForOpprettelse';
 import { OppgaveTypeForOpprettelse } from './oppgaveForOpprettelseTyper';
-import { useToggles } from '../../../App/context/TogglesContext';
-import { ToggleName } from '../../../App/context/toggles';
 
 const Footer = styled.footer`
     width: 100%;
@@ -65,7 +63,6 @@ const SendTilBeslutterFooter: React.FC<{
     const [feilmelding, settFeilmelding] = useState<string>();
     const [visModal, settVisModal] = useState<boolean>(false);
     const behandlingId = behandling.id;
-    const { toggles } = useToggles();
     const sendTilBeslutter = () => {
         settLaster(true);
         settFeilmelding(undefined);
@@ -73,10 +70,9 @@ const SendTilBeslutterFooter: React.FC<{
             method: 'POST',
             url: `/familie-ef-sak/api/vedtak/${behandlingId}/send-til-beslutter`,
             data: {
-                oppgavetyperSomSkalOpprettes:
-                    oppgaverForOpprettelse && toggles[ToggleName.fremleggsoppgave]
-                        ? oppgaverForOpprettelse.oppgavetyperSomSkalOpprettes
-                        : [],
+                oppgavetyperSomSkalOpprettes: oppgaverForOpprettelse
+                    ? oppgaverForOpprettelse.oppgavetyperSomSkalOpprettes
+                    : [],
             },
         })
             .then((res: RessursSuksess<string> | RessursFeilet) => {
@@ -113,7 +109,7 @@ const SendTilBeslutterFooter: React.FC<{
                         <AlertInfo>Vedtaket vil ikke bli sendt til totrinnskontroll</AlertInfo>
                     )}
                     <FlexBox>
-                        {oppgaverForOpprettelse && toggles[ToggleName.fremleggsoppgave] && (
+                        {oppgaverForOpprettelse && (
                             <OppgaverForOpprettelse
                                 behandling={behandling}
                                 oppgaverForOpprettelse={oppgaverForOpprettelse}

--- a/src/frontend/Komponenter/Behandling/ÅrsakRevurdering/EndreÅrsakRevurdering.tsx
+++ b/src/frontend/Komponenter/Behandling/ÅrsakRevurdering/EndreÅrsakRevurdering.tsx
@@ -17,8 +17,6 @@ import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../App/typer
 import { EnsligErrorMessage } from '../../../Felles/ErrorMessage/EnsligErrorMessage';
 import styled from 'styled-components';
 import { erGyldigDato } from '../../../App/utils/dato';
-import { useToggles } from '../../../App/context/TogglesContext';
-import { ToggleName } from '../../../App/context/toggles';
 
 const Container = styled.div`
     > * {
@@ -42,8 +40,6 @@ export const EndreÅrsakRevurdering: React.FC<Props> = ({
     const { axiosRequest, nullstillIkkePersisterteKomponenter, settIkkePersistertKomponent } =
         useApp();
     const { behandlingErRedigerbar, hentBehandling } = useBehandling();
-
-    const { toggles } = useToggles();
 
     const [revurderingsinformasjon, settRevurderingsinformasjon] =
         useState<Revurderingsinformasjon>(initStateRevurderingsinformasjon);
@@ -149,9 +145,6 @@ export const EndreÅrsakRevurdering: React.FC<Props> = ({
                 onChange={(e) =>
                     oppdaterÅrsakRevurdering({
                         årsak: e.target.value as Årsak,
-                        ...(toggles[ToggleName.årsakRevurderingBeskrivelse]
-                            ? {}
-                            : { beskrivelse: undefined }),
                     })
                 }
             >
@@ -162,18 +155,15 @@ export const EndreÅrsakRevurdering: React.FC<Props> = ({
                     </option>
                 ))}
             </Select>
-            {(årsakRevurdering?.årsak === Årsak.ANNET ||
-                toggles[ToggleName.årsakRevurderingBeskrivelse]) && (
-                <Textarea
-                    label={labelBeskrivelse}
-                    value={beskrivelse}
-                    onChange={(e) =>
-                        oppdaterÅrsakRevurdering({
-                            beskrivelse: e.target.value,
-                        })
-                    }
-                />
-            )}
+            <Textarea
+                label={labelBeskrivelse}
+                value={beskrivelse}
+                onChange={(e) =>
+                    oppdaterÅrsakRevurdering({
+                        beskrivelse: e.target.value,
+                    })
+                }
+            />
             <EnsligErrorMessage>{feilmelding}</EnsligErrorMessage>
             <Button variant={'primary'} onClick={lagreRevurderingsinformasjon} disabled={laster}>
                 Lagre

--- a/src/frontend/Komponenter/Migrering/MigrerFagsak.tsx
+++ b/src/frontend/Komponenter/Migrering/MigrerFagsak.tsx
@@ -17,8 +17,6 @@ import {
     nullableBooleanTilTekst,
 } from '../../App/utils/formatter';
 import Utregningstabell from '../Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/Utregningstabell';
-import { useToggles } from '../../App/context/TogglesContext';
-import { ToggleName } from '../../App/context/toggles';
 import { IFagsakPerson } from '../../App/typer/fagsak';
 import styled from 'styled-components';
 import { Button, Checkbox, CheckboxGroup } from '@navikt/ds-react';
@@ -102,7 +100,6 @@ const MigrerFagsak: React.FC<{
     fagsakPerson: IFagsakPerson;
 }> = ({ fagsakPerson }) => {
     const { axiosRequest } = useApp();
-    const { toggles } = useToggles();
     const [migreringInfo, settMigreringInfo] = useState<Ressurs<MigreringInfoResponse>>(
         byggTomRessurs()
     );
@@ -118,10 +115,6 @@ const MigrerFagsak: React.FC<{
         }),
         [fagsakPersonId]
     );
-
-    if (!toggles[ToggleName.kanMigrereFagsak]) {
-        return null;
-    }
 
     const hentMigreringInfo = () => {
         settMigrertStatus(byggTomRessurs());


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Fjerner feature-toggles som ikke lenger har noen nytteverdi:
* `familie.ef.sak.arsak-revurdering-beskrivelse`
* `familie.ef.sak.automatiske-oppgaver.fremleggsoppgave`
* `familie.ef.sak.migrering`

Årsak til revurdering ble merget av meg i forrige uke og var kun nødvendig for å teste i løpet av utviklingsprosessen.
Fremleggsoppgaver ble implementert av Trond og har stått aktivert i prod siden 15.05.
Migrering har vært urørt siden juni i fjor.

Unleash-toggles:
* https://unleash.nais.io/#/features/history/familie.ef.sak.arsak-revurdering-beskrivelse
* https://unleash.nais.io/#/features/history/familie.ef.sak.automatiske-oppgaver.fremleggsoppgave
* https://unleash.nais.io/#/features/strategies/familie.ef.sak.migrering

Backend:
* https://github.com/navikt/familie-ef-sak/pull/2368