### PR TITLE
Feilmelding på ikke sammenhengende vedtaksperioder

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/vedtaksvalidering.ts
@@ -9,6 +9,7 @@ import {
     erMånedÅrEtter,
     erMånedÅrEtterEllerLik,
     erMånedÅrLik,
+    erPåfølgendeÅrMåned,
     plusMåneder,
     tilDato,
     tilÅrMåned,
@@ -139,12 +140,21 @@ export const validerVedtaksperioder = ({
                 årMånedFra: `Ugyldig periode - fra (${årMånedFra}) må være før til (${årMånedTil})`,
             };
         }
-        const forrige = index > 0 && perioder[index - 1];
-        if (forrige && forrige.årMånedTil) {
-            if (!erMånedÅrLik(tilÅrMåned(plusMåneder(forrige.årMånedTil, 1)), årMånedFra)) {
+
+        const forrigePeriode = index > 0 && perioder[index - 1];
+
+        if (forrigePeriode && forrigePeriode.årMånedTil) {
+            if (!erMånedÅrEtter(forrigePeriode.årMånedTil, årMånedFra)) {
                 return {
                     ...vedtaksperiodeFeil,
-                    årMånedFra: `Ugyldig etterfølgende periode - fra (${årMånedFra}) må være etter til (${forrige.årMånedTil})`,
+                    årMånedFra: `Ugyldig etterfølgende periode - fra (${årMånedFra}) må være etter til (${forrigePeriode.årMånedTil})`,
+                };
+            }
+
+            if (!erPåfølgendeÅrMåned(forrigePeriode.årMånedTil, årMånedFra)) {
+                return {
+                    ...vedtaksperiodeFeil,
+                    årMånedFra: `Periodene er ikke sammenhengende`,
                 };
             }
         }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Gjort endringer slik at feilmeldingen skal være mer forståelig, når periodene ikke er sammenhengende.
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-18256)

Feilmelding etter endringer:
<img width="1220" alt="image" src="https://github.com/navikt/familie-ef-sak-frontend/assets/141132903/f7db6844-aa82-4b4f-a595-fc766f19b21f">
