### PR TITLE
Bugfix - kontantstøtte uten utbetaling

### DIFF
--- a/src/frontend/App/typer/vedtak.ts
+++ b/src/frontend/App/typer/vedtak.ts
@@ -76,7 +76,7 @@ export type IInnvilgeVedtakForOvergangsstønad = {
 };
 
 export type IInnvilgeVedtakForBarnetilsyn = {
-    resultatType: EBehandlingResultat.INNVILGE;
+    resultatType: EBehandlingResultat.INNVILGE | EBehandlingResultat.INNVILGE_UTEN_UTBETALING;
     begrunnelse?: string;
     perioder: IUtgiftsperiode[];
     perioderKontantstøtte: IPeriodeMedBeløp[];

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
@@ -52,7 +52,9 @@ const VedtakOgBeregningBarnetilsyn: FC<Props> = ({ behandling, vilkår }) => {
                                 <InnvilgeVedtak
                                     behandling={behandling}
                                     lagretVedtak={
-                                        vedtak?._type === IVedtakType.InnvilgelseBarnetilsyn
+                                        vedtak?._type === IVedtakType.InnvilgelseBarnetilsyn ||
+                                        vedtak?._type ===
+                                            IVedtakType.InnvilgelseBarnetilsynUtenUtbetaling
                                             ? vedtak
                                             : undefined
                                     }


### PR DESCRIPTION

### Hvorfor er denne endringen nødvendig? ✨
Ved Innvilgelse med kontantstøtte som overstiger utbetaling vises ikke verdiene som saksbehandler har fylt inn - ettersom vedtaket ikke sendes videre til InnvilgeBarnetilsyn-komponenten. Fikset dette
