### PR TITLE
Historikk, responsiv fiks

### DIFF
--- a/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/overgangsstønad/KortInnholdOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/overgangsstønad/KortInnholdOvergangsstønad.tsx
@@ -18,7 +18,7 @@ const Grid = styled.div`
         grid-template-columns: repeat(2, max-content);
     }
 
-    @media (max-width: 500px) {
+    @media (max-width: 700px) {
         grid-template-columns: repeat(1, max-content);
     }
 `;

--- a/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/overgangsstønad/KortInnholdOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/overgangsstønad/KortInnholdOvergangsstønad.tsx
@@ -9,19 +9,9 @@ const Grid = styled.div`
     grid-template-columns: repeat(4, max-content);
     row-gap: 0.2rem;
     column-gap: 1rem;
-
-    @media (max-width: 1300px) {
-        grid-template-columns: repeat(3, max-content);
-    }
-
-    @media (max-width: 1000px) {
-        grid-template-columns: repeat(2, max-content);
-    }
-
-    @media (max-width: 700px) {
-        grid-template-columns: repeat(1, max-content);
-    }
+    text-overflow: ellipsis;
 `;
+
 const Row = styled.div`
     display: contents;
 `;

--- a/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/overgangsstønad/KortInnholdOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/overgangsstønad/KortInnholdOvergangsstønad.tsx
@@ -10,15 +10,15 @@ const Grid = styled.div`
     row-gap: 0.2rem;
     column-gap: 1rem;
 
-    @media (max-width: 900px) {
+    @media (max-width: 1300px) {
         grid-template-columns: repeat(3, max-content);
     }
 
-    @media (max-width: 768px) {
+    @media (max-width: 1000px) {
         grid-template-columns: repeat(2, max-content);
     }
 
-    @media (max-width: 480px) {
+    @media (max-width: 500px) {
         grid-template-columns: repeat(1, max-content);
     }
 `;

--- a/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/overgangsstønad/KortInnholdOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/overgangsstønad/KortInnholdOvergangsstønad.tsx
@@ -9,6 +9,18 @@ const Grid = styled.div`
     grid-template-columns: repeat(4, max-content);
     row-gap: 0.2rem;
     column-gap: 1rem;
+
+    @media (max-width: 1024px) {
+        grid-template-columns: repeat(3, max-content);
+    }
+
+    @media (max-width: 768px) {
+        grid-template-columns: repeat(2, max-content);
+    }
+
+    @media (max-width: 480px) {
+        grid-template-columns: 1fr;
+    }
 `;
 const Row = styled.div`
     display: contents;

--- a/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/overgangsstønad/KortInnholdOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/overgangsstønad/KortInnholdOvergangsstønad.tsx
@@ -9,7 +9,6 @@ const Grid = styled.div`
     grid-template-columns: repeat(4, minmax(auto, max-content));
     row-gap: 0.2rem;
     column-gap: 1rem;
-    text-overflow: ellipsis;
 `;
 
 const Row = styled.div`

--- a/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/overgangsstønad/KortInnholdOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/overgangsstønad/KortInnholdOvergangsstønad.tsx
@@ -10,7 +10,7 @@ const Grid = styled.div`
     row-gap: 0.2rem;
     column-gap: 1rem;
 
-    @media (max-width: 1024px) {
+    @media (max-width: 900px) {
         grid-template-columns: repeat(3, max-content);
     }
 
@@ -19,7 +19,7 @@ const Grid = styled.div`
     }
 
     @media (max-width: 480px) {
-        grid-template-columns: 1fr;
+        grid-template-columns: repeat(1, max-content);
     }
 `;
 const Row = styled.div`

--- a/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/overgangsstønad/KortInnholdOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/overgangsstønad/KortInnholdOvergangsstønad.tsx
@@ -6,7 +6,7 @@ import HistorikkRadIOvergangsstønad from './HistorikkRadIOvergangsstønad';
 
 const Grid = styled.div`
     display: grid;
-    grid-template-columns: repeat(4, max-content);
+    grid-template-columns: repeat(4, minmax(auto, max-content));
     row-gap: 0.2rem;
     column-gap: 1rem;
     text-overflow: ellipsis;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Trenger å utbedre ikke responsiv tekst i oversikten over historiske vedtaksperioder. 

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-17720

En hard squeeze: 

![image](https://github.com/navikt/familie-ef-sak-frontend/assets/56258085/1797745d-8f18-46fe-b1ea-58b4d585ef78)
