### PR TITLE
Footer brev - ikke se gjennom feilmelding

### DIFF
--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutterFooter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutterFooter.tsx
@@ -22,6 +22,7 @@ const Footer = styled.footer`
     position: fixed;
     bottom: 0;
     background-color: ${ABorderStrong};
+    z-index: 1;
 `;
 
 const MidtstiltInnhold = styled.div`
@@ -29,11 +30,6 @@ const MidtstiltInnhold = styled.div`
     align-items: center;
     margin-left: auto;
     margin-right: 50%;
-`;
-
-const HovedKnapp = styled(Button)`
-    margin-left: 1rem;
-    margin-right: 1rem;
 `;
 
 const FlexBox = styled.div`
@@ -126,7 +122,7 @@ const SendTilBeslutterFooter: React.FC<{
                             />
                         )}
                         <MidtstiltInnhold>
-                            <HovedKnapp
+                            <Button
                                 onClick={sendTilBeslutter}
                                 disabled={
                                     laster ||
@@ -136,7 +132,7 @@ const SendTilBeslutterFooter: React.FC<{
                                 type={'button'}
                             >
                                 {ferdigstillTittel}
-                            </HovedKnapp>
+                            </Button>
                         </MidtstiltInnhold>
                     </FlexBox>
                 </Footer>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
- Lagt til z-indeks på Footer fordi Aksel Accordion Header har z-indeks 1 som gjør at den legger seg over footeren.
- Fjernet unødvendig margin style på button.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-21238)

Uten indeks 1:
![image](https://github.com/navikt/familie-ef-sak-frontend/assets/141132903/9e169c40-ffd5-473e-a2e4-f001717f4f48)

Med indeks 1:
![image](https://github.com/navikt/familie-ef-sak-frontend/assets/141132903/0ffa6502-d475-4a57-880e-e5398b333dbf)
