### PR TITLE
Skal vise tag for om tidligere barnetilsynsperioder overlapper 

### DIFF
--- a/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/barnetilsyn/HistorikkRadIBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/barnetilsyn/HistorikkRadIBarnetilsyn.tsx
@@ -3,6 +3,8 @@ import { BodyShort } from '@navikt/ds-react';
 import { formaterIsoDato } from '../../../../App/utils/formatter';
 import styled from 'styled-components';
 import { IGrunnlagsdataPeriodeHistorikkBarnetilsyn } from '../typer';
+import { Tag } from '@navikt/ds-react';
+import { etikettTypeOverlappBarnetilsyn } from '../../../Personoversikt/HistorikkVedtaksperioder/vedtakshistorikkUtil';
 
 interface HistorikkRadProps {
     rad: IGrunnlagsdataPeriodeHistorikkBarnetilsyn;
@@ -20,6 +22,12 @@ const HistorikkRadIBarnetilsyn: React.FC<HistorikkRadProps> = ({ rad, indeks }) 
                 {`${formaterIsoDato(rad.fom)} 
             - 
             ${formaterIsoDato(rad.tom)}`}
+            </BodyShort>
+            <BodyShort size="small">
+                <Tag variant={etikettTypeOverlappBarnetilsyn(rad.overlapp)} size={'small'}>
+                    {rad.overlapp && 'Ja'}
+                    {!rad.overlapp && 'Nei'}
+                </Tag>
             </BodyShort>
         </Row>
     );

--- a/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/barnetilsyn/KortInnholdBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/barnetilsyn/KortInnholdBarnetilsyn.tsx
@@ -6,8 +6,9 @@ import HistorikkRadIBarnetilsyn from './HistorikkRadIBarnetilsyn';
 
 const Grid = styled.div`
     display: grid;
-    grid-template-columns: auto;
+    grid-template-columns: repeat(2, max-content);
     row-gap: 0.2rem;
+    column-gap: 1rem;
 `;
 const Row = styled.div`
     display: contents;
@@ -19,6 +20,7 @@ const KortInnholdBarnetilsyn: React.FC<{
         <Grid>
             <Row>
                 <Label>Periode</Label>
+                <Label>Overlapp</Label>
             </Row>
             {periodeHistorikkData?.map((rad, i) => (
                 <HistorikkRadIBarnetilsyn key={i} rad={rad} indeks={i} />

--- a/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/typer.ts
+++ b/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/typer.ts
@@ -24,6 +24,7 @@ export interface IGrunnlagsdataPeriodeHistorikkOvergangsstønad {
 export interface IGrunnlagsdataPeriodeHistorikkBarnetilsyn {
     fom: string;
     tom: string;
+    overlapp: boolean;
 }
 export interface IHistorikkForStønad {
     stønadstype: string;

--- a/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/vedtakshistorikkUtil.tsx
+++ b/src/frontend/Komponenter/Personoversikt/HistorikkVedtaksperioder/vedtakshistorikkUtil.tsx
@@ -64,6 +64,13 @@ export const etikettTypeBarnetilsyn = (periodeType?: EUtgiftsperiodetype): TagPr
     }
 };
 
+export const etikettTypeOverlappBarnetilsyn = (overlapp: boolean): TagProps['variant'] => {
+    if (overlapp) {
+        return 'success';
+    }
+    return 'warning';
+};
+
 export const datoAndelHistorikk = (andel: AndelHistorikk) => {
     const fra = formaterNullableIsoDato(andel.andel.stønadFra);
     if (andel.erOpphør) {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Inkluderer å vise om bruker har barnetilsynsperioder som overlapper med overgangsstønadsperioder. Fortsettelse av https://github.com/navikt/familie-ef-sak/pull/2456

PR i ef-sak: https://github.com/navikt/familie-ef-sak/pull/2467

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-16910

![image](https://github.com/navikt/familie-ef-sak-frontend/assets/56258085/aa140641-8818-44f8-9613-a9fff3a731e5)

