### PR TITLE
Legg til tekst - ikke mulig å endre brevmottaker i tilbakekrevinger u…

### DIFF
--- a/src/frontend/Komponenter/Behandling/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/TilbakekrevingSkjema.tsx
@@ -208,11 +208,9 @@ const FireGangerRettsgebyr = () => (
             </li>
         </Liste>
         <BodyLong size="small">
-            Saken blir automatisk behandlet og bruker får et vedtak om ikke tilbakebetaling.
-        </BodyLong>
-        <BodyLong size="small">
-            Merk at det ikke er mulig å endre brevmottaker på denne typen tilbakekrevingsbehandling.
-            Hvis du skal endre brevmottaker, må du velge et annet alternativ.
+            Saken blir automatisk behandlet og bruker får et vedtak om ikke tilbakebetaling. Merk at
+            det ikke er mulig å endre brevmottaker på denne typen tilbakekrevingsbehandling. Hvis du
+            skal endre brevmottaker, må du velge et annet alternativ.
         </BodyLong>
     </>
 );

--- a/src/frontend/Komponenter/Behandling/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/TilbakekrevingSkjema.tsx
@@ -210,6 +210,10 @@ const FireGangerRettsgebyr = () => (
         <BodyLong size="small">
             Saken blir automatisk behandlet og bruker får et vedtak om ikke tilbakebetaling.
         </BodyLong>
+        <BodyLong size="small">
+            NB! Det er ikke mulig å endre brevmottaker på denne typen tilbakekrevingsbehandling.
+            Hvis du skal endre brevmottaker, må du velge et annet alternativ.
+        </BodyLong>
     </>
 );
 

--- a/src/frontend/Komponenter/Behandling/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/TilbakekrevingSkjema.tsx
@@ -211,7 +211,7 @@ const FireGangerRettsgebyr = () => (
             Saken blir automatisk behandlet og bruker får et vedtak om ikke tilbakebetaling.
         </BodyLong>
         <BodyLong size="small">
-            NB! Det er ikke mulig å endre brevmottaker på denne typen tilbakekrevingsbehandling.
+            Merk at det ikke er mulig å endre brevmottaker på denne typen tilbakekrevingsbehandling.
             Hvis du skal endre brevmottaker, må du velge et annet alternativ.
         </BodyLong>
     </>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er ikke mulig å endre brevmottaker på tilbakekrevingsbehandlinger under 4r som går automatisk. Vil derfor legge til en advarsel om at dette ikke er mulig. 

Diskutert tekst med funksjonell




