### PR TITLE
Rette typo i infomelding om at det allerede finnes en åpen behandling

### DIFF
--- a/src/frontend/Komponenter/Journalføring/Standard/Klagebehandlinger.tsx
+++ b/src/frontend/Komponenter/Journalføring/Standard/Klagebehandlinger.tsx
@@ -85,7 +85,7 @@ const Klagebehandlinger: React.FC<Props> = ({ journalpostState, settFeilmelding 
                         </AlertInfo>
                         {fagsakHarÅpenKlagebehandling && (
                             <AlertInfo>
-                                Merk at det allerede finnes en åpen fagsak på denne fagsaken
+                                Merk at det allerede finnes en åpen behandling på denne fagsaken
                             </AlertInfo>
                         )}
                         <Table zebraStripes={true}>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
