### PR TITLE
Prøver å endre grid-template-columns i grid for utenlandsopphold for …

### DIFF
--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Medlemskap/Utenlandsopphold.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Medlemskap/Utenlandsopphold.tsx
@@ -20,7 +20,7 @@ const PeriodeStyling = styled(BodyShort)`
 const Grid = styled.div`
     font-size: var(--a-font-size-medium);
     display: grid;
-    grid-template-columns: repeat(2, max-content);
+    grid-template-columns: auto 1fr;
     gap: 1rem;
     padding-left: 2rem;
 `;


### PR DESCRIPTION
…å bryte lengre linjer

### Hvorfor er denne endringen nødvendig? ✨

Saksbehandler melder om at teksten for årsak til utelandsopphold ikke brytes. Forsøker å endre grid-template-column i Grid for å bryte lengre tekst. 

Før:
<img width="1333" alt="image" src="https://github.com/navikt/familie-ef-sak-frontend/assets/56258085/35d3a4e4-6e85-4efc-bff9-8758561e33d3">

Etter:
<img width="1345" alt="image" src="https://github.com/navikt/familie-ef-sak-frontend/assets/56258085/dd89de6e-2bb2-4a65-82b6-099aae1fcfbd">



