### PR TITLE
Fjern å fra url og endre til standard navngiving i url'er i ef-sak

### DIFF
--- a/src/frontend/Komponenter/Behandling/Simulering/SimuleringSide.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/SimuleringSide.tsx
@@ -49,7 +49,7 @@ const SimuleringSide: React.FC<{
     const hentFinnesFlereTilbakekrevingsvalgRegistrertSisteÅr = () =>
         axiosRequest<boolean, null>({
             method: 'GET',
-            url: `/familie-ef-sak/api/tilbakekreving/behandlinger/${behandlingId}/finnesFlereTilbakekrevingerValgtSisteÅr`,
+            url: `/familie-ef-sak/api/tilbakekreving/behandlinger/${behandlingId}/finnes-flere-tilbakekrevinger-valgt-siste-aar`,
         }).then((response) => settFinnesFlereTilbakekrevingsvalgRegistrertSisteÅr(response));
 
     useEffect(() => {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Får feil i prod om at ressurs/endepunkt ikke finnes: `api/tilbakekreving/behandlinger/2b4d7e04-67b4-401e-8ad1-42a43321e30c/finnesFlereTilbakekrevingerValgtSiste%C3%85r`
Antar at dette har noe å gjøre med å i url, så erstatter denne med aa. Bare litt rart at det virker i preprod.

[Backend-PR](https://github.com/navikt/familie-ef-sak/pull/2620)