### PR TITLE
Skal sette fagsakid ved valgt stønadstype og uthentet fagsak

### DIFF
--- a/src/frontend/App/hooks/useJournalføringState.ts
+++ b/src/frontend/App/hooks/useJournalføringState.ts
@@ -169,6 +169,12 @@ export const useJournalføringState = (
         settBehandling(undefined);
     }, [fagsakId]);
 
+    useEffect(() => {
+        if (fagsak.status === RessursStatus.SUKSESS) {
+            settFagsakId(fagsak.data.id);
+        }
+    }, [fagsak]);
+
     const fullførJournalføring = () => {
         if (!behandling || innsending.status === RessursStatus.HENTER) {
             return;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Første versjon setter ikke fagsakid - så ingen journalføringer er mulig å få igjennom uten dette. 