### PR TITLE
behandlingen er ikke redigerbar dersom ansvarlig ssaksbehandler for b…

### DIFF
--- a/src/frontend/App/typer/behandlingstatus.ts
+++ b/src/frontend/App/typer/behandlingstatus.ts
@@ -34,7 +34,6 @@ export const innloggetSaksbehandlerKanRedigereBehandling = (
     ansvarligSaksbehandler: AnsvarligSaksbehandler
 ) => {
     return (
-        ansvarligSaksbehandler.rolle === AnsvarligSaksbehandlerRolle.IKKE_SATT ||
         ansvarligSaksbehandler.rolle === AnsvarligSaksbehandlerRolle.INNLOGGET_SAKSBEHANDLER ||
         ansvarligSaksbehandler.rolle === AnsvarligSaksbehandlerRolle.OPPGAVE_FINNES_IKKE
     );


### PR DESCRIPTION
…ehandlingen ikke er satt

### Hvorfor er denne endringen nødvendig? ✨
Dersom ansvarlig saksbehandler ikke er satt skal man ikke kunne gjøre endringer på behandlingen.
Dette løser punkt 4 i [dette favrokortet](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-15887)

Backend PR:
* https://github.com/navikt/familie-ef-sak/pull/2427