### PR TITLE
sletter FamilieTextArea og erstatter denne med TextArea fra Aksel

### DIFF
--- a/src/frontend/Felles/Input/TekstInput/EnsligTextArea.tsx
+++ b/src/frontend/Felles/Input/TekstInput/EnsligTextArea.tsx
@@ -1,34 +1,20 @@
+import { Textarea, TextareaProps } from '@navikt/ds-react';
 import React from 'react';
 import styled from 'styled-components';
-import { FamilieTextarea, IFamilieTextareaProps } from '@navikt/familie-form-elements';
 import { EnsligErrorMessage } from '../../ErrorMessage/EnsligErrorMessage';
 
-const StyledFamilieTextArea: React.FC<IFamilieTextareaProps> = styled(FamilieTextarea)`
+const StyledTextArea = styled(Textarea)`
     white-space: pre-wrap;
     word-wrap: break-word;
     max-width: 60rem;
 `;
 
-type Props = { feilmelding?: string } & IFamilieTextareaProps;
+type Props = TextareaProps & { feilmelding?: string };
 
-export const EnsligTextArea: React.FC<Props> = ({
-    className,
-    erLesevisning,
-    feilmelding,
-    label,
-    maxLength,
-    onChange,
-    value,
-}) => {
+export const EnsligTextArea: React.FC<Props> = ({ feilmelding, ...props }) => {
     return (
-        <div className={className}>
-            <StyledFamilieTextArea
-                value={value}
-                onChange={(e) => onChange && onChange(e)}
-                label={label}
-                maxLength={maxLength}
-                erLesevisning={erLesevisning}
-            />
+        <div>
+            <StyledTextArea {...props} />
             <EnsligErrorMessage>{feilmelding}</EnsligErrorMessage>
         </div>
     );

--- a/src/frontend/Komponenter/Behandling/Sanksjon/Sanksjonsfastsettelse.tsx
+++ b/src/frontend/Komponenter/Behandling/Sanksjon/Sanksjonsfastsettelse.tsx
@@ -23,7 +23,6 @@ import {
 import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../App/typer/ressurs';
 import useFormState, { FormState } from '../../../App/hooks/felles/useFormState';
 import { FieldState } from '../../../App/hooks/felles/useFieldState';
-import { EnsligTextArea } from '../../../Felles/Input/TekstInput/EnsligTextArea';
 import AlertStripeFeilPreWrap from '../../../Felles/Visningskomponenter/AlertStripeFeilPreWrap';
 import { SANKSJONERE_VEDTAK, validerSanksjonereVedtakForm } from './utils';
 import { useHentVedtak } from '../../../App/hooks/useHentVedtak';
@@ -42,6 +41,7 @@ import {
     antallDagerIgjenAvNåværendeMåned,
     nåværendeÅrOgMånedFormatert,
 } from '../../../App/utils/formatter';
+import { EnsligTextArea } from '../../../Felles/Input/TekstInput/EnsligTextArea';
 
 export type SanksjonereVedtakForm = ISanksjonereVedtakDto;
 
@@ -252,7 +252,7 @@ const SanksjonsvedtakVisning: FC<{
                                     settIkkePersistertKomponent(SANKSJONERE_VEDTAK);
                                     internBegrunnelse.onChange(event);
                                 }}
-                                erLesevisning={!behandlingErRedigerbar}
+                                readOnly={!behandlingErRedigerbar}
                                 feilmelding={formState.errors.internBegrunnelse}
                             />
                         </Seksjon>

--- a/src/frontend/Komponenter/Behandling/Simulering/TilbakekrevingSkjema.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/TilbakekrevingSkjema.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { EnsligTextArea } from '../../../Felles/Input/TekstInput/EnsligTextArea';
 import styled from 'styled-components';
 import { ITilbakekrevingsvalg, TilbakekrevingsvalgTilTekst } from './Tilbakekreving';
 import { useApp } from '../../../App/context/AppContext';
@@ -10,6 +9,7 @@ import { BodyLong, Button, Heading, Radio, RadioGroup, VStack } from '@navikt/ds
 import { FileTextIcon } from '@navikt/aksel-icons';
 import { ABlue50, ARed500 } from '@navikt/ds-tokens/dist/tokens';
 import { HeaderBegrunnelse } from './HeaderBegrunnelse';
+import { EnsligTextArea } from '../../../Felles/Input/TekstInput/EnsligTextArea';
 
 const Container = styled(VStack)`
     margin-top: 1.5rem;
@@ -112,7 +112,7 @@ export const TilbakekrevingSkjema: React.FC<Props> = ({
             <Container gap="8">
                 <EnsligTextArea
                     label={<HeaderBegrunnelse />}
-                    erLesevisning={false}
+                    readOnly={false}
                     value={begrunnelse}
                     maxLength={0}
                     onChange={(e) => {
@@ -147,7 +147,7 @@ export const TilbakekrevingSkjema: React.FC<Props> = ({
                         <VarselValg>
                             <EnsligTextArea
                                 label={'Fritekst i varselet'}
-                                erLesevisning={false}
+                                readOnly={false}
                                 value={varseltekst}
                                 maxLength={0}
                                 onChange={(e) => {

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Tilleggsstønadsvalg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Tilleggsstønadsvalg.tsx
@@ -15,7 +15,6 @@ import InputMedTusenSkille from '../../../../../Felles/Visningskomponenter/Input
 import { harTallverdi, tilHeltall, tilTallverdi } from '../../../../../App/utils/utils';
 import LeggTilKnapp from '../../../../../Felles/Knapper/LeggTilKnapp';
 import { FieldState } from '../../../../../App/hooks/felles/useFieldState';
-import { EnsligTextArea } from '../../../../../Felles/Input/TekstInput/EnsligTextArea';
 import { Heading, Tooltip } from '@navikt/ds-react';
 import FjernKnapp from '../../../../../Felles/Knapper/FjernKnapp';
 import { SmallTextLabel } from '../../../../../Felles/Visningskomponenter/Tekster';
@@ -24,6 +23,7 @@ import JaNeiRadioGruppe from '../../Felles/JaNeiRadioGruppe';
 import { HorizontalScroll } from '../../Felles/HorizontalScroll';
 import { useBehandling } from '../../../../../App/context/BehandlingContext';
 import { AGray50 } from '@navikt/ds-tokens/dist/tokens';
+import { EnsligTextArea } from '../../../../../Felles/Input/TekstInput/EnsligTextArea';
 
 const Container = styled.div`
     padding: 1rem;
@@ -49,7 +49,7 @@ const Input = styled(InputMedTusenSkille)`
     text-align: right;
 `;
 
-const TekstFelt = styled(EnsligTextArea)`
+const TextArea = styled(EnsligTextArea)`
     margin-top: 1rem;
 `;
 
@@ -260,8 +260,8 @@ const TilleggsstønadValg: React.FC<Props> = ({
                 </HorizontalScroll>
             )}
             {søktTilleggsstønad && (
-                <TekstFelt
-                    erLesevisning={erLesevisning}
+                <TextArea
+                    readOnly={erLesevisning}
                     feilmelding={valideringsfeil.tilleggsstønadBegrunnelse}
                     label="Begrunnelse"
                     maxLength={0}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/UtgiftsperiodeValg.tsx
@@ -31,8 +31,8 @@ import {
 import { HorizontalScroll } from '../../Felles/HorizontalScroll';
 import { FieldState } from '../../../../../App/hooks/felles/useFieldState';
 import { IngenBegrunnelseOppgitt } from '../../Overgangsstønad/InnvilgeVedtak/IngenBegrunnelseOppgitt';
-import { EnsligTextArea } from '../../../../../Felles/Input/TekstInput/EnsligTextArea';
 import { AGray50 } from '@navikt/ds-tokens/dist/tokens';
+import { EnsligTextArea } from '../../../../../Felles/Input/TekstInput/EnsligTextArea';
 
 const Container = styled.div`
     padding: 1rem;
@@ -368,7 +368,7 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
                 <IngenBegrunnelseOppgitt />
             ) : (
                 <TextArea
-                    erLesevisning={!behandlingErRedigerbar}
+                    readOnly={!behandlingErRedigerbar}
                     value={begrunnelseState.value}
                     onChange={(event) => {
                         settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/AvslåVedtak/AvslåVedtakForm.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/AvslåVedtak/AvslåVedtakForm.tsx
@@ -1,13 +1,13 @@
 import React, { FormEvent, useEffect } from 'react';
 import styled from 'styled-components';
 import AlertStripeFeilPreWrap from '../../../../../Felles/Visningskomponenter/AlertStripeFeilPreWrap';
-import { EnsligTextArea } from '../../../../../Felles/Input/TekstInput/EnsligTextArea';
 import { VEDTAK_OG_BEREGNING } from '../konstanter';
 import { useApp } from '../../../../../App/context/AppContext';
 import SelectAvslagÅrsak from './SelectAvslagÅrsak';
 import { EAvslagÅrsak } from '../../../../../App/typer/vedtak';
 import { AGray50 } from '@navikt/ds-tokens/dist/tokens';
 import HovedKnapp from '../../../../../Felles/Knapper/HovedKnapp';
+import { EnsligTextArea } from '../../../../../Felles/Input/TekstInput/EnsligTextArea';
 
 const Form = styled.form`
     background-color: ${AGray50};
@@ -58,14 +58,14 @@ const AvslåVedtakForm: React.FC<Props> = ({
                 />
             )}
             <EnsligTextArea
+                label="Begrunnelse"
+                maxLength={0}
+                readOnly={!behandlingErRedigerbar}
                 value={avslagBegrunnelse}
                 onChange={(e) => {
                     settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
                     settAvslagBegrunnelse(e.target.value);
                 }}
-                label="Begrunnelse"
-                maxLength={0}
-                erLesevisning={!behandlingErRedigerbar}
             />
             {feilmelding && <AlertStripeFeilPreWrap>{feilmelding}</AlertStripeFeilPreWrap>}
             {behandlingErRedigerbar && <HovedKnapp disabled={laster} knappetekst="Lagre vedtak" />}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/OpphøreVedtak/OpphøreVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/OpphøreVedtak/OpphøreVedtak.tsx
@@ -5,7 +5,6 @@ import { useApp } from '../../../../../App/context/AppContext';
 import { EBehandlingResultat, IOpphørtVedtak, IVedtakType } from '../../../../../App/typer/vedtak';
 import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../../../App/typer/ressurs';
 import styled from 'styled-components';
-import { EnsligTextArea } from '../../../../../Felles/Input/TekstInput/EnsligTextArea';
 import { VEDTAK_OG_BEREGNING } from '../konstanter';
 import { AlertError } from '../../../../../Felles/Visningskomponenter/Alerts';
 import { AGray50 } from '@navikt/ds-tokens/dist/tokens';
@@ -13,6 +12,7 @@ import { useRedirectEtterLagring } from '../../../../../App/hooks/felles/useRedi
 import { v4 as uuidv4 } from 'uuid';
 import HovedKnapp from '../../../../../Felles/Knapper/HovedKnapp';
 import { ModalState } from '../../../Modal/NyEierModal';
+import { EnsligTextArea } from '../../../../../Felles/Input/TekstInput/EnsligTextArea';
 
 const Form = styled.form`
     padding: 1rem;
@@ -97,7 +97,7 @@ export const OpphøreVedtak: React.FC<{
             <EnsligTextArea
                 label={'Begrunnelse for opphør'}
                 maxLength={0}
-                erLesevisning={!behandlingErRedigerbar}
+                readOnly={!behandlingErRedigerbar}
                 value={opphørtBegrunnelse}
                 onChange={(begrunnelse) => {
                     settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
@@ -205,7 +205,7 @@ const InntektsperiodeValg: React.FC<Props> = ({
                     }}
                     label="Begrunnelse for inntektsfastsettelse"
                     maxLength={0}
-                    erLesevisning={!behandlingErRedigerbar}
+                    readOnly={!behandlingErRedigerbar}
                     feilmelding={errorState?.inntektBegrunnelse}
                 />
             )}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/VedtaksperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/VedtaksperiodeValg.tsx
@@ -26,9 +26,9 @@ import {
 import { HorizontalScroll } from '../../Felles/HorizontalScroll';
 import { AGray50 } from '@navikt/ds-tokens/dist/tokens';
 import { IngenBegrunnelseOppgitt } from './IngenBegrunnelseOppgitt';
-import { EnsligTextArea } from '../../../../../Felles/Input/TekstInput/EnsligTextArea';
 import { FieldState } from '../../../../../App/hooks/felles/useFieldState';
 import { tomVedtaksperiodeRad } from '../Felles/utils';
+import { EnsligTextArea } from '../../../../../Felles/Input/TekstInput/EnsligTextArea';
 
 const Container = styled.div`
     padding: 1rem;
@@ -163,7 +163,7 @@ const VedtaksperiodeValg: React.FC<Props> = ({
                     }}
                     label="Begrunnelse for vedtaksperiode"
                     maxLength={0}
-                    erLesevisning={!behandlingErRedigerbar}
+                    readOnly={!behandlingErRedigerbar}
                     feilmelding={errorState?.periodeBegrunnelse}
                 />
             )}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/Felles/BegrunnelsesFelt.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/Felles/BegrunnelsesFelt.tsx
@@ -1,6 +1,5 @@
 import React, { FC } from 'react';
 import { Heading } from '@navikt/ds-react';
-import { EnsligTextArea } from '../../../../../Felles/Input/TekstInput/EnsligTextArea';
 import { VEDTAK_OG_BEREGNING } from '../../Felles/konstanter';
 import styled from 'styled-components';
 import { AGray50 } from '@navikt/ds-tokens/dist/tokens';
@@ -9,6 +8,7 @@ import { FieldState } from '../../../../../App/hooks/felles/useFieldState';
 import { useApp } from '../../../../../App/context/AppContext';
 import { InnvilgeVedtakForm } from './typer';
 import { FormErrors } from '../../../../../App/hooks/felles/useFormState';
+import { EnsligTextArea } from '../../../../../Felles/Input/TekstInput/EnsligTextArea';
 
 interface Props {
     begrunnelseState: FieldState;
@@ -30,15 +30,15 @@ export const BegrunnelsesFelt: FC<Props> = ({ begrunnelseState, errorState }) =>
                 Utgifter til skolepenger
             </Heading>
             <EnsligTextArea
-                erLesevisning={!behandlingErRedigerbar}
+                label={'Begrunnelse'}
+                maxLength={0}
+                feilmelding={errorState.begrunnelse}
+                readOnly={!behandlingErRedigerbar}
                 value={begrunnelseState.value}
                 onChange={(event) => {
                     settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
                     begrunnelseState.onChange(event);
                 }}
-                label={'Begrunnelse'}
-                maxLength={0}
-                feilmelding={errorState.begrunnelse}
             />
         </Container>
     );


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker å slutte å bruke felleskomponenter. Fjerner derfor FamilieTextArea.
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-18273)

Alle forskjellene:

![Skjermbilde 2024-07-02 kl  10 23 45](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/7a1e63ef-aaa0-46b8-8233-c885031822cf)
![Skjermbilde 2024-07-02 kl  10 03 33](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/771124ba-aeb1-4199-be39-6526c8c97017)
![Skjermbilde 2024-07-02 kl  10 26 16](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/35e0ca3e-f5ba-4620-8708-34b2f5bb2b4f)
![Skjermbilde 2024-07-02 kl  09 50 34](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/57a01331-4ddc-47f5-9d79-fe51b91b018c)
![Skjermbilde 2024-07-02 kl  09 47 53](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/eee19cd8-95f5-4153-bae3-6ec8ee23332d)
![Skjermbilde 2024-07-02 kl  09 45 30](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/4f83f540-c006-4212-bcb8-4372d875cbfb)
![Skjermbilde 2024-07-01 kl  16 57 08](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/9732031a-a7cf-43b0-b8f5-15630860467d)
![Skjermbilde 2024-07-01 kl  16 57 27](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/46473a75-7515-4935-bdd8-cfb96e448994)
![Skjermbilde 2024-07-02 kl  09 48 09](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/de20b886-1b67-4ca4-bdad-8a5f6aab60d6)
![Skjermbilde 2024-07-02 kl  09 50 13](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/96830d8e-7550-4414-a959-c32abc44a94b)
![Skjermbilde 2024-07-02 kl  09 45 37](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/91eae1aa-06a8-4b6a-8ddb-de48a22059e7)
![Skjermbilde 2024-07-02 kl  10 03 17](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/5c5e8a9e-0b77-41dd-98e0-77fb1d951913)
![Skjermbilde 2024-07-02 kl  10 24 14](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/20565d7f-4a37-4911-8a37-013bbb7d8100)
![Skjermbilde 2024-07-02 kl  10 26 37](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/dac6ef98-83d7-465f-9e08-e20da061a0fe)
![Skjermbilde 2024-07-01 kl  16 24 45](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/43c36ca8-9ee4-4947-ae02-bb97091520fa)
![Skjermbilde 2024-07-01 kl  16 24 59](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/fbe380e1-9a12-433d-955c-df027f5d45a3)
