### PR TITLE
Ikke kopier fødselsnummer med mellomrom

### DIFF
--- a/src/frontend/Felles/Fødselsnummer/KopierbartNullableFødselsnummer.tsx
+++ b/src/frontend/Felles/Fødselsnummer/KopierbartNullableFødselsnummer.tsx
@@ -18,7 +18,7 @@ export const KopierbartNullableFødselsnummer: React.FC<{ fødselsnummer: string
             <span>{formaterFødselsnummer(fødselsnummer)}</span>
             <CopyButton
                 size={'xsmall'}
-                copyText={formaterFødselsnummer(fødselsnummer)}
+                copyText={fødselsnummer}
                 variant={'action'}
                 activeText={'kopiert'}
             />


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Saksbehandlere kopierer fødselsnummer for å se på mer informasjon om personen i gosys, og for at søket i gosys skal virke kan ikke fødselsnummeret inneholde noen mellomrom.

[Meldt om i teams](https://teams.microsoft.com/l/message/19:55fb7a15fdad4fb29e568d7dc617b52e@thread.tacv2/1695458585597?tenantId=62366534-1ec3-4962-8869-9b5535279d0b&groupId=11014155-e8a7-46ad-8be0-b5c10a863a36&parentMessageId=1695458585597&teamName=Team%20enslig%20fors%C3%B8rger%20kontinuerlig%20forbedring&channelName=EF%20sak%20(ny)&createdTime=1695458585597&allowXTenantAccess=false)