### PR TITLE
Fjerne felter fra Sivilstand som også blir vist på  Samvær

### DIFF
--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Sivilstand/Søknadsinformasjon.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Sivilstand/Søknadsinformasjon.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { SivilstandType } from '../../../../App/typer/personopplysninger';
-import { EÅrsakEnslig, ISivilstandSøknadsgrunnlag, ÅrsakEnsligTilTekst } from './typer';
+import { EÅrsakEnslig, ISivilstandSøknadsgrunnlag } from './typer';
 import { hentBooleanTekst } from '../utils';
 import { formaterNullableIsoDato, mapTrueFalse } from '../../../../App/utils/formatter';
 import Informasjonsrad from '../../Vilkårpanel/Informasjonsrad';
@@ -78,23 +78,6 @@ const Søknadsinformasjon: FC<Props> = ({ sivilstandtype, søknad }) => {
                             mapTrueFalse(erUformeltSeparertEllerSkilt)
                         }
                     />
-                    <Informasjonsrad
-                        ikon={VilkårInfoIkon.SØKNAD}
-                        label="Alene med barn fordi"
-                        verdi={søknad.årsakEnslig && ÅrsakEnsligTilTekst[søknad.årsakEnslig]}
-                    />
-
-                    {søknad.årsakEnslig === EÅrsakEnslig.samlivsbruddForeldre && (
-                        <Informasjonsrad
-                            ikon={VilkårInfoIkon.SØKNAD}
-                            label="Dato for samlivsbrudd"
-                            verdi={
-                                søknad.samlivsbruddsdato
-                                    ? formaterNullableIsoDato(søknad.samlivsbruddsdato)
-                                    : '-'
-                            }
-                        />
-                    )}
 
                     {søknad.årsakEnslig === EÅrsakEnslig.samlivsbruddAndre && (
                         <>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-21625)

![image](https://github.com/navikt/familie-ef-sak-frontend/assets/141132903/2769e59d-3df0-4627-a499-3b75bfa3b22e)
