### PR TITLE
Mulighet for å velge opprett tilbakekreving automatisk dersom feilutbetalingsbeløp er under 4x rettsgebyr

### DIFF
--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -9,6 +9,7 @@ export enum ToggleName {
     kanMigrereBarnetilsyn = 'familie.ef.sak.migrering.barnetilsyn',
     henleggBehandlingUtenÅHenleggeOppgave = 'familie.ef.sak.henlegg-behandling-uten-oppgave',
     visSatsendring = 'familie.ef.sak.frontend-vis-satsendring',
+    visAutomatiskBehandlingAvTilbakekrevingValg = 'familie.ef.sak.frontend.tilbakekreving-under-4x-rettsgebyr',
 
     // Miljø-toggles - la stå
     visIkkePubliserteBrevmaler = 'familie.ef.sak.frontend-vis-ikke-publiserte-brevmaler',

--- a/src/frontend/Komponenter/Behandling/Simulering/InfostripeTilbakekrevingsvalg.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/InfostripeTilbakekrevingsvalg.tsx
@@ -11,11 +11,37 @@ const StyledAlert = styled(Alert)`
     margin: 1rem 0 0.25rem 0;
 `;
 
-export const InfostripeTilbakekrevingsvalg: React.FC = () => (
+const Liste = styled.ul`
+    display: flex;
+    flex-direction: column;
+    list-style: none;
+    padding-bottom: 1rem;
+    margin: 0;
+`;
+
+export const InfostripeTilbakekrevingsvalg: React.FC<{ erUnder4xRettsgebyr: boolean }> = ({
+    erUnder4xRettsgebyr,
+}) => (
     <StyledAlert variant={'info'}>
         <Heading spacing size="small" level="3">
             Informasjon om valg for tilbakekreving
         </Heading>
+        {erUnder4xRettsgebyr && (
+            <DivMedMargin>
+                <strong>
+                    Opprett automatisk behandling av tilbakekreving under 4 ganger rettsgebyret:
+                </strong>
+                <DivMedMargin>
+                    Dette valget kan du bruke når alle punktene er oppfylt:
+                    <Liste>
+                        <li>- Bruker har ikke handlet forsettlig eller grovt uaktsomt</li>
+                        <li>- Beløpet er under 4 ganger rettsgebyr</li>
+                        <li>- Beløpet skal ikke betales tilbake</li>
+                    </Liste>
+                    Saken blir automatisk behandlet og bruker får et vedtak om ikke tilbakebetaling.
+                </DivMedMargin>
+            </DivMedMargin>
+        )}
         <DivMedMargin>
             <strong>Opprett tilbakekreving, send varsel:</strong> Brukes når du vet at det blir
             feilutbetaling

--- a/src/frontend/Komponenter/Behandling/Simulering/InfostripeTilbakekrevingsvalg.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/InfostripeTilbakekrevingsvalg.tsx
@@ -11,10 +11,10 @@ const StyledAlert = styled(Alert)`
     margin: 1rem 0 0.25rem 0;
 `;
 
-const Liste = styled.ul`
+const Liste = styled.ol`
     display: flex;
     flex-direction: column;
-    list-style: none;
+    list-style-type: disc;
     padding-bottom: 1rem;
     margin: 0;
 `;
@@ -34,9 +34,9 @@ export const InfostripeTilbakekrevingsvalg: React.FC<{ erUnder4xRettsgebyr: bool
                 <DivMedMargin>
                     Dette valget kan du bruke når alle punktene er oppfylt:
                     <Liste>
-                        <li>- Bruker har ikke handlet forsettlig eller grovt uaktsomt</li>
-                        <li>- Beløpet er under 4 ganger rettsgebyr</li>
-                        <li>- Beløpet skal ikke betales tilbake</li>
+                        <li>Bruker har ikke handlet forsettlig eller grovt uaktsomt</li>
+                        <li>Beløpet er under 4 ganger rettsgebyr</li>
+                        <li>Beløpet skal ikke betales tilbake</li>
                     </Liste>
                     Saken blir automatisk behandlet og bruker får et vedtak om ikke tilbakebetaling.
                 </DivMedMargin>

--- a/src/frontend/Komponenter/Behandling/Simulering/SimuleringTabellWrapper.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/SimuleringTabellWrapper.tsx
@@ -39,7 +39,7 @@ const TekstMedMargin = styled(BodyShortSmall)`
 const StyledAlert = styled(Alert)`
     max-width: 60rem;
 `;
-
+const RETTSGEBYR_BELOP = 1277;
 const mapSimuleringstabellRader = (
     simuleringsresultat: ISimulering,
     år: number
@@ -84,7 +84,7 @@ const SimuleringTabellWrapper: React.FC<{
 
     function erUnder4xRettsgebyr() {
         return (
-            simuleringsresultat.feilutbetaling < 5108 &&
+            simuleringsresultat.feilutbetaling < RETTSGEBYR_BELOP * 4 &&
             toggles[ToggleName.visAutomatiskBehandlingAvTilbakekrevingValg]
         );
     }

--- a/src/frontend/Komponenter/Behandling/Simulering/SimuleringTabellWrapper.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/SimuleringTabellWrapper.tsx
@@ -17,6 +17,8 @@ import {
 } from '../../../App/typer/vedtak';
 import { BodyShortSmall } from '../../../Felles/Visningskomponenter/Tekster';
 import { Heading, Alert } from '@navikt/ds-react';
+import { useToggles } from '../../../App/context/TogglesContext';
+import { ToggleName } from '../../../App/context/toggles';
 
 const SimuleringsContainer = styled.div`
     margin: 2rem;
@@ -62,6 +64,7 @@ const SimuleringTabellWrapper: React.FC<{
     behandlingId: string;
     lagretVedtak?: IVedtak;
 }> = ({ simuleringsresultat, behandlingId, lagretVedtak }) => {
+    const { toggles } = useToggles();
     const muligeÅr = [...new Set(simuleringsresultat.perioder.map((p) => formaterIsoÅr(p.fom)))];
 
     const [år, settÅr] = useState(
@@ -77,6 +80,13 @@ const SimuleringTabellWrapper: React.FC<{
 
     function harFeilutbetaling() {
         return simuleringsresultat.feilutbetaling > 0;
+    }
+
+    function erUnder4xRettsgebyr() {
+        return (
+            simuleringsresultat.feilutbetaling < 5108 &&
+            toggles[ToggleName.visAutomatiskBehandlingAvTilbakekrevingValg]
+        );
     }
 
     function positivSumAvManuellePosteringer(simuleringsresultat: ISimulering) {
@@ -117,7 +127,12 @@ const SimuleringTabellWrapper: React.FC<{
                     </TekstMedMargin>
                 </Seksjon>
             )}
-            {harFeilutbetaling() && <Tilbakekreving behandlingId={behandlingId} />}
+            {harFeilutbetaling() && (
+                <Tilbakekreving
+                    behandlingId={behandlingId}
+                    erUnder4xRettsgebyr={erUnder4xRettsgebyr()}
+                />
+            )}
         </SimuleringsContainer>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Simulering/Tilbakekreving.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/Tilbakekreving.tsx
@@ -10,6 +10,7 @@ import { Loader } from '@navikt/ds-react';
 import { BodyShortSmall } from '../../../Felles/Visningskomponenter/Tekster';
 import { useRedirectEtterLagring } from '../../../App/hooks/felles/useRedirectEtterLagring';
 import { v4 as uuidv4 } from 'uuid';
+import { harVerdi } from '../../../App/utils/utils';
 
 export enum ITilbakekrevingsvalg {
     OPPRETT_MED_VARSEL = 'OPPRETT_MED_VARSEL',
@@ -25,10 +26,10 @@ export interface ITilbakekreving {
 }
 
 export const TilbakekrevingsvalgTilTekst: Record<ITilbakekrevingsvalg, string> = {
-    OPPRETT_MED_VARSEL: 'Opprett med varsel',
-    OPPRETT_UTEN_VARSEL: 'Opprett uten varsel',
+    OPPRETT_MED_VARSEL: 'Opprett tilbakekreving, send varsel',
+    OPPRETT_UTEN_VARSEL: 'Opprett tilbakekreving, ikke send varsel',
     OPPRETT_AUTOMATISK:
-        'Opprett automatisk behandling av tilbakekreving under 4 ganger rettsgebyret',
+        'Opprett automatisk behandling av tilbakekreving under 4 ganger rettsgebyret (ingen tilbakekreving)',
     AVVENT: 'Avvent',
 };
 
@@ -131,7 +132,10 @@ export const Tilbakekreving: React.FC<TilbakekrevingProps> = ({
             return;
         }
 
-        if (tilbakekrevingsvalg == ITilbakekrevingsvalg.OPPRETT_AUTOMATISK && begrunnelse == '') {
+        if (
+            tilbakekrevingsvalg == ITilbakekrevingsvalg.OPPRETT_AUTOMATISK &&
+            !harVerdi(begrunnelse)
+        ) {
             settValideringsfeil(
                 'Begrunnelse må fylles ut dersom automatisk opprettelse av tilbakekreving er valgt'
             );

--- a/src/frontend/Komponenter/Behandling/Simulering/Tilbakekreving.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/Tilbakekreving.tsx
@@ -14,6 +14,7 @@ import { v4 as uuidv4 } from 'uuid';
 export enum ITilbakekrevingsvalg {
     OPPRETT_MED_VARSEL = 'OPPRETT_MED_VARSEL',
     OPPRETT_UTEN_VARSEL = 'OPPRETT_UTEN_VARSEL',
+    OPPRETT_AUTOMATISK = 'OPPRETT_AUTOMATISK',
     AVVENT = 'AVVENT',
 }
 
@@ -26,6 +27,8 @@ export interface ITilbakekreving {
 export const TilbakekrevingsvalgTilTekst: Record<ITilbakekrevingsvalg, string> = {
     OPPRETT_MED_VARSEL: 'Opprett med varsel',
     OPPRETT_UTEN_VARSEL: 'Opprett uten varsel',
+    OPPRETT_AUTOMATISK:
+        'Opprett automatisk behandling av tilbakekreving under 4 ganger rettsgebyret',
     AVVENT: 'Avvent',
 };
 
@@ -37,9 +40,13 @@ const enum ÅpenTilbakekrevingStatus {
 
 export interface TilbakekrevingProps {
     behandlingId: string;
+    erUnder4xRettsgebyr: boolean;
 }
 
-export const Tilbakekreving: React.FC<TilbakekrevingProps> = ({ behandlingId }) => {
+export const Tilbakekreving: React.FC<TilbakekrevingProps> = ({
+    behandlingId,
+    erUnder4xRettsgebyr,
+}) => {
     const { axiosRequest, nullstillIkkePersisterteKomponenter, settIkkePersistertKomponent } =
         useApp();
     const { behandlingErRedigerbar, behandling } = useBehandling();
@@ -123,6 +130,14 @@ export const Tilbakekreving: React.FC<TilbakekrevingProps> = ({ behandlingId }) 
             settValideringsfeil('Mangelfull utfylling av tilbakekrevingsvalg');
             return;
         }
+
+        if (tilbakekrevingsvalg == ITilbakekrevingsvalg.OPPRETT_AUTOMATISK && begrunnelse == '') {
+            settValideringsfeil(
+                'Begrunnelse må fylles ut dersom automatisk opprettelse av tilbakekreving er valgt'
+            );
+            return;
+        }
+
         settFeilmelding('');
         settLåsKnapp(true);
         nullstillIkkePersisterteKomponenter();
@@ -190,6 +205,7 @@ export const Tilbakekreving: React.FC<TilbakekrevingProps> = ({ behandlingId }) 
                             låsKnapp={låsKnapp}
                             behandlingId={behandlingId}
                             valideringsfeil={valideringsfeil}
+                            erUnder4xRettsgebyr={erUnder4xRettsgebyr}
                         />
                     )}
                     {!behandlingErRedigerbar && (

--- a/src/frontend/Komponenter/Behandling/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/TilbakekrevingSkjema.tsx
@@ -35,6 +35,7 @@ interface Props {
     låsKnapp: boolean;
     behandlingId: string;
     valideringsfeil: string;
+    erUnder4xRettsgebyr: boolean;
 }
 
 export const TilbakekrevingSkjema: React.FC<Props> = ({
@@ -48,6 +49,7 @@ export const TilbakekrevingSkjema: React.FC<Props> = ({
     låsKnapp,
     behandlingId,
     valideringsfeil,
+    erUnder4xRettsgebyr,
 }) => {
     const { settIkkePersistertKomponent, axiosRequest } = useApp();
 
@@ -95,7 +97,16 @@ export const TilbakekrevingSkjema: React.FC<Props> = ({
                         endreBegrunnelse(e.target.value);
                     }}
                 />
-                <InfostripeTilbakekrevingsvalg />
+                <InfostripeTilbakekrevingsvalg erUnder4xRettsgebyr={erUnder4xRettsgebyr} />
+                {erUnder4xRettsgebyr && (
+                    <Radio
+                        value={ITilbakekrevingsvalg.OPPRETT_AUTOMATISK}
+                        name="tilbakekrevingRadio"
+                    >
+                        Opprett automatisk behandling av tilbakekreving under 4 ganger rettsgebyret
+                    </Radio>
+                )}
+
                 <Radio value={ITilbakekrevingsvalg.OPPRETT_MED_VARSEL} name="tilbakekrevingRadio">
                     Opprett tilbakekreving, send varsel
                 </Radio>

--- a/src/frontend/Komponenter/Behandling/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/TilbakekrevingSkjema.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { EnsligTextArea } from '../../../Felles/Input/TekstInput/EnsligTextArea';
 import styled from 'styled-components';
-import { ITilbakekrevingsvalg } from './Tilbakekreving';
+import { ITilbakekrevingsvalg, TilbakekrevingsvalgTilTekst } from './Tilbakekreving';
 import { useApp } from '../../../App/context/AppContext';
 import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../App/typer/ressurs';
 import { base64toBlob, åpnePdfIEgenTab } from '../../../App/utils/utils';
@@ -103,12 +103,12 @@ export const TilbakekrevingSkjema: React.FC<Props> = ({
                         value={ITilbakekrevingsvalg.OPPRETT_AUTOMATISK}
                         name="tilbakekrevingRadio"
                     >
-                        Opprett automatisk behandling av tilbakekreving under 4 ganger rettsgebyret
+                        {TilbakekrevingsvalgTilTekst[ITilbakekrevingsvalg.OPPRETT_AUTOMATISK]}
                     </Radio>
                 )}
 
                 <Radio value={ITilbakekrevingsvalg.OPPRETT_MED_VARSEL} name="tilbakekrevingRadio">
-                    Opprett tilbakekreving, send varsel
+                    {TilbakekrevingsvalgTilTekst[ITilbakekrevingsvalg.OPPRETT_MED_VARSEL]}
                 </Radio>
                 {tilbakekrevingsvalg === ITilbakekrevingsvalg.OPPRETT_MED_VARSEL && (
                     <VarselValg>
@@ -135,10 +135,10 @@ export const TilbakekrevingSkjema: React.FC<Props> = ({
                     </VarselValg>
                 )}
                 <Radio value={ITilbakekrevingsvalg.OPPRETT_UTEN_VARSEL} name="tilbakekrevingRadio">
-                    Opprett tilbakekreving, ikke send varsel
+                    {TilbakekrevingsvalgTilTekst[ITilbakekrevingsvalg.OPPRETT_UTEN_VARSEL]}
                 </Radio>
                 <Radio value={ITilbakekrevingsvalg.AVVENT} name="tilbakekrevingRadio">
-                    Avvent
+                    {TilbakekrevingsvalgTilTekst[ITilbakekrevingsvalg.AVVENT]}
                 </Radio>
             </RadioGroup>
             {valideringsfeil && <ErrorTekst>{valideringsfeil}</ErrorTekst>}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ikke ferdig avklart med hverken design eller tekster, men ønsker å merge denne med featuretoggle for å komme i gang med testing og "veien videre" til tilbakekreving.

<img width="1028" alt="Screenshot 2024-04-11 at 09 47 21" src="https://github.com/navikt/familie-ef-sak-frontend/assets/42737566/1bc0b92d-66ad-495e-b085-3934b9a22098">

[Feature toggle](https://teamfamilie-unleash-web.nav.cloud.nais.io/projects/default/features/familie.ef.sak.frontend.tilbakekreving-under-4x-rettsgebyr)

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-18192)