### PR TITLE
Midlertidig fjerne revurdering ka uten brev da det feiler i prod.

### DIFF
--- a/src/frontend/Komponenter/Personoversikt/Revurdering/LagRevurdering.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Revurdering/LagRevurdering.tsx
@@ -117,6 +117,8 @@ export const LagRevurdering: React.FunctionComponent<IProps> = ({
                     toggles[ToggleName.visSatsendring] &&
                     fagsak.stønadstype === Stønadstype.BARNETILSYN
                 );
+            case Behandlingsårsak.IVERKSETTE_KA_VEDTAK:
+                return false;
             default:
                 return true;
         }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Midlertidig fjerne revurdering ka uten brev da det feiler i prod.