### PR TITLE
Vise feilmelding på vedtak og beregning

### DIFF
--- a/src/frontend/App/context/BehandlingContext.tsx
+++ b/src/frontend/App/context/BehandlingContext.tsx
@@ -98,20 +98,18 @@ const [BehandlingProvider, useBehandling] = constate(() => {
     }, [ansvarligSaksbehandler]);
 
     useEffect(() => {
-        const henter =
-            behandling.status === RessursStatus.HENTER ||
-            ansvarligSaksbehandler.status === RessursStatus.HENTER;
-
-        if (henter) {
-            return;
-        }
-
-        settBehandlingErRedigerbar(
+        const kanOppdatereOmBehandlingErRedigerbar =
             behandling.status === RessursStatus.SUKSESS &&
-                ansvarligSaksbehandler.status === RessursStatus.SUKSESS &&
-                erBehandlingRedigerbar(behandling.data) &&
-                innloggetSaksbehandlerKanRedigereBehandling(ansvarligSaksbehandler.data)
-        );
+            ansvarligSaksbehandler.status === RessursStatus.SUKSESS;
+
+        if (kanOppdatereOmBehandlingErRedigerbar) {
+            settBehandlingErRedigerbar(
+                behandling.status === RessursStatus.SUKSESS &&
+                    ansvarligSaksbehandler.status === RessursStatus.SUKSESS &&
+                    erBehandlingRedigerbar(behandling.data) &&
+                    innloggetSaksbehandlerKanRedigereBehandling(ansvarligSaksbehandler.data)
+            );
+        }
     }, [behandling, ansvarligSaksbehandler, innloggetSaksbehandler]);
 
     const vilkårState = useVilkår();

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeOvergangsstønad.tsx
@@ -31,6 +31,7 @@ import HovedKnapp, { Knapp } from '../../../../../Felles/Knapper/HovedKnapp';
 import { CalculatorIcon } from '@navikt/aksel-icons';
 import { tomInntektsperiodeRad, tomVedtaksperiodeRad } from '../Felles/utils';
 import { ModalState } from '../../../Modal/NyEierModal';
+import { VStack } from '@navikt/ds-react';
 
 export type InnvilgeVedtakForm = Omit<
     Omit<IInnvilgeVedtakForOvergangsstønad, 'resultatType'>,
@@ -45,12 +46,6 @@ const Form = styled.form`
 
 const Beregningstabell = styled(Utregningstabell)`
     margin-left: 1rem;
-`;
-
-const Container = styled.div`
-    & > :not(:last-child) {
-        margin-bottom: 1rem;
-    }
 `;
 
 export const InnvilgeOvergangsstønad: React.FC<{
@@ -250,7 +245,7 @@ export const InnvilgeOvergangsstønad: React.FC<{
                 skalVelgeSamordningstype={skalVelgeSamordningstype}
             />
             {behandlingErRedigerbar && (
-                <Container>
+                <VStack gap={'4'}>
                     <Knapp
                         onClick={beregnPerioder}
                         variant={'secondary'}
@@ -261,7 +256,7 @@ export const InnvilgeOvergangsstønad: React.FC<{
                         Beregn
                     </Knapp>
                     {feilmelding && <AlertStripeFeilPreWrap>{feilmelding}</AlertStripeFeilPreWrap>}
-                </Container>
+                </VStack>
             )}
             <Beregningstabell beregnetStønad={beregnetStønad} />
             {behandlingErRedigerbar && <HovedKnapp disabled={laster} knappetekst="Lagre vedtak" />}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal få feilmelding på vedtak og beregning siden hvis det er revurdering med gammel G
 
- Bruker vstack for å lage luft mellom knapp og feilmelding
- Skal ikke kjøre settBehandlingErRedigerbar hvis noen av statusene ikke suksess fordi da blir hentLagretBeløpForYtelse kjørt.

![image](https://github.com/navikt/familie-ef-sak-frontend/assets/141132903/5ca84074-8ddc-451a-a961-c780c46606d3)
