### PR TITLE
Endret feilmelding på validering av perioder

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/vedtaksvalidering.ts
@@ -12,7 +12,11 @@ import {
     erPåfølgendeÅrMåned,
 } from '../../../../../App/utils/dato';
 import { erOpphørEllerSanksjon } from '../Felles/utils';
-import { ugyldigEtterfølgendePeriodeFeilmelding, validerGyldigTallverdi } from '../../Felles/utils';
+import {
+    fraPeriodeErEtterTilPeriode,
+    ugyldigEtterfølgendePeriodeFeilmelding,
+    validerGyldigTallverdi,
+} from '../../Felles/utils';
 
 export const validerInnvilgetVedtakForm = ({
     utgiftsperioder,
@@ -131,7 +135,7 @@ export const validerUtgiftsperioder = ({
         if (!erMånedÅrEtterEllerLik(årMånedFra, årMånedTil)) {
             return {
                 ...utgiftsperiodeFeil,
-                årMånedFra: `Ugyldig periode - fra (${årMånedFra}) må være før til (${årMånedTil})`,
+                årMånedFra: fraPeriodeErEtterTilPeriode,
             };
         }
 
@@ -211,7 +215,7 @@ const validerKontantstøttePerioder = (
         if (!erMånedÅrEtterEllerLik(årMånedFra, årMånedTil)) {
             return {
                 ...kontantstøtteperiodeFeil,
-                årMånedFra: `Ugyldig periode - fra (${årMånedFra}) må være før til (${årMånedTil})`,
+                årMånedFra: fraPeriodeErEtterTilPeriode,
             };
         }
         const forrige = index > 0 && kontantstøtteperioder[index - 1];
@@ -272,7 +276,7 @@ const validerTilleggsstønadPerioder = (
         if (!erMånedÅrEtterEllerLik(årMånedFra, årMånedTil)) {
             return {
                 ...tilleggsstønadPeriodeFeil,
-                årMånedFra: `Ugyldig periode - fra (${årMånedFra}) må være før til (${årMånedTil})`,
+                årMånedFra: fraPeriodeErEtterTilPeriode,
             };
         }
         const forrige = index > 0 && tilleggsstønadsperioder[index - 1];

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
@@ -206,3 +206,5 @@ export const validerGyldigTallverdi = (verdi: string | number | undefined | null
 export const ugyldigEtterfølgendePeriodeFeilmelding = (årMånedFra: string, årMånedTil: string) => {
     return `Periodene er ikke sammenhengende. ${genererÅrOgMånedFraStreng(årMånedFra)} må være etter ${genererÅrOgMånedFraStreng(årMånedTil)}`;
 };
+
+export const fraPeriodeErEtterTilPeriode = 'Til og med dato må være etter fra og med dato';

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/vedtaksvalidering.ts
@@ -16,7 +16,11 @@ import {
 } from '../../../../../App/utils/dato';
 import { InnvilgeVedtakForm } from './InnvilgeOvergangsstønad';
 import { FormErrors } from '../../../../../App/hooks/felles/useFormState';
-import { ugyldigEtterfølgendePeriodeFeilmelding, validerGyldigTallverdi } from '../../Felles/utils';
+import {
+    fraPeriodeErEtterTilPeriode,
+    ugyldigEtterfølgendePeriodeFeilmelding,
+    validerGyldigTallverdi,
+} from '../../Felles/utils';
 
 const attenMånederFremITiden = tilÅrMåned(plusMåneder(new Date(), 18));
 const syvMånederFremITiden = tilÅrMåned(plusMåneder(new Date(), 7));
@@ -138,7 +142,7 @@ export const validerVedtaksperioder = ({
         if (!erMånedÅrEtterEllerLik(årMånedFra, årMånedTil)) {
             return {
                 ...vedtaksperiodeFeil,
-                årMånedFra: `Ugyldig periode - fra (${årMånedFra}) må være før til (${årMånedTil})`,
+                årMånedFra: fraPeriodeErEtterTilPeriode,
             };
         }
 

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/Felles/vedtaksvalidering.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/Felles/vedtaksvalidering.ts
@@ -11,7 +11,7 @@ import {
     overlapper,
 } from '../../../../../App/utils/dato';
 import { beregnSkoleår, validerSkoleår } from './skoleår';
-import { validerGyldigTallverdi } from '../../Felles/utils';
+import { fraPeriodeErEtterTilPeriode, validerGyldigTallverdi } from '../../Felles/utils';
 import { InnvilgeVedtakForm } from './typer';
 
 const periodeSkolepengerFeil: FormErrors<IPeriodeSkolepenger> = {
@@ -134,7 +134,7 @@ const validerDelårsperioder = (
         if (!erMånedÅrEtterEllerLik(årMånedFra, årMånedTil)) {
             return {
                 ...periodeSkolepengerFeil,
-                årMånedFra: `Ugyldig periode - fra (${årMånedFra}) må være før til (${årMånedTil})`,
+                årMånedFra: fraPeriodeErEtterTilPeriode,
             };
         }
         const intervall: Intervall = {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

- Endret teksten slik at den blir mer forklarende.
- Laget en variabel med feilmelding som skal vises når fra og med dato er før til og med dato, da feilmeldingen brukes flere steder.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-4963)

Ny feilmelding:
![image](https://github.com/navikt/familie-ef-sak-frontend/assets/141132903/b8414ab2-c180-4fa4-acd1-3394bbd0f654)
