### PR TITLE
skal fase ut felleskomponenten FamilieInput

### DIFF
--- a/src/frontend/Felles/Visningskomponenter/InputUtenSpinner.tsx
+++ b/src/frontend/Felles/Visningskomponenter/InputUtenSpinner.tsx
@@ -1,14 +1,14 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { FamilieInput, IFamilieInputProps } from '@navikt/familie-form-elements';
 import { ASpacing12 } from '@navikt/ds-tokens/dist/tokens';
+import { BodyShort, TextField, TextFieldProps } from '@navikt/ds-react';
 
-export interface PropsInputUtenSpinner extends IFamilieInputProps {
+export interface PropsInputUtenSpinner extends TextFieldProps {
     value: number | string | undefined;
     formatValue?: (value: number | string | undefined) => number | string | undefined;
 }
 
-const StyledInputUtenSpinner = styled(FamilieInput)`
+const StyledInputUtenSpinner = styled(TextField)`
     text-align: right;
     input {
         text-align: right;
@@ -33,20 +33,14 @@ const StyledInputUtenSpinner = styled(FamilieInput)`
 
 const InputUtenSpinner: React.FC<PropsInputUtenSpinner> = ({ formatValue, ...props }) => {
     const [harFokus, settHarFokus] = useState(false);
-    if (!harFokus) {
-        return (
-            <StyledInputUtenSpinner
-                {...props}
-                type="text"
-                autoComplete="off"
-                value={formatValue ? formatValue(props.value) : props.value}
-                onWheel={(event) => event.currentTarget.blur()}
-                label={''}
-                onFocus={() => settHarFokus(true)}
-                hideLabel
-            />
-        );
-    } else {
+
+    const formatertVerdi = formatValue ? formatValue(props.value) : props.value;
+
+    if (props.readOnly) {
+        return <BodyShort>{formatertVerdi}</BodyShort>;
+    }
+
+    if (harFokus) {
         return (
             <StyledInputUtenSpinner
                 {...props}
@@ -60,6 +54,19 @@ const InputUtenSpinner: React.FC<PropsInputUtenSpinner> = ({ formatValue, ...pro
             />
         );
     }
+
+    return (
+        <StyledInputUtenSpinner
+            {...props}
+            type="text"
+            autoComplete="off"
+            value={formatertVerdi}
+            onWheel={(event) => event.currentTarget.blur()}
+            label={''}
+            onFocus={() => settHarFokus(true)}
+            hideLabel
+        />
+    );
 };
 
 export default InputUtenSpinner;

--- a/src/frontend/Komponenter/Behandling/Førstegangsbehandling/VelgPersonOgStønadstype.tsx
+++ b/src/frontend/Komponenter/Behandling/Førstegangsbehandling/VelgPersonOgStønadstype.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect, useState } from 'react';
 import { Stønadstype, stønadstypeTilTekst } from '../../../App/typer/behandlingstema';
 import { useHentFagsak } from '../../../App/hooks/useHentFagsak';
-import { FamilieInput, FamilieSelect } from '@navikt/familie-form-elements';
+import { FamilieSelect } from '@navikt/familie-form-elements';
 import { fnr } from '@navikt/fnrvalidator';
 import AlertStripeFeilPreWrap from '../../../Felles/Visningskomponenter/AlertStripeFeilPreWrap';
-import { BodyLong, Button, Heading } from '@navikt/ds-react';
+import { BodyLong, Button, Heading, TextField } from '@navikt/ds-react';
 import { erAvTypeFeil, RessursStatus } from '../../../App/typer/ressurs';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
@@ -48,6 +48,14 @@ const VelgPersonOgStønadstype = () => {
         }
     };
 
+    const oppdaterFødselsnummer = (personIdent: string) => {
+        const feilmelding =
+            fnr(personIdent).status === 'invalid' ? 'Ugyldig fødselsnummer' : undefined;
+
+        settPersonIdent(personIdent);
+        settFeilmelding(feilmelding);
+    };
+
     useEffect(() => {
         if (fagsak.status === RessursStatus.SUKSESS) {
             navigate(`/opprett-forstegangsbehandling/${fagsak.data.id}`);
@@ -87,16 +95,11 @@ const VelgPersonOgStønadstype = () => {
                         </option>
                     ))}
                 </FamilieSelect>
-                <FamilieInput
-                    label={'Fødselsnummer'}
+                <TextField
+                    label="Fødselsnummer"
                     autoComplete="off"
-                    onChange={(e) => {
-                        const verdi = e.target.value;
-                        settPersonIdent(verdi);
-                        settFeilmelding(
-                            fnr(verdi).status === 'invalid' ? 'Ugyldig fødselsnummer' : undefined
-                        );
-                    }}
+                    value={personIdent}
+                    onChange={(e) => oppdaterFødselsnummer(e.target.value)}
                 />
                 <WrapperMedMargin>
                     <Button onClick={bekreftValg} type="button">

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/KontantstøtteValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/KontantstøtteValg.tsx
@@ -187,7 +187,7 @@ const KontantstøtteValg: React.FC<Props> = ({
                                                     tilTallverdi(e.target.value)
                                                 );
                                             }}
-                                            erLesevisning={erLesevisning}
+                                            readOnly={erLesevisning}
                                             label={'Utgifter kontantstøtte'}
                                             hideLabel
                                         />

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Tilleggsstønadsvalg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Tilleggsstønadsvalg.tsx
@@ -192,7 +192,7 @@ const TilleggsstønadValg: React.FC<Props> = ({
                                             årMånedTilInitiell={årMånedTil}
                                         />
                                         <Input
-                                            erLesevisning={erLesevisning}
+                                            readOnly={erLesevisning}
                                             hideLabel
                                             label={'Stønadsreduksjon'}
                                             error={

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/UtgiftsperiodeValg.tsx
@@ -326,7 +326,7 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
                                                 tilTallverdi(e.target.value)
                                             );
                                         }}
-                                        erLesevisning={!behandlingErRedigerbar}
+                                        readOnly={!behandlingErRedigerbar}
                                         label={'Utgifter'}
                                         hideLabel
                                     />

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
@@ -289,7 +289,7 @@ const InntektsperiodeValg: React.FC<Props> = ({
                                                     errorState?.inntekter &&
                                                     errorState?.inntekter[index]?.dagsats
                                                 }
-                                                erLesevisning={!behandlingErRedigerbar}
+                                                readOnly={!behandlingErRedigerbar}
                                                 value={harTallverdi(rad.dagsats) ? rad.dagsats : ''}
                                                 onChange={(e) => {
                                                     oppdaterInntektslisteVerdier(index, {
@@ -305,7 +305,7 @@ const InntektsperiodeValg: React.FC<Props> = ({
                                             <StyledInput
                                                 label={'Månedsinntekt'}
                                                 hideLabel
-                                                erLesevisning={!behandlingErRedigerbar}
+                                                readOnly={!behandlingErRedigerbar}
                                                 error={
                                                     errorState?.inntekter &&
                                                     errorState?.inntekter[index]?.månedsinntekt
@@ -352,7 +352,7 @@ const InntektsperiodeValg: React.FC<Props> = ({
                                                             verdi,
                                                     });
                                                 }}
-                                                erLesevisning={!behandlingErRedigerbar}
+                                                readOnly={!behandlingErRedigerbar}
                                             />
                                         )}
                                         {valgteInntektstyper.includes(
@@ -379,7 +379,7 @@ const InntektsperiodeValg: React.FC<Props> = ({
                                                                 tilTallverdi(e.target.value),
                                                         });
                                                     }}
-                                                    erLesevisning={!behandlingErRedigerbar}
+                                                    readOnly={!behandlingErRedigerbar}
                                                 />
                                             </>
                                         )}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgeVedtak/Delårsperioder.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgeVedtak/Delårsperioder.tsx
@@ -141,7 +141,7 @@ const Delårsperioder: React.FC<Props> = ({
                                     tilTallverdi(e.target.value)
                                 )
                             }
-                            erLesevisning={erLesevisning}
+                            readOnly={erLesevisning}
                         />
                         <MånedÅrPeriode
                             årMånedFraInitiell={årMånedFra}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgeVedtak/Utgiftsperioder.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgeVedtak/Utgiftsperioder.tsx
@@ -119,7 +119,7 @@ const Utgiftsperioder: React.FC<Props> = ({
                                                 tilTallverdi(e.target.value)
                                             );
                                         }}
-                                        erLesevisning={erLesevisning}
+                                        readOnly={erLesevisning}
                                         disabled={erLåstFraForrigeBehandling}
                                     />
                                     <MånedÅrVelger

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/OpphøreVedtak/Delårsperioder.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/OpphøreVedtak/Delårsperioder.tsx
@@ -156,7 +156,7 @@ const Delårsperioder: React.FC<ValideringsPropsMedOppdatering<IPeriodeSkolepeng
                                         tilTallverdi(e.target.value)
                                     )
                                 }
-                                erLesevisning={erLesevisning}
+                                readOnly={erLesevisning}
                             />
                             {skalViseFjernKnapp && (
                                 <FjernKnapp

--- a/src/frontend/Komponenter/Journalføring/Admin/JournalføringAdminVelger.tsx
+++ b/src/frontend/Komponenter/Journalføring/Admin/JournalføringAdminVelger.tsx
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { FamilieInput } from '@navikt/familie-form-elements';
 import { useNavigate } from 'react-router-dom';
 import { idnr } from '@navikt/fnrvalidator';
-import { Button, Heading } from '@navikt/ds-react';
+import { Button, Heading, TextField } from '@navikt/ds-react';
 
 const SideLayout = styled.div`
     max-width: 50rem;
@@ -16,7 +15,7 @@ const Blokk = styled.div`
     max-width: 10rem;
 `;
 
-const StyledInput = styled(FamilieInput)`
+const StyledInput = styled(TextField)`
     width: max-content;
 `;
 
@@ -24,6 +23,7 @@ export const JournalføringAdminVelger: React.FC = () => {
     const [journalpostId, settJournalpostId] = useState<string>('');
     const [erGyligFnr, settErGyldigFnr] = useState<boolean>(false);
     const navigate = useNavigate();
+
     const gåVidere = () => {
         if (journalpostId) {
             navigate(`/admin/ny-behandling-for-ferdigstilt-journalpost/${journalpostId}`);


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi ønsker å fase ut så mange felleskomponenter fra familie-felles som mulig. 
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-18273)

Har sjekket at lesevisningen nå blir lik som før. Dette gjelder alle steder denne komponenten tas i bruk. ✅ 