### PR TITLE
Journalføring 2.0 klage

### DIFF
--- a/src/frontend/App/hooks/useJournalføringState.ts
+++ b/src/frontend/App/hooks/useJournalføringState.ts
@@ -69,6 +69,8 @@ export interface JournalføringStateRequest {
     settSkalOppretteNyBehandling: Dispatch<SetStateAction<boolean>>;
     nyAvsender: string;
     settNyAvsender: Dispatch<SetStateAction<string>>;
+    klageGjelderTilbakekreving: boolean;
+    settKlageGjelderTilbakekreving: Dispatch<SetStateAction<boolean>>;
 }
 
 export const useJournalføringState = (
@@ -116,6 +118,7 @@ export const useJournalføringState = (
     );
     const [skalOppretteNyBehandling, settSkalOppretteNyBehandling] = useState<boolean>(false); // TODO: Denne må sendes med til backend for å bli utført
     const [nyAvsender, settNyAvsender] = useState<string>(''); // TODO: Denne må sendes med til backend for å bli satt
+    const [klageGjelderTilbakekreving, settKlageGjelderTilbakekreving] = useState<boolean>(false); // TODO: Denne må sendes med til backend for å bli satt
 
     useEffect(() => {
         if (stønadstype) {
@@ -186,5 +189,7 @@ export const useJournalføringState = (
         settSkalOppretteNyBehandling,
         nyAvsender,
         settNyAvsender,
+        klageGjelderTilbakekreving,
+        settKlageGjelderTilbakekreving,
     };
 };

--- a/src/frontend/App/typer/klage.ts
+++ b/src/frontend/App/typer/klage.ts
@@ -45,19 +45,6 @@ export enum KlageinstansUtfall {
     INNSTILLING_AVVIST = 'INNSTILLING_AVVIST',
 }
 
-export const klageinstansUtfallTilTekst: Record<KlageinstansUtfall, string> = {
-    TRUKKET: 'Trukket KA',
-    RETUR: 'Retur KA',
-    OPPHEVET: 'Opphevet KA',
-    MEDHOLD: 'Medhold KA',
-    DELVIS_MEDHOLD: 'Delvis medhold KA',
-    STADFESTELSE: 'Stadfestelse KA',
-    UGUNST: 'Ugunst (Ugyldig) KA',
-    AVVIST: 'Avvist KA',
-    INNSTILLING_STADFESTELSE: 'Innstilling om stadfestelse til trygderetten fra KA',
-    INNSTILLING_AVVIST: 'Innstilling om avist til trygderetten fra KA',
-};
-
 export enum KlagebehandlingResultat {
     MEDHOLD = 'MEDHOLD',
     IKKE_MEDHOLD = 'IKKE_MEDHOLD',
@@ -85,3 +72,23 @@ export enum KlageHenlagtÅrsak {
     TRUKKET_TILBAKE = 'TRUKKET_TILBAKE',
     FEILREGISTRERT = 'FEILREGISTRERT',
 }
+
+export const klageinstansUtfallTilTekst: Record<KlageinstansUtfall, string> = {
+    TRUKKET: 'Trukket KA',
+    RETUR: 'Retur KA',
+    OPPHEVET: 'Opphevet KA',
+    MEDHOLD: 'Medhold KA',
+    DELVIS_MEDHOLD: 'Delvis medhold KA',
+    STADFESTELSE: 'Stadfestelse KA',
+    UGUNST: 'Ugunst (Ugyldig) KA',
+    AVVIST: 'Avvist KA',
+    INNSTILLING_STADFESTELSE: 'Innstilling om stadfestelse til trygderetten fra KA',
+    INNSTILLING_AVVIST: 'Innstilling om avist til trygderetten fra KA',
+};
+
+export const KlagebehandlingStatusTilTekst: Record<KlagebehandlingStatus, string> = {
+    OPPRETTET: 'Opprettet',
+    UTREDES: 'Utredes',
+    VENTER: 'Venter',
+    FERDIGSTILT: 'Ferdigstilt',
+};

--- a/src/frontend/Felles/Knapper/LeggTilKnapp.tsx
+++ b/src/frontend/Felles/Knapper/LeggTilKnapp.tsx
@@ -11,7 +11,8 @@ const LeggTilKnapp: React.FC<{
     onClick: () => void;
     variant?: ButtonProps['variant'];
     size?: ButtonProps['size'];
-}> = ({ className, ikontekst, ikonPosisjon, knappetekst, onClick, variant, size }) => {
+    disabled?: boolean;
+}> = ({ className, ikontekst, ikonPosisjon, knappetekst, onClick, variant, size, disabled }) => {
     return (
         <Knapp
             className={className}
@@ -21,6 +22,7 @@ const LeggTilKnapp: React.FC<{
             type="button"
             variant={variant || 'secondary'}
             size={size || 'medium'}
+            disabled={disabled}
         >
             {knappetekst && <span>{knappetekst}</span>}
         </Knapp>

--- a/src/frontend/Komponenter/Journalføring/Felles/utils.ts
+++ b/src/frontend/Komponenter/Journalføring/Felles/utils.ts
@@ -1,10 +1,15 @@
 import { DokumentTitler, IJournalpostResponse } from '../../../App/typer/journalføring';
-import { Behandlingstema, behandlingstemaTilTekst } from '../../../App/typer/behandlingstema';
+import {
+    Behandlingstema,
+    behandlingstemaTilTekst,
+    Stønadstype,
+} from '../../../App/typer/behandlingstema';
 import { Behandling, BehandlingResultat } from '../../../App/typer/fagsak';
 import { Behandlingstype } from '../../../App/typer/behandlingstype';
 import { BehandlingRequest } from '../../../App/hooks/useJournalføringState';
 import { BehandlingKlageRequest } from '../../../App/hooks/useJournalføringKlageState';
 import { ISelectOption, MultiValue, SingleValue } from '@navikt/familie-form-elements';
+import { Klagebehandlinger } from '../../../App/typer/klage';
 
 export const JOURNALPOST_QUERY_STRING = 'journalpostId';
 export const OPPGAVEID_QUERY_STRING = 'oppgaveId';
@@ -139,3 +144,18 @@ export const valgbareJournalføringsårsaker = [
     Journalføringsårsak.KLAGE,
     Journalføringsårsak.PAPIRSØKNAD,
 ];
+
+export const stønadstypeTilKey = (
+    stønadstype: Stønadstype | undefined
+): keyof Klagebehandlinger | undefined => {
+    switch (stønadstype) {
+        case Stønadstype.OVERGANGSSTØNAD:
+            return 'overgangsstønad';
+        case Stønadstype.BARNETILSYN:
+            return 'barnetilsyn';
+        case Stønadstype.SKOLEPENGER:
+            return 'skolepenger';
+        default:
+            return undefined;
+    }
+};

--- a/src/frontend/Komponenter/Journalføring/Standard/Behandlinger.tsx
+++ b/src/frontend/Komponenter/Journalføring/Standard/Behandlinger.tsx
@@ -1,5 +1,5 @@
 import React, { Dispatch, SetStateAction } from 'react';
-import { Button, HStack, Table, VStack } from '@navikt/ds-react';
+import { BodyShort, Button, HStack, Table, VStack } from '@navikt/ds-react';
 import { Fagsak } from '../../../App/typer/fagsak';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { formaterIsoDatoTid } from '../../../App/utils/formatter';
@@ -18,7 +18,17 @@ const StyledDataCell = styled(Table.DataCell)`
 `;
 
 const FjernBehandlingButton = styled(Button)`
-    margin-right: 1rem;
+    margin-right: 0.5rem;
+`;
+
+const TekstContainer = styled.div`
+    padding-left: 1rem;
+    padding-right: 1rem;
+`;
+
+const BodyShortItalic = styled(BodyShort)`
+    font-style: italic;
+    width: 47rem;
 `;
 
 interface Props {
@@ -102,6 +112,15 @@ const Behandlinger: React.FC<Props> = ({ journalpostState, settFeilmelding }) =>
                                 ))}
                             </Table.Body>
                         </Table>
+                        {behandlinger.length === 0 && (
+                            <TekstContainer>
+                                <BodyShortItalic>
+                                    Det finnes ingen behandlinger på denne fagsaken til brukeren. Du
+                                    kan opprette en behandling eller journalføre på bruker uten
+                                    behandling (lik generell sak i Gosys)
+                                </BodyShortItalic>
+                            </TekstContainer>
+                        )}
                         <LeggTilKnapp
                             onClick={() => leggTilNyBehandlingForOpprettelse(fagsak)}
                             knappetekst={'Opprett ny behandling'}

--- a/src/frontend/Komponenter/Journalføring/Standard/JournalføringAppNy.tsx
+++ b/src/frontend/Komponenter/Journalføring/Standard/JournalføringAppNy.tsx
@@ -24,9 +24,11 @@ import JournalpostPanel from './JournalpostPanel';
 import BrukerPanel from './BrukerPanel';
 import AvsenderPanel from './AvsenderPanel';
 import Dokumenter from './Dokumenter';
-import { AlertError, AlertInfo } from '../../../Felles/Visningskomponenter/Alerts';
+import { AlertError } from '../../../Felles/Visningskomponenter/Alerts';
 import Behandlinger from './Behandlinger';
 import { Knapp } from '../../../Felles/Knapper/HovedKnapp';
+import { Journalføringsårsak } from '../Felles/utils';
+import Klagebehandlinger from './Klagebehandlinger';
 
 const InnerContainer = styled.div`
     display: flex;
@@ -66,6 +68,9 @@ const JournalføringSide: React.FC<JournalføringAppProps> = ({ oppgaveId, journ
             navigate('/oppgavebenk');
         }
     }, [innloggetSaksbehandler, journalResponse, journalpostState, navigate]);
+
+    const skalViseKlagebehandlinger =
+        journalpostState.journalføringsårsak === Journalføringsårsak.KLAGE;
 
     return (
         <Kolonner>
@@ -108,20 +113,17 @@ const JournalføringSide: React.FC<JournalføringAppProps> = ({ oppgaveId, journ
                         <Tittel size={'small'} level={'2'}>
                             Behandling
                         </Tittel>
-                        <AlertInfo>
-                            Merk at du ikke lenger trenger å knytte dokumenter til spesifikke
-                            behandlinger da de automatisk knyttes til bruker. Du kan i listen under
-                            få oversikt over tidligere behandlinger og vurdere om det skal opprettes
-                            en ny behandling fra denne journalføringen.
-                        </AlertInfo>
-                        <Behandlinger
-                            fagsak={journalpostState.fagsak}
-                            settFeilmelding={settFeilmelding}
-                            skalOppretteNyBehandling={journalpostState.skalOppretteNyBehandling}
-                            settSkalOppretteNyBehandling={
-                                journalpostState.settSkalOppretteNyBehandling
-                            }
-                        />
+                        {skalViseKlagebehandlinger ? (
+                            <Klagebehandlinger
+                                journalpostState={journalpostState}
+                                settFeilmelding={settFeilmelding}
+                            />
+                        ) : (
+                            <Behandlinger
+                                journalpostState={journalpostState}
+                                settFeilmelding={settFeilmelding}
+                            />
+                        )}
                     </section>
                     <HStack gap="4" justify="end">
                         <Knapp

--- a/src/frontend/Komponenter/Journalføring/Standard/JournalpostPanel.tsx
+++ b/src/frontend/Komponenter/Journalføring/Standard/JournalpostPanel.tsx
@@ -1,5 +1,13 @@
 import React, { useState } from 'react';
-import { BodyShort, ExpansionCard, Heading, HStack, Select, VStack } from '@navikt/ds-react';
+import {
+    BodyShort,
+    Checkbox,
+    ExpansionCard,
+    Heading,
+    HStack,
+    Select,
+    VStack,
+} from '@navikt/ds-react';
 import styled from 'styled-components';
 import { FolderFileFillIcon, FolderFileIcon } from '@navikt/aksel-icons';
 import { ABlue500 } from '@navikt/ds-tokens/dist/tokens';
@@ -33,6 +41,10 @@ const StyledSelect = styled(Select)`
     max-width: 13rem;
 `;
 
+const StyledCheckbox = styled(Checkbox)`
+    margin-left: 1rem;
+`;
+
 const Grid = styled.div`
     display: grid;
     grid-template-columns: repeat(4, max-content);
@@ -45,8 +57,14 @@ interface Props {
 }
 
 const JournalpostPanel: React.FC<Props> = ({ journalpost, journalpostState }) => {
-    const { journalføringsårsak, settJournalføringsårsak, stønadstype, settStønadstype } =
-        journalpostState;
+    const {
+        journalføringsårsak,
+        settJournalføringsårsak,
+        stønadstype,
+        settStønadstype,
+        klageGjelderTilbakekreving,
+        settKlageGjelderTilbakekreving,
+    } = journalpostState;
 
     const [erPanelEkspandert, settErPanelEkspandert] = useState<boolean>(false);
 
@@ -134,6 +152,17 @@ const JournalpostPanel: React.FC<Props> = ({ journalpost, journalpostState }) =>
                             </option>
                         ))}
                     </StyledSelect>
+                    {journalføringsårsak === Journalføringsårsak.KLAGE && (
+                        <StyledCheckbox
+                            size="small"
+                            checked={klageGjelderTilbakekreving}
+                            onChange={() => {
+                                settKlageGjelderTilbakekreving((prevState) => !prevState);
+                            }}
+                        >
+                            Klagen gjelder tilbakekreving
+                        </StyledCheckbox>
+                    )}
                 </ExpansionCardContent>
             </ExpansionCard.Content>
         </ExpansionCard>

--- a/src/frontend/Komponenter/Journalføring/Standard/JournalpostPanel.tsx
+++ b/src/frontend/Komponenter/Journalføring/Standard/JournalpostPanel.tsx
@@ -62,6 +62,7 @@ const JournalpostPanel: React.FC<Props> = ({ journalpost, journalpostState }) =>
         settJournalføringsårsak,
         stønadstype,
         settStønadstype,
+        settSkalOppretteNyBehandling,
         klageGjelderTilbakekreving,
         settKlageGjelderTilbakekreving,
     } = journalpostState;
@@ -122,6 +123,7 @@ const JournalpostPanel: React.FC<Props> = ({ journalpost, journalpostState }) =>
                         size="small"
                         value={stønadstype}
                         onChange={(event) => {
+                            settSkalOppretteNyBehandling(false);
                             settStønadstype(event.target.value as Stønadstype);
                         }}
                         disabled={!kanRedigere}
@@ -141,9 +143,10 @@ const JournalpostPanel: React.FC<Props> = ({ journalpost, journalpostState }) =>
                         label="Type"
                         size="small"
                         value={journalføringsårsak}
-                        onChange={(event) =>
-                            settJournalføringsårsak(event.target.value as Journalføringsårsak)
-                        }
+                        onChange={(event) => {
+                            settSkalOppretteNyBehandling(false);
+                            settJournalføringsårsak(event.target.value as Journalføringsårsak);
+                        }}
                         disabled={!kanRedigere}
                     >
                         {valgbareJournalføringsårsaker.map((type) => (

--- a/src/frontend/Komponenter/Journalføring/Standard/Klagebehandlinger.tsx
+++ b/src/frontend/Komponenter/Journalføring/Standard/Klagebehandlinger.tsx
@@ -1,5 +1,5 @@
 import React, { Dispatch, SetStateAction, useEffect } from 'react';
-import { Button, HStack, Table, VStack } from '@navikt/ds-react';
+import { BodyShort, Button, HStack, Table, VStack } from '@navikt/ds-react';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { formaterNullableIsoDato } from '../../../App/utils/formatter';
 import LeggTilKnapp from '../../../Felles/Knapper/LeggTilKnapp';
@@ -18,7 +18,17 @@ const StyledDataCell = styled(Table.DataCell)`
 `;
 
 const FjernBehandlingButton = styled(Button)`
-    margin-right: 0.5rem;
+    margin-right: 1rem;
+`;
+
+const TekstContainer = styled.div`
+    padding-left: 1rem;
+    padding-right: 1rem;
+`;
+
+const BodyShortItalic = styled(BodyShort)`
+    font-style: italic;
+    width: 47rem;
 `;
 
 interface Props {
@@ -112,6 +122,15 @@ const Behandlinger: React.FC<Props> = ({ journalpostState, settFeilmelding }) =>
                                 ))}
                             </Table.Body>
                         </Table>
+                        {klageBehandlinger.length === 0 && (
+                            <TekstContainer>
+                                <BodyShortItalic>
+                                    Det finnes ingen behandlinger på denne fagsaken til brukeren. Du
+                                    kan opprette en behandling eller journalføre på bruker uten
+                                    behandling (lik generell sak i Gosys)
+                                </BodyShortItalic>
+                            </TekstContainer>
+                        )}
                         <LeggTilKnapp
                             onClick={() => leggTilNyBehandlingForOpprettelse()}
                             knappetekst={'Opprett ny behandling'}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Denne PRen tilrettelegger for at klagebehandlinger skal kunne velges, vises og journalføres i det nye journalføringsbildet.

[Favro kort](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-3990)

Visning av klagebehandlinger - skal informere om at det allerede eksisterer en åpen klagebehandling:
![Skjermbilde 2023-10-31 kl  14 45 54](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/07c5ec5b-c14e-48df-8adf-c30278fad76e)

Visning av klagebehandlinger - skal informere om at ikke eksisterer noen klagebehandlinger på valgt stønadstype/fagsak:
![Skjermbilde 2023-10-31 kl  14 46 08](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/2857bf4f-d2b6-4fca-b2c9-3b510c2132da)

Visning av standard behandlinger:
![Skjermbilde 2023-10-31 kl  14 46 23](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/175b1030-d978-42e9-bb5e-3df549778d9e)

Visning av standard behandlinger - skal informere om at ikke eksisterer noen klagebehandlinger på valgt stønadstype/fagsak:
![Skjermbilde 2023-10-31 kl  14 46 32](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/c3c996b8-c795-44ea-8d71-aa8903a37b1e)
