### PR TITLE
Refaktorert dokumentliste

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@navikt/ds-react": "6.13.0",
     "@navikt/ds-tokens": "6.13.0",
     "@navikt/familie-backend": "10.0.21",
-    "@navikt/familie-dokumentliste": "^12.0.0",
     "@navikt/familie-endringslogg": "^12.0.2",
     "@navikt/familie-form-elements": "^15.0.0",
     "@navikt/familie-header": "^14.0.3",

--- a/src/frontend/Komponenter/Behandling/Høyremeny/Dokumentliste.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/Dokumentliste.tsx
@@ -1,0 +1,104 @@
+import * as React from 'react';
+import styled from 'styled-components';
+import { ILogiskVedlegg, Journalposttype } from '@navikt/familie-typer';
+import { BodyShort, Button, Tag } from '@navikt/ds-react';
+import { LogiskeVedlegg } from './LogiskeVedlegg';
+
+const StyledDokumentListe = styled.ul`
+    padding: 0;
+    margin: 0 1rem;
+    list-style-type: none;
+    span {
+        font-weight: var(--a-font-weight-regular);
+    }
+`;
+
+const StyledLi = styled.li`
+    margin: 1rem 0;
+`;
+
+const StyledButton = styled(Button)`
+    margin: 0;
+    padding: 0;
+    text-align: left;
+`;
+
+const Container = styled.div`
+    display: flex;
+    gap: 0.5rem;
+`;
+
+interface JournalpostTagProps {
+    journalposttype: Journalposttype;
+}
+
+const JournalpostTag: React.FC<JournalpostTagProps> = ({ journalposttype }) => {
+    switch (journalposttype) {
+        case 'I':
+            return (
+                <Tag variant="info-moderate" size="small">
+                    Inn
+                </Tag>
+            );
+        case 'N':
+            return (
+                <Tag variant="neutral-moderate" size="small">
+                    Notat
+                </Tag>
+            );
+        case 'U':
+            return (
+                <Tag variant="alt1-moderate" size="small">
+                    Ut
+                </Tag>
+            );
+    }
+};
+
+export interface DokumentProps {
+    tittel: string;
+    dato?: string;
+    journalpostId: string;
+    journalposttype: Journalposttype;
+    dokumentinfoId: string;
+    filnavn?: string;
+    logiskeVedlegg?: ILogiskVedlegg[];
+}
+
+export interface DokumentElementProps {
+    dokument: DokumentProps;
+    onClick: (dokument: DokumentProps) => void;
+}
+
+export interface DokumentlisteProps {
+    dokumenter: DokumentProps[];
+    onClick: (dokument: DokumentProps) => void;
+    className?: string;
+}
+
+export const DokumentElement: React.FC<DokumentElementProps> = ({ dokument, onClick }) => {
+    return (
+        <StyledLi>
+            <StyledButton variant="tertiary" size="small" onClick={() => onClick(dokument)}>
+                {dokument.tittel}
+            </StyledButton>
+            <LogiskeVedlegg logiskeVedlegg={dokument.logiskeVedlegg} />
+            <Container>
+                <JournalpostTag journalposttype={dokument.journalposttype} />
+                <BodyShort size="small">{dokument.dato}</BodyShort>
+            </Container>
+        </StyledLi>
+    );
+};
+
+export const Dokumentliste: React.FC<DokumentlisteProps> = ({ dokumenter, onClick, className }) => {
+    return (
+        <StyledDokumentListe className={className}>
+            {dokumenter.map((dokument: DokumentProps, indeks: number) => {
+                return <DokumentElement dokument={dokument} onClick={onClick} key={indeks} />;
+            })}
+        </StyledDokumentListe>
+    );
+};
+
+export default Dokumentliste;

--- a/src/frontend/Komponenter/Behandling/Høyremeny/Dokumentliste.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/Dokumentliste.tsx
@@ -14,18 +14,16 @@ const StyledDokumentListe = styled.ul`
 `;
 
 const StyledLi = styled.li`
-    margin: 1rem 0;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(2rem, max-content));
+    gap: 0.5rem;
+    margin: 0.5rem 0;
 `;
 
 const StyledButton = styled(Button)`
     margin: 0;
     padding: 0;
     text-align: left;
-`;
-
-const Container = styled.div`
-    display: flex;
-    gap: 0.5rem;
 `;
 
 interface JournalpostTagProps {
@@ -37,19 +35,19 @@ const JournalpostTag: React.FC<JournalpostTagProps> = ({ journalposttype }) => {
         case 'I':
             return (
                 <Tag variant="info-moderate" size="small">
-                    Inn
+                    I
                 </Tag>
             );
         case 'N':
             return (
                 <Tag variant="neutral-moderate" size="small">
-                    Notat
+                    N
                 </Tag>
             );
         case 'U':
             return (
                 <Tag variant="alt1-moderate" size="small">
-                    Ut
+                    U
                 </Tag>
             );
     }
@@ -79,14 +77,16 @@ export interface DokumentlisteProps {
 export const DokumentElement: React.FC<DokumentElementProps> = ({ dokument, onClick }) => {
     return (
         <StyledLi>
-            <StyledButton variant="tertiary" size="small" onClick={() => onClick(dokument)}>
-                {dokument.tittel}
-            </StyledButton>
-            <LogiskeVedlegg logiskeVedlegg={dokument.logiskeVedlegg} />
-            <Container>
+            <div>
                 <JournalpostTag journalposttype={dokument.journalposttype} />
+            </div>
+            <div>
+                <StyledButton variant="tertiary" size="small" onClick={() => onClick(dokument)}>
+                    {dokument.tittel}
+                </StyledButton>
                 <BodyShort size="small">{dokument.dato}</BodyShort>
-            </Container>
+                <LogiskeVedlegg logiskeVedlegg={dokument.logiskeVedlegg} />
+            </div>
         </StyledLi>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Høyremeny/Dokumentoversikt.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/Dokumentoversikt.tsx
@@ -1,22 +1,14 @@
 import * as React from 'react';
 import { useMemo } from 'react';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
-import Dokumentliste, { DokumentProps } from '@navikt/familie-dokumentliste';
 import { AxiosRequestConfig } from 'axios';
 import { useDataHenter } from '../../../App/hooks/felles/useDataHenter';
 import { useParams } from 'react-router-dom';
 import { IBehandlingParams } from '../../../App/typer/routing';
-import styled from 'styled-components';
 import { formaterNullableIsoDatoTid } from '../../../App/utils/formatter';
 import { compareDesc } from 'date-fns';
 import { åpneFilIEgenTab } from '../../../App/utils/utils';
-import { Heading } from '@navikt/ds-react';
-import { AGray800 } from '@navikt/ds-tokens/dist/tokens';
-
-const Tittel = styled.div`
-    padding: 0.5rem 1rem;
-    color: ${AGray800};
-`;
+import Dokumentliste, { DokumentProps } from './Dokumentliste';
 
 type AlleDokument = {
     dokumenterKnyttetTilBehandlingen: DokumentProps[];
@@ -67,17 +59,10 @@ const Dokumentoversikt: React.FC = () => {
                 {({ dokumentResponse }) => {
                     const sortertDokumentliste = sorterDokumentlisten(dokumentResponse);
                     return (
-                        <>
-                            <Tittel>
-                                <Heading size={'small'} level={'5'}>
-                                    Dokumentoversikt
-                                </Heading>
-                            </Tittel>
-                            <Dokumentliste
-                                dokumenter={sortertDokumentliste}
-                                onClick={lastNedDokument}
-                            />
-                        </>
+                        <Dokumentliste
+                            dokumenter={sortertDokumentliste}
+                            onClick={lastNedDokument}
+                        />
                     );
                 }}
             </DataViewer>

--- a/src/frontend/Komponenter/Behandling/Høyremeny/LogiskeVedlegg.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/LogiskeVedlegg.tsx
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+import * as React from 'react';
+import { ILogiskVedlegg } from '@navikt/familie-typer';
+import { Detail } from '@navikt/ds-react';
+
+const LogiskVedleggWrapper = styled.ul`
+    list-style-type: circle;
+`;
+
+export const LogiskeVedlegg: React.FC<{ logiskeVedlegg: ILogiskVedlegg[] | undefined }> = ({
+    logiskeVedlegg,
+}) => (
+    <LogiskVedleggWrapper>
+        {logiskeVedlegg &&
+            logiskeVedlegg.map((logiskVedlegg, index) => (
+                <li key={logiskVedlegg.tittel + index}>
+                    <Detail>{logiskVedlegg.tittel}</Detail>
+                </li>
+            ))}
+    </LogiskVedleggWrapper>
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1707,14 +1707,6 @@
     prom-client "^15.1.2"
     redis "^4.6.14"
 
-"@navikt/familie-dokumentliste@^12.0.0":
-  version "12.0.0"
-  resolved "https://npm.pkg.github.com/download/@navikt/familie-dokumentliste/12.0.0/48a391b8365dd40b6abaee4124f7588e4bff0ca1#48a391b8365dd40b6abaee4124f7588e4bff0ca1"
-  integrity sha512-OMan+enwh+vbyUJ6hPXueuRpCAAHsd9SNsiEOSyLAL8i+HAUuAcR07elZ05wg9gjq4Ehj7MnH+zydGTIg8530A==
-  dependencies:
-    "@navikt/familie-ikoner" "^9.0.1"
-    "@navikt/familie-typer" "^8.0.2"
-
 "@navikt/familie-endringslogg@^12.0.2":
   version "12.0.2"
   resolved "https://npm.pkg.github.com/download/@navikt/familie-endringslogg/12.0.2/4036173993d27265340ae9febbc0a4205b992b73#4036173993d27265340ae9febbc0a4205b992b73"


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

- Fjernet avhengigheten familie-dokumentliste.
- Hentet kode fra felles og refaktorert komponenten Dokumentliste.
- Journaltype vises ikke lenger med piler, men med tags og bokstaver I / U / N.

Bildet viser hvordan nytt design:
![image](https://github.com/navikt/familie-ef-sak-frontend/assets/141132903/79ba7715-7e0d-4fba-98c6-1e49a67a2179)

Gammelt: 
![image](https://github.com/navikt/familie-ef-sak-frontend/assets/141132903/1efdebb0-1c80-4a3f-bebe-fdb036e77f02)
