### PR TITLE
Tekstfix for 4x rettsgebyr

### DIFF
--- a/src/frontend/Komponenter/Behandling/Simulering/HeaderBegrunnelse.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/HeaderBegrunnelse.tsx
@@ -44,5 +44,10 @@ export const HeaderBegrunnelse: React.FC = () => (
                 </Tekst>
             </li>
         </Liste>
+        <Tekst textColor="subtle">
+            Hvis det feilutbetalte beløpet er under 4 ganger rettsgebyret og du ikke skal kreve det
+            tilbake, må du i tillegg ha vurdert at bruker ikke har handlet forsettlig eller grovt
+            uaktsomt.
+        </Tekst>
     </>
 );

--- a/src/frontend/Komponenter/Behandling/Simulering/HeaderBegrunnelse.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/HeaderBegrunnelse.tsx
@@ -13,6 +13,10 @@ const Liste = styled.ul`
     }
 `;
 
+const ListeTekst = styled(BodyLong)`
+    padding-left: 0.25rem;
+`;
+
 const Tekst = styled(BodyLong)`
     padding-top: 1.25rem;
 `;
@@ -24,24 +28,26 @@ export const HeaderBegrunnelse: React.FC = () => (
         <BodyLong textColor="subtle">Dette må være med i vurderingen:</BodyLong>
         <Liste>
             <li>
-                <Tekst textColor="subtle">Årsaken til feilutbetalingen</Tekst>
+                <ListeTekst textColor="subtle">Årsaken til feilutbetalingen</ListeTekst>
             </li>
             <li>
-                <Tekst textColor="subtle">Hvordan feilutbetalingen ble oppdaget </Tekst>
+                <ListeTekst textColor="subtle">Hvordan feilutbetalingen ble oppdaget </ListeTekst>
             </li>
             <li>
-                <Tekst textColor="subtle">
+                <ListeTekst textColor="subtle">
                     Hvem som oppdaget feilutbetalingen (bruker eller NAV)
-                </Tekst>
+                </ListeTekst>
             </li>
             <li>
-                <Tekst textColor="subtle">Dato for når feilutbetalingen ble oppdaget</Tekst>
+                <ListeTekst textColor="subtle">
+                    Dato for når feilutbetalingen ble oppdaget
+                </ListeTekst>
             </li>
             <li>
-                <Tekst textColor="subtle">
+                <ListeTekst textColor="subtle">
                     Andre relevante opplysninger, for eksempel hva slags informasjon bruker har fått
                     eller tidligere feilutbetalingssaker
-                </Tekst>
+                </ListeTekst>
             </li>
         </Liste>
         <Tekst textColor="subtle">

--- a/src/frontend/Komponenter/Behandling/Simulering/HeaderBegrunnelse.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/HeaderBegrunnelse.tsx
@@ -14,7 +14,7 @@ const Liste = styled.ul`
 `;
 
 const Tekst = styled(BodyLong)`
-    padding-left: 1.25rem;
+    padding-top: 1.25rem;
 `;
 
 export const HeaderBegrunnelse: React.FC = () => (
@@ -45,8 +45,9 @@ export const HeaderBegrunnelse: React.FC = () => (
             </li>
         </Liste>
         <Tekst textColor="subtle">
-            Hvis det feilutbetalte beløpet er under 4 rettsgebyr og du ikke skal kreve det tilbake,
-            må du i tillegg ha vurdert at bruker ikke har handlet forsettlig eller grovt uaktsomt.
+            Hvis det feilutbetalte beløpet er under 4 rettsgebyr og beløpet ikke skal betales
+            tilbake, må du i tillegg ha vurdert at bruker ikke har handlet forsettlig eller grovt
+            uaktsomt.
         </Tekst>
     </>
 );

--- a/src/frontend/Komponenter/Behandling/Simulering/HeaderBegrunnelse.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/HeaderBegrunnelse.tsx
@@ -45,9 +45,8 @@ export const HeaderBegrunnelse: React.FC = () => (
             </li>
         </Liste>
         <Tekst textColor="subtle">
-            Hvis det feilutbetalte beløpet er under 4 ganger rettsgebyret og du ikke skal kreve det
-            tilbake, må du i tillegg ha vurdert at bruker ikke har handlet forsettlig eller grovt
-            uaktsomt.
+            Hvis det feilutbetalte beløpet er under 4 rettsgebyr og du ikke skal kreve det tilbake,
+            må du i tillegg ha vurdert at bruker ikke har handlet forsettlig eller grovt uaktsomt.
         </Tekst>
     </>
 );


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
La til tekst som skal ligge under punktlista ved aktivering av 4x rettsgebyr.
Fikk dessverre ikke testet at den vises riktig, da simulering i preprod er nede.