### PR TITLE
Forbedring av addressevisning for barn

### DIFF
--- a/src/frontend/App/hooks/useGjeldeneBarn.ts
+++ b/src/frontend/App/hooks/useGjeldeneBarn.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+import { useBehandling } from '../context/BehandlingContext';
+import { IBarn } from '../typer/personopplysninger';
+
+export const useGjeldendeBarn = (barnIdent: string | undefined) => {
+    const { personopplysningerResponse } = useBehandling();
+    const [gjeldendeBarn, setGjeldendeBarn] = useState<IBarn | undefined>(undefined);
+
+    useEffect(() => {
+        if (personopplysningerResponse.status === 'SUKSESS') {
+            const barn = personopplysningerResponse.data.barn.find(
+                (barn) => barn.personIdent === barnIdent
+            );
+            setGjeldendeBarn(barn);
+        }
+    }, [personopplysningerResponse, barnIdent]);
+
+    return gjeldendeBarn;
+};

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/AleneomsorgInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/AleneomsorgInfo.tsx
@@ -80,6 +80,7 @@ const AleneomsorgInfo: FC<{
                 harDeltBostedVedGrunnlagsdataopprettelse={
                     registergrunnlag.harDeltBostedVedGrunnlagsdataopprettelse
                 }
+                barnFødselsnummer={registergrunnlag.fødselsnummer}
             />
             {skalViseSøknadsdata && søknadsgrunnlag.skalBoBorHosSøker && (
                 <Informasjonsrad

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/Bosted.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/Bosted.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { Popover } from '@navikt/ds-react';
 import { InformationSquareIcon } from '@navikt/aksel-icons';
 import { popoverContentDeltBosted } from '../../../../Felles/Personopplysninger/BarnDeltBosted';
+import BostedMedReadMore from './ReadMoreMedAdresser';
 
 interface Props {
     harSammeAdresseSøknad?: boolean;
@@ -13,6 +14,7 @@ interface Props {
     erBarnetFødt: boolean;
     deltBostedPerioder: IDeltBostedPeriode[];
     harDeltBostedVedGrunnlagsdataopprettelse: boolean;
+    barnFødselsnummer?: string;
 }
 
 const FlexBox = styled.div`
@@ -38,13 +40,17 @@ const utledBostedTekst = (harDeltBosted: boolean, harSammeAdresse: boolean | und
     }
     return 'Ikke registrert på brukers adresse';
 };
+
 const Bosted: FC<Props> = ({
     harSammeAdresseSøknad,
     harSammeAdresseRegister,
     erBarnetFødt,
     deltBostedPerioder,
     harDeltBostedVedGrunnlagsdataopprettelse,
+    barnFødselsnummer,
 }) => {
+    const skalViseAdresser = !harDeltBostedVedGrunnlagsdataopprettelse && !harSammeAdresseRegister;
+
     const iconRef = useRef<SVGSVGElement>(null);
     const [openState, setOpenState] = useState(false);
     return (
@@ -55,10 +61,16 @@ const Bosted: FC<Props> = ({
                     <Informasjonsrad
                         ikon={VilkårInfoIkon.REGISTER}
                         label="Bosted"
-                        verdi={utledBostedTekst(
-                            harDeltBostedVedGrunnlagsdataopprettelse,
-                            harSammeAdresseRegister
-                        )}
+                        verdi={
+                            skalViseAdresser ? (
+                                <BostedMedReadMore barnIdent={barnFødselsnummer} />
+                            ) : (
+                                utledBostedTekst(
+                                    harDeltBostedVedGrunnlagsdataopprettelse,
+                                    harSammeAdresseRegister
+                                )
+                            )
+                        }
                     />
                     {deltBostedPerioder.length > 0 && (
                         <>

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/ReadMoreMedAdresser.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/ReadMoreMedAdresser.tsx
@@ -1,0 +1,72 @@
+import { ReadMore, Table } from '@navikt/ds-react';
+import React, { FC } from 'react';
+import styled from 'styled-components';
+import { useBehandling } from '../../../../App/context/BehandlingContext';
+import DataViewer from '../../../../Felles/DataViewer/DataViewer';
+import { useGjeldendeBarn } from '../../../../App/hooks/useGjeldeneBarn';
+import { IAdresse } from '../../../../App/typer/personopplysninger';
+
+const StyledReadMore = styled(ReadMore)`
+    --ac-read-more-text: var(--a-text-default);
+`;
+
+const ReadMoreMedAdresser: FC<{ barnIdent?: string }> = ({ barnIdent }) => {
+    const { personopplysningerResponse } = useBehandling();
+    const gjeldendeBarn = useGjeldendeBarn(barnIdent);
+
+    const sisteAdresse = (adresse: IAdresse[]) => {
+        return adresse[adresse.length - 1]?.visningsadresse;
+    };
+
+    return (
+        <DataViewer response={{ personopplysningerResponse }}>
+            {({ personopplysningerResponse }) => (
+                <StyledReadMore
+                    header="Ikke registrert på brukers adresse"
+                    size="small"
+                    defaultOpen={true}
+                >
+                    {gjeldendeBarn?.adresse ? (
+                        <>
+                            Dette er adressene vi har registrert på bruker og gjeldene barn:
+                            <Table size="small" style={{ marginTop: '0.5rem' }}>
+                                <Table.Header>
+                                    <Table.Row>
+                                        <Table.HeaderCell scope="col" textSize="small">
+                                            Navn
+                                        </Table.HeaderCell>
+                                        <Table.HeaderCell scope="col" textSize="small">
+                                            Adresse
+                                        </Table.HeaderCell>
+                                    </Table.Row>
+                                </Table.Header>
+                                <Table.Body>
+                                    <Table.Row>
+                                        <Table.DataCell textSize="small">
+                                            {personopplysningerResponse.navn.visningsnavn}
+                                        </Table.DataCell>
+                                        <Table.DataCell textSize="small">
+                                            {sisteAdresse(personopplysningerResponse.adresse)}
+                                        </Table.DataCell>
+                                    </Table.Row>
+                                    <Table.Row>
+                                        <Table.DataCell textSize="small">
+                                            {gjeldendeBarn?.navn}
+                                        </Table.DataCell>
+                                        <Table.DataCell textSize="small">
+                                            {sisteAdresse(gjeldendeBarn.adresse)}
+                                        </Table.DataCell>
+                                    </Table.Row>
+                                </Table.Body>
+                            </Table>
+                        </>
+                    ) : (
+                        'Vi har ikke registrert noen adresse å sammenlikne med.'
+                    )}
+                </StyledReadMore>
+            )}
+        </DataViewer>
+    );
+};
+
+export default ReadMoreMedAdresser;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Laget komponenten ReadMoreMedAdresser som skal brukes til å vise frem gjelde barn og søker sine adresser slik at man raskt og enkelt kan se og samenlikne adressene. Dette er fordi vi ikke alltid kan si om barn og søker bor på samme adresse.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-20230)

Bildet viser tabellen med navn og adresse på søker og gjeldene barn.
![image](https://github.com/navikt/familie-ef-sak-frontend/assets/141132903/4b6104da-467b-4a24-ba3d-40c8e7c3915c)
