### PR TITLE
Vis warning dersom bruker har flere tilbakekrevinger siste året

### DIFF
--- a/src/frontend/Komponenter/Behandling/Simulering/SimuleringSide.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/SimuleringSide.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { Simulering } from './SimuleringTyper';
 import SimuleringTabell from './SimuleringTabell';
 import { formaterIsoÅr } from '../../../App/utils/formatter';
@@ -15,6 +15,8 @@ import { useToggles } from '../../../App/context/TogglesContext';
 import { ToggleName } from '../../../App/context/toggles';
 import { mapSimuleringstabellRader } from './utils';
 import Sanksjonsperiode from './Sanksjonsperiode';
+import { useApp } from '../../../App/context/AppContext';
+import { byggTomRessurs, Ressurs } from '../../../App/typer/ressurs';
 
 const Container = styled.div`
     padding: 2rem;
@@ -36,7 +38,24 @@ const SimuleringSide: React.FC<{
     lagretVedtak?: IVedtak;
 }> = ({ simuleringsresultat, behandlingId, lagretVedtak }) => {
     const { toggles } = useToggles();
+    const { axiosRequest } = useApp();
     const muligeÅr = [...new Set(simuleringsresultat.perioder.map((p) => formaterIsoÅr(p.fom)))];
+
+    const [
+        finnesFlereTilbakekrevingsvalgRegistrertSisteÅr,
+        settFinnesFlereTilbakekrevingsvalgRegistrertSisteÅr,
+    ] = useState<Ressurs<boolean>>(byggTomRessurs());
+
+    const hentFinnesFlereTilbakekrevingsvalgRegistrertSisteÅr = () =>
+        axiosRequest<boolean, null>({
+            method: 'GET',
+            url: `/familie-ef-sak/api/tilbakekreving/behandlinger/${behandlingId}/finnesFlereTilbakekrevingerValgtSisteÅr`,
+        }).then((response) => settFinnesFlereTilbakekrevingsvalgRegistrertSisteÅr(response));
+
+    useEffect(() => {
+        hentFinnesFlereTilbakekrevingsvalgRegistrertSisteÅr();
+        // eslint-disable-next-line
+    }, [behandlingId]);
 
     const [år, settÅr] = useState(
         muligeÅr.length ? Math.max(...muligeÅr) : new Date().getFullYear()
@@ -69,6 +88,11 @@ const SimuleringSide: React.FC<{
                     <AlertWarning variant={'warning'}>
                         Det finnes manuelle posteringer tilknyttet tidligere behandling.
                         Simuleringsbildet kan derfor være ufullstendig.
+                    </AlertWarning>
+                )}
+                {finnesFlereTilbakekrevingsvalgRegistrertSisteÅr && (
+                    <AlertWarning variant={'warning'}>
+                        Det er registrert feilutbetaling i flere behandlinger siste året
                     </AlertWarning>
                 )}
                 <SimuleringTabell

--- a/src/frontend/Komponenter/Behandling/Simulering/SimuleringSide.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/SimuleringSide.tsx
@@ -93,7 +93,8 @@ const SimuleringSide: React.FC<{
                 {finnesFlereTilbakekrevingsvalgRegistrertSisteÅr &&
                     skalViseValgForAutomatiskBehandlingUnder4xRettsgebyr && (
                         <AlertWarning variant={'warning'}>
-                            Det er registrert feilutbetaling i flere behandlinger siste året
+                            Det er opprettet automatisk behandling av tilbakekreving minst 2 ganger
+                            i løpet av de siste 12 månedene. Vurder om beløpet skal betales tilbake.
                         </AlertWarning>
                     )}
                 <SimuleringTabell

--- a/src/frontend/Komponenter/Behandling/Simulering/SimuleringSide.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/SimuleringSide.tsx
@@ -90,11 +90,12 @@ const SimuleringSide: React.FC<{
                         Simuleringsbildet kan derfor være ufullstendig.
                     </AlertWarning>
                 )}
-                {finnesFlereTilbakekrevingsvalgRegistrertSisteÅr && (
-                    <AlertWarning variant={'warning'}>
-                        Det er registrert feilutbetaling i flere behandlinger siste året
-                    </AlertWarning>
-                )}
+                {finnesFlereTilbakekrevingsvalgRegistrertSisteÅr &&
+                    skalViseValgForAutomatiskBehandlingUnder4xRettsgebyr && (
+                        <AlertWarning variant={'warning'}>
+                            Det er registrert feilutbetaling i flere behandlinger siste året
+                        </AlertWarning>
+                    )}
                 <SimuleringTabell
                     perioder={simuleringTabellRader}
                     årsvelger={{ valgtÅr: år, settÅr: settÅr, muligeÅr: muligeÅr }}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Dersom bruker har hatt to eller flere behandlinger det er gjort tilbakekrevingsvalg på i løpet av det siste året, så skal det vises en warning. Dette gjelder i tilfeller hvor det er mulig å velge automatisk behandling av tilbakekreving, da saksbehandler i disse tilfellene må vurdere nøyere om behandlingen kan/burde automatisk behandles.

![Screenshot 2024-06-11 at 13 27 44](https://github.com/navikt/familie-ef-sak-frontend/assets/42737566/9fecb890-bab6-4750-9dc4-5dbdf28efd56)

[Link til backend-PR](https://github.com/navikt/familie-ef-sak/pull/2619)

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-20869)