### PR TITLE
Skal bruke riktig variabel for opphavsvilkår. Har hatt feil i prod si…

### DIFF
--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/vilkår.ts
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/vilkår.ts
@@ -54,7 +54,7 @@ export interface IVurdering {
 
 export interface Opphavsvilkår {
     behandlingId: string;
-    vurderingstidspunkt: string;
+    endretTid: string;
 }
 
 export interface IDokumentasjonGrunnlag {

--- a/src/frontend/Komponenter/Behandling/Vurdering/VisVurdering.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/VisVurdering.tsx
@@ -73,7 +73,7 @@ const VisVurdering: FC<Props> = ({
 }) => {
     const vilkårsresultat = vurdering.resultat;
     const sistOppdatert = formaterIsoDatoTidMedSekunder(
-        vurdering.opphavsvilkår?.vurderingstidspunkt || vurdering.endretTid
+        vurdering.opphavsvilkår?.endretTid || vurdering.endretTid
     );
     const vurderingerBesvartAvSaksbehandler = vurdering.delvilkårsvurderinger.filter(
         (delvilkårsvurdering) =>


### PR DESCRIPTION
…den vi la til dette.

### Hvorfor er denne endringen nødvendig? ✨

Backend har `OpphavsvilkårDto(endretTid)` og ikke `vurderingstidspunkt` som frontend prøver å bruke. Dette har gjort at datoene vi skriver ut ved siden av gjenbrukte vilkår er _feil_. 