### PR TITLE
Mindre luft rundt behandlingshistorikk på høyre side

### DIFF
--- a/src/frontend/Komponenter/Behandling/Høyremeny/BehandlingHistorikk.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/BehandlingHistorikk.tsx
@@ -12,8 +12,8 @@ interface Props {
 }
 
 const HistorikkListe = styled.ul`
-    padding: 0 0.5rem 2rem 0.5rem;
-    margin: 0;
+    padding: 0;
+    margin: 0.5rem 1rem;
 `;
 
 const BehandlingHistorikk: React.FC<Props> = ({ behandling, behandlingId }) => {
@@ -28,12 +28,10 @@ const BehandlingHistorikk: React.FC<Props> = ({ behandling, behandlingId }) => {
                 return (
                     <HistorikkListe>
                         {behandlingHistorikkResponse.map((behandlingshistorikk, idx) => {
-                            const første = idx === 0;
                             const siste = idx === behandlingHistorikkResponse.length - 1;
 
                             return (
                                 <HistorikkElement
-                                    første={første}
                                     siste={siste}
                                     behandlingshistorikk={behandlingshistorikk}
                                     key={idx}

--- a/src/frontend/Komponenter/Behandling/Høyremeny/HistorikkElement.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/HistorikkElement.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { formaterIsoDatoTidKort } from '../../../App/utils/formatter';
 import { Hendelse, HendelseIkon, hendelseTilHistorikkTekst } from './Historikk';
-import { HistorikkElementProps, LinjeProps, StyledHistorikkElementProps } from './typer';
+import { HistorikkElementProps, LinjeProps } from './typer';
 import { useApp } from '../../../App/context/AppContext';
 import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../App/typer/ressurs';
 import { base64toBlob, winUrl, åpnePdfIEgenTab } from '../../../App/utils/utils';
@@ -29,12 +29,10 @@ const Linje = styled.div<LinjeProps>`
 
 const Innhold = styled.div``;
 
-const StyledHistorikkElement = styled.li<StyledHistorikkElementProps>`
+const StyledHistorikkElement = styled.li`
     display: flex;
-
     list-style: none;
-
-    padding: ${(props) => (props.$første ? '0.75rem 2rem 0' : '0 2rem')};
+    padding: 0;
 
     .navds-body-short,
     .navds-label,
@@ -45,7 +43,6 @@ const StyledHistorikkElement = styled.li<StyledHistorikkElementProps>`
 
 const HistorikkElement: React.FC<HistorikkElementProps> = ({
     behandlingshistorikk,
-    første,
     siste,
     behandlingId,
     behandling,
@@ -90,7 +87,7 @@ const HistorikkElement: React.FC<HistorikkElementProps> = ({
         vedtakIverksatt;
 
     return (
-        <StyledHistorikkElement $første={første}>
+        <StyledHistorikkElement>
             <IkonMedStipletLinje>
                 <HendelseIkon behandlingshistorikk={behandlingshistorikk} />
                 <Linje $siste={siste} $størreMellomrom={harMetadata} />

--- a/src/frontend/Komponenter/Behandling/Høyremeny/typer.ts
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/typer.ts
@@ -20,14 +20,9 @@ export interface LinjeProps {
 }
 
 export interface HistorikkElementProps {
-    første: boolean;
     siste: boolean;
     behandlingshistorikk: Behandlingshistorikk;
     behandlingId: string;
     behandling: Behandling;
     skalViseBegrunnelse: boolean;
-}
-
-export interface StyledHistorikkElementProps {
-    $første: boolean;
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

- Refaktorert slik at BehandlingHistorikk har like margin som Dokumentoversikt.
- Får plass til all skrift på en linje.

Gammel:
![image](https://github.com/navikt/familie-ef-sak-frontend/assets/141132903/f0cefd0d-8cb3-4cff-a138-8310a0ce3b97)

Nytt:
![image](https://github.com/navikt/familie-ef-sak-frontend/assets/141132903/f39cd3df-c3ad-4d0c-b7cb-2bc94b07f988)
