### PR TITLE
skal kursivere unntak som kun skal brukes for saker der bruker har ft…

### DIFF
--- a/src/frontend/Komponenter/Behandling/Vurdering/Delvilkår.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/Delvilkår.tsx
@@ -3,9 +3,10 @@ import { FC } from 'react';
 import { Regel } from './typer';
 import { DelvilkårContainer } from './DelvilkårContainer';
 import { hjelpeTekstConfig } from './hjelpetekstconfig';
-import { delvilkårTypeTilTekst, svarTypeTilTekst } from './tekster';
+import { delvilkårTypeTilTekst, svarTypeTilTekst, tekstSkalKursiveres } from './tekster';
 import { Vurdering } from '../Inngangsvilkår/vilkår';
 import { HelpText, Radio, RadioGroup } from '@navikt/ds-react';
+import styled from 'styled-components';
 
 interface Props {
     regel: Regel;
@@ -13,26 +14,34 @@ interface Props {
     settVurdering: (nyttSvar: Vurdering) => void;
 }
 
+const FontStyle = styled.div<{ italic: boolean }>`
+    font-style: ${(props) => (props.italic ? 'italic' : 'normal')};
+`;
+
 const Delvilkår: FC<Props> = ({ regel, vurdering, settVurdering }) => {
     const hjelpetekst = hjelpeTekstConfig[regel.regelId];
     return (
         <DelvilkårContainer>
             <RadioGroup legend={delvilkårTypeTilTekst[regel.regelId]} value={vurdering.svar || ''}>
-                {Object.keys(regel.svarMapping).map((svarId) => (
-                    <Radio
-                        key={`${regel.regelId}_${svarId}`}
-                        name={`${regel.regelId}_${svarId}`}
-                        value={svarId}
-                        onChange={() =>
-                            settVurdering({
-                                svar: svarId,
-                                regelId: regel.regelId,
-                            })
-                        }
-                    >
-                        {svarTypeTilTekst[svarId]}
-                    </Radio>
-                ))}
+                {Object.keys(regel.svarMapping).map((svarId) => {
+                    const erTekstKursiv = tekstSkalKursiveres(svarId);
+
+                    return (
+                        <Radio
+                            key={`${regel.regelId}_${svarId}`}
+                            name={`${regel.regelId}_${svarId}`}
+                            value={svarId}
+                            onChange={() =>
+                                settVurdering({
+                                    svar: svarId,
+                                    regelId: regel.regelId,
+                                })
+                            }
+                        >
+                            <FontStyle italic={erTekstKursiv}>{svarTypeTilTekst[svarId]}</FontStyle>
+                        </Radio>
+                    );
+                })}
             </RadioGroup>
             {hjelpetekst && (
                 <HelpText placement={hjelpetekst.plassering}>

--- a/src/frontend/Komponenter/Behandling/Vurdering/tekster.ts
+++ b/src/frontend/Komponenter/Behandling/Vurdering/tekster.ts
@@ -110,4 +110,6 @@ export const svarTypeTilTekst: Record<string, string> = {
     BRUKER_MOTTAR_IKKE_OVERGANGSSTØNAD: 'Bruker mottar ikke overgangsstønad',
 };
 
+/* Alternativer som kun er aktuelle for vedtak før 1. september 2023 skal kursiveres - for å vise saksbehandler at de
+ *  er utdaterte. Alternativene må fortsatt være tilgjengelige å velge for potensielle saker man ikke får migrert fra infotrygd */
 export const tekstSkalKursiveres = (tekst: string): boolean => teksterMedKursiv.includes(tekst);

--- a/src/frontend/Komponenter/Behandling/Vurdering/tekster.ts
+++ b/src/frontend/Komponenter/Behandling/Vurdering/tekster.ts
@@ -1,3 +1,13 @@
+export const teksterMedKursiv = [
+    'MEDLEM_MER_ENN_7_ÅR_AVBRUDD_MER_ENN_10ÅR',
+    'ANDRE_FORELDER_MEDLEM_MINST_7_ÅR_AVBRUDD_MER_ENN_10_ÅR',
+    'I_LANDET_FOR_GJENFORENING_ELLER_GIFTE_SEG',
+    'ANDRE_FORELDER_MEDLEM_SISTE_5_ÅR',
+    'ANDRE_FORELDER_MEDLEM_MINST_5_ÅR_AVBRUDD_MINDRE_ENN_10_ÅR',
+    'ANDRE_FORELDER_MEDLEM_MINST_7_ÅR_AVBRUDD_MER_ENN_10_ÅR',
+    'TOTALVURDERING_OPPFYLLER_FORSKRIFT',
+];
+
 export const delvilkårTypeTilTekst: Record<string, string> = {
     SØKER_MEDLEM_I_FOLKETRYGDEN: 'Har bruker vært medlem i folketrygden i de siste 5 årene?',
     BOR_OG_OPPHOLDER_SEG_I_NORGE: 'Bor og oppholder bruker og barna seg i Norge?',
@@ -99,3 +109,5 @@ export const svarTypeTilTekst: Record<string, string> = {
     NOEN_MÅNEDER_OVERSTIGER_6G: 'Ja, men noen måneder overstiger 6G',
     BRUKER_MOTTAR_IKKE_OVERGANGSSTØNAD: 'Bruker mottar ikke overgangsstønad',
 };
+
+export const tekstSkalKursiveres = (tekst: string): boolean => teksterMedKursiv.includes(tekst);


### PR DESCRIPTION
…t stønad før 1. september 2023

### Hvorfor er denne endringen nødvendig? ✨
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-15302)

Denne oppgaven er gjort etter forespørsel fra Mirja. Når man lister opp alle unntak for inngangsvilkåret `Forutgående medlemskap` skal man kursivere de unntakene som kun skal brukes for saker der bruker har fått søtnad før 1. september 2023.

![Skjermbilde 2023-09-11 kl  11 25 37](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/7aa8dd49-753a-41dd-8738-ff3e7455d14b)

