### PR TITLE
Minimum bredde på kolonnen med Dato

### DIFF
--- a/src/frontend/Felles/Personopplysninger/TabellWrapper.tsx
+++ b/src/frontend/Felles/Personopplysninger/TabellWrapper.tsx
@@ -50,12 +50,21 @@ export const SmallTable = styled(Table).attrs({ size: 'small' })`
 
 type Kolonnetittel = string | React.ReactNode;
 
-export const KolonneTitler: React.FC<{ titler: Kolonnetittel[] }> = ({ titler }) => {
+export const KolonneTitler: React.FC<{
+    titler: Kolonnetittel[];
+    skalHaMinimumBreddePåKolonne?: boolean;
+}> = ({ titler, skalHaMinimumBreddePåKolonne = false }) => {
+    const minimumBreddePåDatoStyle = (tittel: Kolonnetittel) => {
+        return tittel === 'Dato' && skalHaMinimumBreddePåKolonne ? { minWidth: '10rem' } : {};
+    };
+
     return (
         <Table.Header>
             <Table.Row>
                 {titler.map((tittel, indeks) => (
-                    <Table.HeaderCell key={indeks}>{tittel}</Table.HeaderCell>
+                    <Table.HeaderCell key={indeks} style={minimumBreddePåDatoStyle(tittel)}>
+                        {tittel}
+                    </Table.HeaderCell>
                 ))}
             </Table.Row>
         </Table.Header>

--- a/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
@@ -180,7 +180,7 @@ const Dokumenter: React.FC<{ fagsakPerson: IFagsakPerson }> = ({ fagsakPerson })
             </FiltreringGrid>
 
             <Table size="small">
-                <KolonneTitler titler={titler} minimumBreddeDatoKolonne={true} />
+                <KolonneTitler titler={titler} skalHaMinimumBreddePåKolonne={true} />
                 <DataViewer response={{ dokumentResponse }}>
                     {({ dokumentResponse }) => {
                         const grupperteDokumenter = groupBy(

--- a/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
@@ -180,7 +180,7 @@ const Dokumenter: React.FC<{ fagsakPerson: IFagsakPerson }> = ({ fagsakPerson })
             </FiltreringGrid>
 
             <Table size="small">
-                <KolonneTitler titler={titler} />
+                <KolonneTitler titler={titler} minimumBreddeDatoKolonne={true} />
                 <DataViewer response={{ dokumentResponse }}>
                     {({ dokumentResponse }) => {
                         const grupperteDokumenter = groupBy(


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Dette er for å utbedre tabellen på Dokumentoversikt.

Ønsker at kolonnen med dato skal ha en minimumbredde slik at innholdet i cellene ikke legger seg over to linjer. Denne kolonnen hadde en tendens til å være først til å 'gi fra seg plass hvis skjermstørrelsen ble for liten.

- Legger til som optional props fordi komponenten KolonneTitler blir brukt flere steder i koden, og det kan være andre tabeller som har kolonnen 'Dato'

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-21368)