### PR TITLE
Tar med Svalbard i summering av total inntekt

### DIFF
--- a/src/frontend/Komponenter/Personoversikt/InntektForPerson.tsx
+++ b/src/frontend/Komponenter/Personoversikt/InntektForPerson.tsx
@@ -85,7 +85,15 @@ const PensjonsgivendeInntektTabell: React.FC<{
                                             <HøyrestiltDataCell>
                                                 {formaterTallMedTusenSkille(
                                                     pensjonsgivendeInntekt.næring +
-                                                        pensjonsgivendeInntekt.person
+                                                        pensjonsgivendeInntekt.person +
+                                                        (pensjonsgivendeInntekt.svalbard
+                                                            ? pensjonsgivendeInntekt.svalbard
+                                                                  ?.næring
+                                                            : 0) +
+                                                        (pensjonsgivendeInntekt.svalbard
+                                                            ? pensjonsgivendeInntekt.svalbard
+                                                                  ?.person
+                                                            : 0)
                                                 )}
                                             </HøyrestiltDataCell>
                                             <HøyrestiltDataCell>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Svalbard må summeres med for at det skal bli riktig total pensjonsgivende inntekt.

[Tilhørende PR i ef-sak](https://github.com/navikt/familie-ef-sak/pull/2400)

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12267)

![Screenshot 2023-09-21 at 14 58 45](https://github.com/navikt/familie-ef-sak-frontend/assets/42737566/966a5ee5-f29c-4f3a-83ea-7b8817c5a311)
