### PR TITLE
Sortere brev i brevmeny med prioriteringsnummer

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
@@ -106,4 +106,4 @@ export type FrittståendeSanitybrevDto = {
 };
 
 export type MellomlagerRespons = IMellomlagretBrevResponse;
-export const datasett = 'ef-brev'; // TODO: bruk ef-test for testing, slett kommentar før prodsetting
+export const datasett = 'ef-brev';

--- a/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
@@ -106,4 +106,4 @@ export type FrittståendeSanitybrevDto = {
 };
 
 export type MellomlagerRespons = IMellomlagretBrevResponse;
-export const datasett = 'ef-test'; // TODO endre til ef-brev
+export const datasett = 'ef-brev'; // TODO: bruk ef-test for testing, slett kommentar før prodsetting

--- a/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
@@ -92,6 +92,7 @@ export interface Delmal {
 export interface DokumentNavn {
     apiNavn: string;
     visningsnavn: string;
+    prioriteringsnummer: number;
     overgangsstonad?: boolean;
     barnetilsyn?: boolean;
     skolepenger?: boolean;
@@ -105,4 +106,4 @@ export type FrittståendeSanitybrevDto = {
 };
 
 export type MellomlagerRespons = IMellomlagretBrevResponse;
-export const datasett = 'ef-brev';
+export const datasett = 'ef-test'; // TODO endre til ef-brev

--- a/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
@@ -92,7 +92,7 @@ export interface Delmal {
 export interface DokumentNavn {
     apiNavn: string;
     visningsnavn: string;
-    prioriteringsnummer: number;
+    prioriteringsnummer?: number;
     overgangsstonad?: boolean;
     barnetilsyn?: boolean;
     skolepenger?: boolean;

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmalSelect.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmalSelect.tsx
@@ -25,19 +25,17 @@ export const BrevmalSelect: React.FC<BrevmalSelectProps> = ({
     };
 
     const sorterPåPrioriteringsnummerDeretterAlfabetisk = (dokumentnanvn: DokumentNavn[]) => {
-        return dokumentnanvn
-            ?.filter((mal) => visBrevmal(mal, stønanadstype, frittstående))
-            .sort((a, b) => {
-                if (a.prioriteringsnummer && b.prioriteringsnummer) {
-                    return a.prioriteringsnummer - b.prioriteringsnummer;
-                } else if (a.prioriteringsnummer) {
-                    return -1;
-                } else if (b.prioriteringsnummer) {
-                    return 1;
-                } else {
-                    return a.visningsnavn.localeCompare(b.visningsnavn);
-                }
-            });
+        return dokumentnanvn.sort((a, b) => {
+            if (a.prioriteringsnummer && b.prioriteringsnummer) {
+                return a.prioriteringsnummer - b.prioriteringsnummer;
+            } else if (a.prioriteringsnummer) {
+                return -1;
+            } else if (b.prioriteringsnummer) {
+                return 1;
+            } else {
+                return a.visningsnavn.localeCompare(b.visningsnavn);
+            }
+        });
     };
 
     const ønskedeBrevmalListe = ønskedeBrevmaler(

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmalSelect.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmalSelect.tsx
@@ -1,4 +1,4 @@
-import { Ressurs } from '../../../App/typer/ressurs';
+import { Ressurs, RessursStatus } from '../../../App/typer/ressurs';
 import { DokumentNavn } from './BrevTyper';
 import React, { Dispatch, SetStateAction } from 'react';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
@@ -19,9 +19,30 @@ export const BrevmalSelect: React.FC<BrevmalSelectProps> = ({
     brevmal,
     stønanadstype,
     frittstående,
-}) => (
-    <DataViewer response={{ dokumentnavn }}>
-        {({ dokumentnavn }) => (
+}) => {
+    const ønskedeBrevmaler = (dokumentnanvn: DokumentNavn[]) => {
+        return dokumentnanvn?.filter((mal) => visBrevmal(mal, stønanadstype, frittstående));
+    };
+
+    const sorterPåPrioriteringsnummer = (dokumentnanvn: DokumentNavn[]) => {
+        return dokumentnanvn
+            ?.filter((mal) => visBrevmal(mal, stønanadstype, frittstående))
+            .sort((a, b) => {
+                if (a?.prioriteringsnummer !== b?.prioriteringsnummer) {
+                    return a.prioriteringsnummer - b.prioriteringsnummer;
+                }
+                return a.visningsnavn.localeCompare(b.visningsnavn);
+            });
+    };
+
+    const ønskedeBrevmalListe = ønskedeBrevmaler(
+        dokumentnavn.status === RessursStatus.SUKSESS ? dokumentnavn.data : []
+    );
+
+    const sortertBrevliste = sorterPåPrioriteringsnummer(ønskedeBrevmalListe);
+
+    return (
+        <DataViewer response={{ dokumentnavn }}>
             <Select
                 label="Velg dokument"
                 onChange={(e) => {
@@ -31,14 +52,12 @@ export const BrevmalSelect: React.FC<BrevmalSelectProps> = ({
             >
                 <option value="">Ikke valgt</option>
 
-                {dokumentnavn
-                    ?.filter((mal) => visBrevmal(mal, stønanadstype, frittstående))
-                    .map((navn: DokumentNavn) => (
-                        <option value={navn.apiNavn} key={navn.apiNavn}>
-                            {navn.visningsnavn}
-                        </option>
-                    ))}
+                {sortertBrevliste.map((navn: DokumentNavn) => (
+                    <option value={navn.apiNavn} key={navn.apiNavn}>
+                        {navn.visningsnavn}
+                    </option>
+                ))}
             </Select>
-        )}
-    </DataViewer>
-);
+        </DataViewer>
+    );
+};

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmalSelect.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmalSelect.tsx
@@ -20,7 +20,7 @@ export const BrevmalSelect: React.FC<BrevmalSelectProps> = ({
     stønanadstype,
     frittstående,
 }) => {
-    const ønskedeBrevmaler = (dokumentnanvn: DokumentNavn[]) => {
+    const filtrerBrevmaler = (dokumentnanvn: DokumentNavn[]) => {
         return dokumentnanvn?.filter((mal) => visBrevmal(mal, stønanadstype, frittstående));
     };
 
@@ -38,11 +38,11 @@ export const BrevmalSelect: React.FC<BrevmalSelectProps> = ({
         });
     };
 
-    const ønskedeBrevmalListe = ønskedeBrevmaler(
+    const filtrertBrevmalListe = filtrerBrevmaler(
         dokumentnavn.status === RessursStatus.SUKSESS ? dokumentnavn.data : []
     );
 
-    const sortertBrevliste = sorterPåPrioriteringsnummerDeretterAlfabetisk(ønskedeBrevmalListe);
+    const sortertBrevliste = sorterPåPrioriteringsnummerDeretterAlfabetisk(filtrertBrevmalListe);
 
     return (
         <DataViewer response={{ dokumentnavn }}>

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmalSelect.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmalSelect.tsx
@@ -24,14 +24,19 @@ export const BrevmalSelect: React.FC<BrevmalSelectProps> = ({
         return dokumentnanvn?.filter((mal) => visBrevmal(mal, stønanadstype, frittstående));
     };
 
-    const sorterPåPrioriteringsnummer = (dokumentnanvn: DokumentNavn[]) => {
+    const sorterPåPrioriteringsnummerDeretterAlfabetisk = (dokumentnanvn: DokumentNavn[]) => {
         return dokumentnanvn
             ?.filter((mal) => visBrevmal(mal, stønanadstype, frittstående))
             .sort((a, b) => {
-                if (a?.prioriteringsnummer !== b?.prioriteringsnummer) {
+                if (a.prioriteringsnummer && b.prioriteringsnummer) {
                     return a.prioriteringsnummer - b.prioriteringsnummer;
+                } else if (a.prioriteringsnummer) {
+                    return -1;
+                } else if (b.prioriteringsnummer) {
+                    return 1;
+                } else {
+                    return a.visningsnavn.localeCompare(b.visningsnavn);
                 }
-                return a.visningsnavn.localeCompare(b.visningsnavn);
             });
     };
 
@@ -39,7 +44,7 @@ export const BrevmalSelect: React.FC<BrevmalSelectProps> = ({
         dokumentnavn.status === RessursStatus.SUKSESS ? dokumentnavn.data : []
     );
 
-    const sortertBrevliste = sorterPåPrioriteringsnummer(ønskedeBrevmalListe);
+    const sortertBrevliste = sorterPåPrioriteringsnummerDeretterAlfabetisk(ønskedeBrevmalListe);
 
     return (
         <DataViewer response={{ dokumentnavn }}>

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmalSelect.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmalSelect.tsx
@@ -27,6 +27,9 @@ export const BrevmalSelect: React.FC<BrevmalSelectProps> = ({
     const sorterPåPrioriteringsnummerDeretterAlfabetisk = (dokumentnanvn: DokumentNavn[]) => {
         return dokumentnanvn.sort((a, b) => {
             if (a.prioriteringsnummer && b.prioriteringsnummer) {
+                if (a.prioriteringsnummer === b.prioriteringsnummer) {
+                    return a.visningsnavn.localeCompare(b.visningsnavn);
+                }
                 return a.prioriteringsnummer - b.prioriteringsnummer;
             } else if (a.prioriteringsnummer) {
                 return -1;

--- a/src/frontend/Komponenter/Personoversikt/Revurdering/LagRevurdering.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Revurdering/LagRevurdering.tsx
@@ -117,6 +117,8 @@ export const LagRevurdering: React.FunctionComponent<IProps> = ({
                     toggles[ToggleName.visSatsendring] &&
                     fagsak.stønadstype === Stønadstype.BARNETILSYN
                 );
+            case Behandlingsårsak.IVERKSETTE_KA_VEDTAK:
+                return false;
             default:
                 return true;
         }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker at det skal være enklere å finne korrekt brevmal i brevmeny. Det er nå mulig å legge til et prioriteringsnummer i Sanity. Prioriteringsnummeret brukes for å sortere brevmaler stigende. Hvis det mangler et prioriteringsnummer blir brevmaler sortert alfabetisk.

Familie-brev: https://github.com/navikt/familie-brev/pull/518
Sanity-brev: https://github.com/navikt/familie-sanity-brev/pull/449
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-15425

Bilde av "ef-test", hvor noen brev har fått prioriteringsnummer:
![image](https://github.com/navikt/familie-ef-sak-frontend/assets/141132903/1343a861-9ad9-4670-9f83-434428ae0ec2)

