### PR TITLE
Avslagsgrunn kortvarig avbrudd jobb uten totrinnskontroll

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
@@ -187,7 +187,8 @@ export const skalFerdigstilleUtenBeslutter = (vedtak?: IVedtak | undefined): boo
         !!vedtak &&
         vedtak._type === IVedtakType.Avslag &&
         vedtak.resultatType === EBehandlingResultat.AVSLÅ &&
-        vedtak.avslåÅrsak === EAvslagÅrsak.MINDRE_INNTEKTSENDRINGER
+        (vedtak.avslåÅrsak === EAvslagÅrsak.MINDRE_INNTEKTSENDRINGER ||
+            vedtak.avslåÅrsak === EAvslagÅrsak.KORTVARIG_AVBRUDD_JOBB)
     );
 };
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker at avslagsgrunn ikke skal ha totrinnskontroll, har derfor fjernet dette.

backend: https://github.com/navikt/familie-ef-sak/pull/2402
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-15340