### PR TITLE
Deloverskriften nulles ikke ut når man flytter avsnitt

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/Fritekstområde.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Fritekstområde.tsx
@@ -90,7 +90,7 @@ export const Fritekstområde: React.FC<{
                         <FritekstAvsnittContainer key={indeks}>
                             <TextField
                                 size={'small'}
-                                value={avsnitt.deloverskrift}
+                                value={avsnitt.deloverskrift || ''}
                                 label={'Deloverskrift'}
                                 onChange={(e) =>
                                     oppdaterAvsnitt(indeks, {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Deloverskriften skal settes eksplisitt for ikke å _henge igjen_ når man flytter avsnitt opp eller ned. Komponenten rendres ikke hvis den er undefined
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-14937)