### PR TITLE
Bygg dependabot i GHA

### DIFF
--- a/.github/workflows/build_dev.yaml
+++ b/.github/workflows/build_dev.yaml
@@ -13,7 +13,6 @@ jobs:
           node-version: '18'
           cache: yarn
           registry-url: "https://npm.pkg.github.com"
-        if: github.actor != 'dependabot[bot]'
       - name: Yarn install
         run: yarn --prefer-offline --frozen-lockfile
         env:


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Fjerner if som gjorde at node/npm config kun ble utført dersom actor ikke var dependabot. Dette gjorde at henting av @navikt-pakker feilet og at man fikk 403 på yarn install