### PR TITLE
Tydeliggjør foreldede unntak

### DIFF
--- a/src/frontend/App/utils/utils.ts
+++ b/src/frontend/App/utils/utils.ts
@@ -35,7 +35,7 @@ export const oppdaterFilter = (
 };
 
 /**
- * Deler listen opp i to separate lister basert på en filter-funksjonen.
+ * Deler listen opp i to separate lister basert på filter-funksjonen.
  * @param liste Listen som skal deles i to.
  * @param filter Betingelsen som avgjør om elementet havner i pass- eller fail-listen.
  */

--- a/src/frontend/App/utils/utils.ts
+++ b/src/frontend/App/utils/utils.ts
@@ -34,6 +34,19 @@ export const oppdaterFilter = (
     };
 };
 
+/**
+ * Deler listen opp i to separate lister basert på en filter-funksjonen.
+ * @param liste Listen som skal deles i to.
+ * @param filter Betingelsen som avgjør om elementet havner i pass- eller fail-listen.
+ */
+export const splittListe = <T>(liste: T[], filter: (verdi: T) => boolean): T[][] =>
+    liste.reduce(
+        ([pass, fail], val) => {
+            return filter(val) ? [[...pass, val], fail] : [pass, [...fail, val]];
+        },
+        [[], []] as T[][]
+    );
+
 export const base64toBlob = (b64Data: string, contentType = '', sliceSize = 512): Blob => {
     const byteCharacters = atob(b64Data);
     const byteArrays = [];

--- a/src/frontend/Komponenter/Behandling/Vurdering/Delvilkår.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/Delvilkår.tsx
@@ -3,10 +3,20 @@ import { FC } from 'react';
 import { Regel } from './typer';
 import { DelvilkårContainer } from './DelvilkårContainer';
 import { hjelpeTekstConfig } from './hjelpetekstconfig';
-import { delvilkårTypeTilTekst, svarTypeTilTekst, tekstSkalKursiveres } from './tekster';
+import { delvilkårTypeTilTekst } from './tekster';
 import { Vurdering } from '../Inngangsvilkår/vilkår';
-import { Alert, HelpText, Radio, RadioGroup } from '@navikt/ds-react';
-import styled from 'styled-components';
+import { HelpText, RadioGroup } from '@navikt/ds-react';
+import { RadioKnapper } from './RadioKnapper';
+import { RadioKnapperMedlemskapUnntak } from './RadioKnapperMedlemskapUnntak';
+
+const utledRadioKnapper = (regel: Regel, settVurdering: (nyttSvar: Vurdering) => void) => {
+    switch (regel.regelId) {
+        case 'MEDLEMSKAP_UNNTAK':
+            return <RadioKnapperMedlemskapUnntak regel={regel} settVurdering={settVurdering} />;
+        default:
+            return <RadioKnapper regel={regel} settVurdering={settVurdering} />;
+    }
+};
 
 interface Props {
     regel: Regel;
@@ -14,40 +24,13 @@ interface Props {
     settVurdering: (nyttSvar: Vurdering) => void;
 }
 
-const FontStyle = styled.div<{ $italic: boolean }>`
-    font-style: ${(props) => (props.$italic ? 'italic' : 'normal')};
-`;
-
 const Delvilkår: FC<Props> = ({ regel, vurdering, settVurdering }) => {
     const hjelpetekst = hjelpeTekstConfig[regel.regelId];
 
     return (
         <DelvilkårContainer>
             <RadioGroup legend={delvilkårTypeTilTekst[regel.regelId]} value={vurdering.svar || ''}>
-                {Object.keys(regel.svarMapping).map((svarId, i) => {
-                    const erTekstKursiv = tekstSkalKursiveres(svarId);
-                    return (
-                        <>
-                            <InfoStripe indeks={i} regelId={regel.regelId} />
-
-                            <Radio
-                                key={`${regel.regelId}_${svarId}`}
-                                name={`${regel.regelId}_${svarId}`}
-                                value={svarId}
-                                onChange={() =>
-                                    settVurdering({
-                                        svar: svarId,
-                                        regelId: regel.regelId,
-                                    })
-                                }
-                            >
-                                <FontStyle $italic={erTekstKursiv}>
-                                    {svarTypeTilTekst[svarId]}
-                                </FontStyle>
-                            </Radio>
-                        </>
-                    );
-                })}
+                {utledRadioKnapper(regel, settVurdering)}
             </RadioGroup>
             {hjelpetekst && (
                 <HelpText placement={hjelpetekst.plassering}>
@@ -59,18 +42,3 @@ const Delvilkår: FC<Props> = ({ regel, vurdering, settVurdering }) => {
 };
 
 export default Delvilkår;
-
-const InfoStripe: FC<{ indeks: number; regelId: string }> = ({ indeks, regelId }) => {
-    const skalViseInfostripe = indeks === 0 && regelId === 'MEDLEMSKAP_UNNTAK';
-
-    if (!skalViseInfostripe) {
-        return <></>;
-    }
-
-    return (
-        <Alert size="small" variant="info">
-            Det er nye regler for unntak fra 1. september 2023. Du må vurdere om det er nye eller
-            gamle regler som gjelder for saken din.
-        </Alert>
-    );
-};

--- a/src/frontend/Komponenter/Behandling/Vurdering/RadioKnapper.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/RadioKnapper.tsx
@@ -1,0 +1,30 @@
+import { Regel } from './typer';
+import { Vurdering } from '../Inngangsvilkår/vilkår';
+import { svarTypeTilTekst } from './tekster';
+import { Radio } from '@navikt/ds-react';
+import * as React from 'react';
+
+interface Props {
+    regel: Regel;
+    settVurdering: (nyttSvar: Vurdering) => void;
+}
+
+export const RadioKnapper: React.FC<Props> = ({ regel, settVurdering }) => (
+    <>
+        {Object.keys(regel.svarMapping).map((svarId) => (
+            <Radio
+                key={`${regel.regelId}_${svarId}`}
+                name={`${regel.regelId}_${svarId}`}
+                value={svarId}
+                onChange={() =>
+                    settVurdering({
+                        svar: svarId,
+                        regelId: regel.regelId,
+                    })
+                }
+            >
+                {svarTypeTilTekst[svarId]}
+            </Radio>
+        ))}
+    </>
+);

--- a/src/frontend/Komponenter/Behandling/Vurdering/RadioKnapperMedlemskapUnntak.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/RadioKnapperMedlemskapUnntak.tsx
@@ -1,0 +1,69 @@
+import { Regel } from './typer';
+import { Vurdering } from '../Inngangsvilkår/vilkår';
+import { erUnntakForeldet, svarTypeTilTekst } from './tekster';
+import { Alert, Label, Radio } from '@navikt/ds-react';
+import * as React from 'react';
+import styled from 'styled-components';
+import { splittListe } from '../../../App/utils/utils';
+
+const Italic = styled.div`
+    font-style: italic;
+`;
+
+interface Props {
+    regel: Regel;
+    settVurdering: (nyttSvar: Vurdering) => void;
+}
+
+export const RadioKnapperMedlemskapUnntak: React.FC<Props> = ({ regel, settVurdering }) => {
+    const unntak = Object.keys(regel.svarMapping);
+    const [foreldedeUnntak, nåværendeUnntak] = splittListe(unntak, erUnntakForeldet);
+
+    return (
+        <>
+            <InfoStripe />
+            {nåværendeUnntak.map((svarId) => (
+                <>
+                    <Radio
+                        key={`${regel.regelId}_${svarId}`}
+                        name={`${regel.regelId}_${svarId}`}
+                        value={svarId}
+                        onChange={() =>
+                            settVurdering({
+                                svar: svarId,
+                                regelId: regel.regelId,
+                            })
+                        }
+                    >
+                        {svarTypeTilTekst[svarId]}
+                    </Radio>
+                </>
+            ))}
+            <Label size="small">Gamle regler for unntak:</Label>
+            {foreldedeUnntak.map((svarId) => (
+                <>
+                    <Radio
+                        key={`${regel.regelId}_${svarId}`}
+                        name={`${regel.regelId}_${svarId}`}
+                        value={svarId}
+                        onChange={() =>
+                            settVurdering({
+                                svar: svarId,
+                                regelId: regel.regelId,
+                            })
+                        }
+                    >
+                        <Italic>{svarTypeTilTekst[svarId]}</Italic>
+                    </Radio>
+                </>
+            ))}
+        </>
+    );
+};
+
+const InfoStripe: React.FC = () => (
+    <Alert size="small" variant="info">
+        Det er nye regler for unntak fra 1. september 2023. Du må vurdere om det er nye eller gamle
+        regler som gjelder for saken din.
+    </Alert>
+);

--- a/src/frontend/Komponenter/Behandling/Vurdering/RadioKnapperMedlemskapUnntak.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/RadioKnapperMedlemskapUnntak.tsx
@@ -10,6 +10,10 @@ const Italic = styled.div`
     font-style: italic;
 `;
 
+const Spacing = styled.div`
+    margin-top: 1rem;
+`;
+
 interface Props {
     regel: Regel;
     settVurdering: (nyttSvar: Vurdering) => void;
@@ -22,41 +26,42 @@ export const RadioKnapperMedlemskapUnntak: React.FC<Props> = ({ regel, settVurde
     return (
         <>
             <InfoStripe />
+            <Spacing />
             {nåværendeUnntak.map((svarId) => (
-                <>
-                    <Radio
-                        key={`${regel.regelId}_${svarId}`}
-                        name={`${regel.regelId}_${svarId}`}
-                        value={svarId}
-                        onChange={() =>
-                            settVurdering({
-                                svar: svarId,
-                                regelId: regel.regelId,
-                            })
-                        }
-                    >
-                        {svarTypeTilTekst[svarId]}
-                    </Radio>
-                </>
+                <Radio
+                    key={`${regel.regelId}_${svarId}`}
+                    name={`${regel.regelId}_${svarId}`}
+                    value={svarId}
+                    onChange={() =>
+                        settVurdering({
+                            svar: svarId,
+                            regelId: regel.regelId,
+                        })
+                    }
+                >
+                    {svarTypeTilTekst[svarId]}
+                </Radio>
             ))}
-            <Label size="small">Gamle regler for unntak:</Label>
+            <Spacing />
+            <Label size="small" spacing>
+                Gamle regler for unntak:
+            </Label>
             {foreldedeUnntak.map((svarId) => (
-                <>
-                    <Radio
-                        key={`${regel.regelId}_${svarId}`}
-                        name={`${regel.regelId}_${svarId}`}
-                        value={svarId}
-                        onChange={() =>
-                            settVurdering({
-                                svar: svarId,
-                                regelId: regel.regelId,
-                            })
-                        }
-                    >
-                        <Italic>{svarTypeTilTekst[svarId]}</Italic>
-                    </Radio>
-                </>
+                <Radio
+                    key={`${regel.regelId}_${svarId}`}
+                    name={`${regel.regelId}_${svarId}`}
+                    value={svarId}
+                    onChange={() =>
+                        settVurdering({
+                            svar: svarId,
+                            regelId: regel.regelId,
+                        })
+                    }
+                >
+                    <Italic>{svarTypeTilTekst[svarId]}</Italic>
+                </Radio>
             ))}
+            <Spacing />
         </>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Vurdering/tekster.ts
+++ b/src/frontend/Komponenter/Behandling/Vurdering/tekster.ts
@@ -1,4 +1,4 @@
-export const teksterMedKursiv = [
+export const eldreUnntaksregler = [
     'MEDLEM_MER_ENN_7_ÅR_AVBRUDD_MER_ENN_10ÅR',
     'ANDRE_FORELDER_MEDLEM_MINST_7_ÅR_AVBRUDD_MER_ENN_10_ÅR',
     'I_LANDET_FOR_GJENFORENING_ELLER_GIFTE_SEG',
@@ -112,4 +112,4 @@ export const svarTypeTilTekst: Record<string, string> = {
 
 /* Alternativer som kun er aktuelle for vedtak før 1. september 2023 skal kursiveres - for å vise saksbehandler at de
  *  er utdaterte. Alternativene må fortsatt være tilgjengelige å velge for potensielle saker man ikke får migrert fra infotrygd */
-export const tekstSkalKursiveres = (tekst: string): boolean => teksterMedKursiv.includes(tekst);
+export const erUnntakForeldet = (tekst: string): boolean => eldreUnntaksregler.includes(tekst);


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-21273)

Vi har fått tilbakemeldinger på at det har vært vanskelig å skille på foreldede unntak vs. up-to-date unntak for forutgående medlemskap. Denne PRen tydeliggjør denne forskjellen - se bilde:
![Skjermbilde 2024-06-25 kl  10 15 13](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/39961094-696c-4722-8d98-46cbe37b0bca)
