### PR TITLE
Validering av skolepenger

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/Felles/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/Felles/vedtaksvalidering.ts
@@ -27,6 +27,13 @@ const periodeUtgiftFeil: FormErrors<SkolepengerUtgift> = {
     stønad: undefined,
 };
 
+export const validerSkoleårsperioderForOpphør = ({ begrunnelse }: InnvilgeVedtakForm) => {
+    return {
+        skoleårsperioder: [],
+        begrunnelse: !harVerdi(begrunnelse) ? 'Mangelfull utfylling av begrunnelse' : undefined,
+    };
+};
+
 export const validerSkoleårsperioderMedBegrunnelse = ({
     skoleårsperioder,
     begrunnelse,

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/OpphøreVedtak/OpphøreVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/OpphøreVedtak/OpphøreVedtak.tsx
@@ -21,7 +21,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { BegrunnelsesFelt } from '../Felles/BegrunnelsesFelt';
 import { AlertError } from '../../../../../Felles/Visningskomponenter/Alerts';
 import HovedKnapp from '../../../../../Felles/Knapper/HovedKnapp';
-import { validerSkoleårsperioderMedBegrunnelse } from '../Felles/vedtaksvalidering';
+import { validerSkoleårsperioderForOpphør } from '../Felles/vedtaksvalidering';
 import { Form, Utregningstabell } from '../InnvilgeVedtak/InnvilgeVedtak';
 
 const utledInitielleSkoleårsperioder = (
@@ -58,7 +58,7 @@ export const OpphøreVedtak: React.FC<{
                 : utledInitielleSkoleårsperioder(forrigeVedtak),
             begrunnelse: lagretInnvilgetVedtak?.begrunnelse || '',
         },
-        validerSkoleårsperioderMedBegrunnelse
+        validerSkoleårsperioderForOpphør
     );
 
     const skoleårsPerioderState = formState.getProps(


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ved opphør av skolepenger må vi ha en snillere validering enn ved innvilgelse. Det skal kunne være tomme skoleårsperioder, og duplikate skal ikke kunne eksistere siden man ikke kan legge inn nye perioder. Backend har også validering på at ingenting er lagt til.




