### PR TITLE
Vis varsel ved adresseendring

### DIFF
--- a/src/frontend/Komponenter/Behandling/Endring/EndringPersonopplysninger.tsx
+++ b/src/frontend/Komponenter/Behandling/Endring/EndringPersonopplysninger.tsx
@@ -67,7 +67,7 @@ const FeltEndring: React.FC<{ feltendring: Feltendring }> = ({ feltendring }) =>
 
 const AdresseEndring: React.FC = () => (
     <ul>
-        <li>Det finnes adresseendring på bruker.</li>
+        <li>Det finnes adresseendring på bruker</li>
     </ul>
 );
 

--- a/src/frontend/Komponenter/Behandling/Endring/EndringPersonopplysninger.tsx
+++ b/src/frontend/Komponenter/Behandling/Endring/EndringPersonopplysninger.tsx
@@ -67,7 +67,7 @@ const FeltEndring: React.FC<{ feltendring: Feltendring }> = ({ feltendring }) =>
 
 const AdresseEndring: React.FC = () => (
     <ul>
-        <li>Det finnes adresseendringer på bruker.</li>
+        <li>Det finnes adresseendring på bruker.</li>
     </ul>
 );
 

--- a/src/frontend/Komponenter/Behandling/Endring/EndringPersonopplysninger.tsx
+++ b/src/frontend/Komponenter/Behandling/Endring/EndringPersonopplysninger.tsx
@@ -65,6 +65,12 @@ const FeltEndring: React.FC<{ feltendring: Feltendring }> = ({ feltendring }) =>
     </ul>
 );
 
+const AdresseEndring: React.FC = () => (
+    <ul>
+        <li>Det finnes adresseendringer på bruker.</li>
+    </ul>
+);
+
 const Endringsdetaljer: React.FC<{ endringer: IEndringer; personopplysning: keyof IEndringer }> = ({
     endringer,
     personopplysning,
@@ -77,6 +83,8 @@ const Endringsdetaljer: React.FC<{ endringer: IEndringer; personopplysning: keyo
         case 'fødselsdato':
         case 'dødsdato':
             return <FeltEndring feltendring={endringer[personopplysning].detaljer} />;
+        case 'adresse':
+            return <AdresseEndring />;
         default:
             return null;
     }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Lager en varsel om at det finnes adresseendring på bruker, dersom vilkårsvurderinger er påstartet i behandlingen.
Dersom det ikke er gjort noen vilkårsvurderinger på behandlingen enda, og adressen er endret, så vil alle vilkår reinitialiseres og beregning av avstand til annen forelder vil bli kjørt på nytt.
![Screenshot 2023-10-19 at 14 44 13](https://github.com/navikt/familie-ef-sak-frontend/assets/42737566/e4bafbcc-75a1-471d-b564-82535a95be94)

Det er allerede funksjonalitet som plukker opp om annen forelder flytter, og det vises også i varsel.

Det er verdt å merke seg ved testing at det må ha gått minimium 4 timer siden gunnlagsdata er hentet før det hentes på nytt for at eventuelle endringer og varsel blir vist. 

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-15809)