### PR TITLE
skal ikke sette redigeringsmodus når man bytter vekk fra siden årsak …

### DIFF
--- a/src/frontend/Komponenter/Behandling/ÅrsakRevurdering/ÅrsakRevurdering.tsx
+++ b/src/frontend/Komponenter/Behandling/ÅrsakRevurdering/ÅrsakRevurdering.tsx
@@ -27,11 +27,6 @@ export const ÅrsakRevurdering: React.FC<Props> = ({
 
     useEffect(() => {
         settErRedigeringsmodus(behandlingErRedigerbar && !revurderingsinformasjon.årsakRevurdering);
-        return () => {
-            settErRedigeringsmodus(
-                behandlingErRedigerbar && !revurderingsinformasjon.årsakRevurdering
-            );
-        };
         // eslint-disable-next-line
     }, [behandlingErRedigerbar]);
 


### PR DESCRIPTION
…revurdering

### Hvorfor er denne endringen nødvendig? ✨
Return-statementet i useEffecten er bare en skrivefeil fra PR om ansvarlig saksbehandler. Denne PRen løser punkt 3 i [dette favrokortet](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-15887)