### PR TITLE
Taggene i dokumentlisten skal være av lik bredde, uavhengig av innholdet

### DIFF
--- a/src/frontend/Komponenter/Behandling/Høyremeny/Dokumentliste.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/Dokumentliste.tsx
@@ -26,6 +26,10 @@ const StyledButton = styled(Button)`
     text-align: left;
 `;
 
+const StyledTag = styled(Tag)`
+    width: 1.5rem;
+`;
+
 interface JournalpostTagProps {
     journalposttype: Journalposttype;
 }
@@ -34,21 +38,21 @@ export const JournalpostTag: React.FC<JournalpostTagProps> = ({ journalposttype 
     switch (journalposttype) {
         case 'I':
             return (
-                <Tag variant="info-moderate" size="small">
+                <StyledTag variant="info-moderate" size="small">
                     I
-                </Tag>
+                </StyledTag>
             );
         case 'N':
             return (
-                <Tag variant="neutral-moderate" size="small">
+                <StyledTag variant="neutral-moderate" size="small">
                     N
-                </Tag>
+                </StyledTag>
             );
         case 'U':
             return (
-                <Tag variant="alt1-moderate" size="small">
+                <StyledTag variant="alt1-moderate" size="small">
                     U
-                </Tag>
+                </StyledTag>
             );
     }
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Finjusterer dokumentlisten slik at alle taggene er av lik bredde, uavhengig av om de viser frem I, U eller N.

Før:
![Skjermbilde 2024-07-04 kl  09 46 32](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/1cf18b93-4dfa-45ed-b61a-23e1666c926c)

Etter:
<img width="320" alt="Skjermbilde 2024-07-04 kl  10 02 27" src="https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/3c918c3c-4a1f-41a1-8ed8-b13087321f82">
