### PR TITLE
flytter FamilieSelect inn i ef-sak-frontend direkte

### DIFF
--- a/src/frontend/Felles/Input/EnsligFamilieSelect.tsx
+++ b/src/frontend/Felles/Input/EnsligFamilieSelect.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { IFamilieSelectProps } from '@navikt/familie-form-elements';
 import styled from 'styled-components';
-import { FamilieSelect } from '@navikt/familie-form-elements';
+import { FamilieSelect, FamilieSelectProps } from './FamilieSelect';
 
 const FamilieSelectMedFeilmeldingUtenPrikk = styled(FamilieSelect)`
     .navds-error-message::before {
         content: none;
     }
 `;
-export const EnsligFamilieSelect: React.FC<IFamilieSelectProps> = (props) => {
-    return <FamilieSelectMedFeilmeldingUtenPrikk {...props} />;
-};
+
+export const EnsligFamilieSelect: React.FC<FamilieSelectProps> = (props) => (
+    <FamilieSelectMedFeilmeldingUtenPrikk {...props} />
+);

--- a/src/frontend/Felles/Input/FamilieSelect.tsx
+++ b/src/frontend/Felles/Input/FamilieSelect.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { BodyShort, Label, Select, SelectProps } from '@navikt/ds-react';
+
+export interface FamilieSelectProps extends SelectProps {
+    erLesevisning?: boolean;
+    lesevisningVerdi?: string;
+}
+
+export const FamilieSelect: React.FC<FamilieSelectProps> = ({
+    children,
+    className,
+    erLesevisning = false,
+    label,
+    lesevisningVerdi,
+    value,
+    size,
+    hideLabel,
+    ...props
+}) => {
+    return erLesevisning ? (
+        <div className={className}>
+            {!hideLabel && label && <Label size={size}>{label}</Label>}
+            <BodyShort size={size}>{lesevisningVerdi ? lesevisningVerdi : value}</BodyShort>
+        </div>
+    ) : (
+        <Select
+            className={className}
+            label={label}
+            value={value}
+            size={size}
+            readOnly={erLesevisning}
+            hideLabel={hideLabel}
+            {...props}
+        >
+            {children}
+        </Select>
+    );
+};

--- a/src/frontend/Felles/Input/MånedÅr/MånedVelger.tsx
+++ b/src/frontend/Felles/Input/MånedÅr/MånedVelger.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FamilieSelect } from '@navikt/familie-form-elements';
+import { FamilieSelect } from '../FamilieSelect';
 
 export type FamilieSelectSize = 'small' | 'medium';
 

--- a/src/frontend/Felles/Input/MånedÅr/ÅrVelger.tsx
+++ b/src/frontend/Felles/Input/MånedÅr/ÅrVelger.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { range } from '../../../App/utils/utils';
-import { FamilieSelect } from '@navikt/familie-form-elements';
+import { FamilieSelect } from '../FamilieSelect';
 
 interface ÅrProps {
     år: number | undefined;

--- a/src/frontend/Komponenter/Behandling/Førstegangsbehandling/VelgPersonOgStønadstype.tsx
+++ b/src/frontend/Komponenter/Behandling/Førstegangsbehandling/VelgPersonOgStønadstype.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Stønadstype, stønadstypeTilTekst } from '../../../App/typer/behandlingstema';
 import { useHentFagsak } from '../../../App/hooks/useHentFagsak';
-import { FamilieSelect } from '@navikt/familie-form-elements';
 import { fnr } from '@navikt/fnrvalidator';
 import AlertStripeFeilPreWrap from '../../../Felles/Visningskomponenter/AlertStripeFeilPreWrap';
 import { BodyLong, Button, Heading, TextField } from '@navikt/ds-react';
@@ -9,6 +8,7 @@ import { erAvTypeFeil, RessursStatus } from '../../../App/typer/ressurs';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 import { AlertInfo } from '../../../Felles/Visningskomponenter/Alerts';
+import { FamilieSelect } from '../../../Felles/Input/FamilieSelect';
 
 const AlertInfoPreWrap = styled(AlertInfo)`
     white-space: pre-wrap;

--- a/src/frontend/Komponenter/Behandling/SettPåVent/MappeVelger.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/MappeVelger.tsx
@@ -4,7 +4,7 @@ import { byggTomRessurs, Ressurs } from '../../../App/typer/ressurs';
 import { useApp } from '../../../App/context/AppContext';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { sorterMapperPåNavn } from '../../Oppgavebenk/utils';
-import { FamilieSelect } from '@navikt/familie-form-elements';
+import { FamilieSelect } from '../../../Felles/Input/FamilieSelect';
 
 export const MappeVelger: FC<{
     oppgaveEnhet: string | undefined;

--- a/src/frontend/Komponenter/Behandling/SettPåVent/PrioritetVelger.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/PrioritetVelger.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { Prioritet, prioritetTilTekst } from '../../Oppgavebenk/typer/oppgavetema';
-import { FamilieSelect } from '@navikt/familie-form-elements';
+import { FamilieSelect } from '../../../Felles/Input/FamilieSelect';
 
 export const PrioritetVelger: FC<{
     prioritet: Prioritet | undefined;

--- a/src/frontend/Komponenter/Behandling/SettPåVent/SaksbehandlerVelger.tsx
+++ b/src/frontend/Komponenter/Behandling/SettPåVent/SaksbehandlerVelger.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { useApp } from '../../../App/context/AppContext';
 import { IOppgave } from '../../Oppgavebenk/typer/oppgave';
-import { FamilieSelect } from '@navikt/familie-form-elements';
+import { FamilieSelect } from '../../../Felles/Input/FamilieSelect';
 
 export const SaksbehandlerVelger: FC<{
     oppgave: IOppgave;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker å fase ut familie-felles mest mulig. 
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-18273)

Flytter bare implementasjonen av FamilieSelect direkte inn i ef-sak. Det blir litt for mange tilpasninger dersom vi skal ta i bruk Selecten sin readOnly prop.