### PR TITLE
Satsendring, Korrigering uten brev, G_omregning, og migrering er alle…

### DIFF
--- a/src/frontend/Komponenter/Behandling/Fanemeny/BehandlingsÅrsakUtenBrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Fanemeny/BehandlingsÅrsakUtenBrev.tsx
@@ -24,9 +24,9 @@ const BehandlingsÅrsakUtenBrev: React.FC<Props> = ({ behandlingId }) => {
             {({ behandling, vedtak }) => (
                 <>
                     <AlertInfo>
-                        {behandling.behandlingsårsak === Behandlingsårsak.KORRIGERING_UTEN_BREV
-                            ? 'Korrigering av vedtak uten brevutsendelse'
-                            : 'Iverksette KA-vedtak (uten brev)'}
+                        {behandling.behandlingsårsak === Behandlingsårsak.IVERKSETTE_KA_VEDTAK
+                            ? 'Iverksette KA-vedtak (uten brev)'
+                            : 'Korrigering av vedtak uten brevutsendelse'}
                     </AlertInfo>
                     <SendTilBeslutterFooter
                         behandling={behandling}


### PR DESCRIPTION
… vedtak uten brev - og bør ha felles tekst som sådan. Iverksetting av KA-vedtak skal ha sin egen tekst, og da må vi følgelig sjekke for den typen når vi skriver ut info-alert-tekst

### Hvorfor er denne endringen nødvendig? ✨
Så denne da jeg skulle sjekke manuelle g-omregninger

![Screenshot 2024-06-24 at 12 49 01](https://github.com/navikt/familie-ef-sak-frontend/assets/402915/2409734e-b86f-46ed-8c1a-9d7af90b8abf)
