### PR TITLE
Journalføre - ny behandling hvis satt på vent

### DIFF
--- a/src/frontend/Komponenter/Journalføring/Behandling.tsx
+++ b/src/frontend/Komponenter/Journalføring/Behandling.tsx
@@ -48,6 +48,7 @@ const BehandlingInnold: React.FC<Props> = ({
 
     const håndterCheck = (behandlingsId: string) => {
         return (e: React.ChangeEvent<HTMLInputElement>) => {
+            settFeilmelding('');
             if (e.target.checked) {
                 if (behandlingsId === 'ny') {
                     settBehandling({
@@ -80,7 +81,7 @@ const BehandlingInnold: React.FC<Props> = ({
                 });
             } else {
                 settFeilmelding(
-                    'Kan ikke opprette ny behandling på fagsak med en behandling som ikke er ferdigstilt'
+                    'Kan ikke opprette ny behandling. Det finnes en behandling som ikke er ferdigstilt.'
                 );
             }
         } else {

--- a/src/frontend/Komponenter/Journalføring/EttersendingMedNyeBarn.tsx
+++ b/src/frontend/Komponenter/Journalføring/EttersendingMedNyeBarn.tsx
@@ -12,11 +12,10 @@ import { EVilkårsbehandleBarnValg } from '../../App/typer/vilkårsbehandleBarnV
 import DataViewer from '../../Felles/DataViewer/DataViewer';
 import { NyeBarn } from '../../Felles/NyeBarn/NyeBarn';
 import { Fagsak } from '../../App/typer/fagsak';
-import { BehandlingStatus } from '../../App/typer/behandlingstatus';
+import { alleBehandlingerErFerdigstiltEllerSattPåVent } from '../Personoversikt/utils';
 
-const harBehandlingOgAlleErFerdigstilte = (fagsak: Fagsak) =>
-    fagsak.behandlinger.length > 0 &&
-    fagsak.behandlinger.every((b) => b.status === BehandlingStatus.FERDIGSTILT);
+const harBehandlingOgAlleErFerdigstilteEllerSattPåVent = (fagsak: Fagsak) =>
+    fagsak.behandlinger.length > 0 && alleBehandlingerErFerdigstiltEllerSattPåVent(fagsak);
 
 const EttersendingMedNyeBarn: React.FC<{
     fagsak: Fagsak;
@@ -30,7 +29,7 @@ const EttersendingMedNyeBarn: React.FC<{
     >(byggTomRessurs());
 
     useEffect(() => {
-        if (harBehandlingOgAlleErFerdigstilte(fagsak)) {
+        if (harBehandlingOgAlleErFerdigstilteEllerSattPåVent(fagsak)) {
             axiosRequest<NyeBarnSidenForrigeBehandling, null>({
                 url: `familie-ef-sak/api/behandling/barn/fagsak/${fagsak.id}`,
             }).then((response: RessursSuksess<NyeBarnSidenForrigeBehandling> | RessursFeilet) => {

--- a/src/frontend/Komponenter/Journalføring/JournalføringApp.tsx
+++ b/src/frontend/Komponenter/Journalføring/JournalføringApp.tsx
@@ -133,7 +133,7 @@ const JournalføringAppContent: React.FC<JournalføringAppProps> = ({
     const hentDokumentResponse = useHentDokument(journalResponse.journalpost);
 
     const { hentFagsak, fagsak } = useHentFagsak();
-    const [feilmelding, settFeilMeldning] = useState('');
+    const [feilmelding, settFeilmelding] = useState('');
 
     useEffect(() => {
         if (journalpostState.innsending.status === RessursStatus.SUKSESS) {
@@ -153,7 +153,7 @@ const JournalføringAppContent: React.FC<JournalføringAppProps> = ({
     useEffect(() => {
         if (fagsak.status === RessursStatus.SUKSESS) {
             journalpostState.settFagsakId(fagsak.data.id);
-            settFeilMeldning('');
+            settFeilmelding('');
         }
         // eslint-disable-next-line
     }, [fagsak]);
@@ -190,9 +190,9 @@ const JournalføringAppContent: React.FC<JournalføringAppProps> = ({
         UstrukturertDokumentasjonType.PAPIRSØKNAD;
 
     const journalFør = () => {
-        settFeilMeldning('');
+        settFeilmelding('');
         if (fagsak.status !== RessursStatus.SUKSESS) {
-            settFeilMeldning('Henting av fagsak feilet, relast siden');
+            settFeilmelding('Henting av fagsak feilet, relast siden');
             return;
         }
         const feilmeldingFraValidering = validerJournalføringState(
@@ -201,7 +201,7 @@ const JournalføringAppContent: React.FC<JournalføringAppProps> = ({
             alleBehandlingerErFerdigstiltEllerSattPåVent(fagsak.data)
         );
         if (feilmeldingFraValidering) {
-            settFeilMeldning(feilmeldingFraValidering);
+            settFeilmelding(feilmeldingFraValidering);
         } else if (skalBeOmBekreftelse(harValgtNyBehandling(journalpostState.behandling))) {
             journalpostState.settVisBekreftelsesModal(true);
         } else {
@@ -262,7 +262,7 @@ const JournalføringAppContent: React.FC<JournalføringAppProps> = ({
                             settBehandling={journalpostState.settBehandling}
                             behandling={journalpostState.behandling}
                             fagsak={fagsak}
-                            settFeilmelding={settFeilMeldning}
+                            settFeilmelding={settFeilmelding}
                         />
                         {kanLeggeTilBarnSomSkalFødes() && (
                             <LeggTilBarnSomSkalFødes

--- a/src/frontend/Komponenter/Journalføring/JournalføringApp.tsx
+++ b/src/frontend/Komponenter/Journalføring/JournalføringApp.tsx
@@ -153,6 +153,7 @@ const JournalføringAppContent: React.FC<JournalføringAppProps> = ({
     useEffect(() => {
         if (fagsak.status === RessursStatus.SUKSESS) {
             journalpostState.settFagsakId(fagsak.data.id);
+            settFeilMeldning('');
         }
         // eslint-disable-next-line
     }, [fagsak]);
@@ -189,6 +190,7 @@ const JournalføringAppContent: React.FC<JournalføringAppProps> = ({
         UstrukturertDokumentasjonType.PAPIRSØKNAD;
 
     const journalFør = () => {
+        settFeilMeldning('');
         if (fagsak.status !== RessursStatus.SUKSESS) {
             settFeilMeldning('Henting av fagsak feilet, relast siden');
             return;

--- a/src/frontend/Komponenter/Journalføring/JournalføringKlageApp.tsx
+++ b/src/frontend/Komponenter/Journalføring/JournalføringKlageApp.tsx
@@ -105,7 +105,7 @@ const JournalføringAppContent: React.FC<JournalføringAppProps> = ({
     const { klagebehandlinger, hentKlagebehandlinger } = useHentKlagebehandlinger();
 
     const { hentFagsak, fagsak } = useHentFagsak();
-    const [feilmelding, settFeilMeldning] = useState('');
+    const [feilmelding, settFeilmelding] = useState('');
 
     useEffect(() => {
         if (journalpostState.innsending.status === RessursStatus.SUKSESS) {
@@ -140,7 +140,7 @@ const JournalføringAppContent: React.FC<JournalføringAppProps> = ({
             journalpostState
         );
         if (feilmeldingFraValidering) {
-            settFeilMeldning(feilmeldingFraValidering);
+            settFeilmelding(feilmeldingFraValidering);
         } else {
             journalpostState.fullførJournalføring();
         }
@@ -188,7 +188,7 @@ const JournalføringAppContent: React.FC<JournalføringAppProps> = ({
                             behandling={journalpostState.behandling}
                             behandlinger={klagebehandlinger}
                             valgtFagsak={valgtFagsak}
-                            settFeilmelding={settFeilMeldning}
+                            settFeilmelding={settFeilmelding}
                         />
                         {erNyBehandling && (
                             <KlageMottatt>

--- a/src/frontend/Komponenter/Journalføring/JournalføringKlageApp.tsx
+++ b/src/frontend/Komponenter/Journalføring/JournalføringKlageApp.tsx
@@ -201,7 +201,11 @@ const JournalføringAppContent: React.FC<JournalføringAppProps> = ({
                                             mottattDato,
                                         }));
                                     }}
-                                    value={journalpostState.behandling?.mottattDato}
+                                    value={
+                                        journalResponse.journalpost.datoMottatt
+                                            ? journalResponse.journalpost.datoMottatt
+                                            : journalpostState.behandling?.mottattDato
+                                    }
                                     erLesesvisning={!!journalResponse.journalpost.datoMottatt}
                                 />
                             </KlageMottatt>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det skal være mulig å journalføre på ny behandling dersom det finnes en revurdering som er satt på vent. Er det en førstegangsbehandling som er satt på vent ønsker vi ikke å ha to parallelle førstegangsbehandlinger


