### PR TITLE
skal sjekke om bruker har svart på spørsmål om skillsmisse i sivilsta…

### DIFF
--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Sivilstand/SivilstandInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Sivilstand/SivilstandInfo.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { ISivilstandInngangsvilkår } from './typer';
 import { sivilstandTilTekst } from '../../../../App/typer/personopplysninger';
-import Søknadsinformasjon from './Søknadsinformasjon';
+import { Søknadsinformasjon } from './Søknadsinformasjon';
 import { formaterIsoDato } from '../../../../App/utils/formatter';
 import DokumentasjonSendtInn from '../DokumentasjonSendtInn';
 import { IDokumentasjonGrunnlag } from '../vilkår';

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Sivilstand/Søknadsinformasjon.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Sivilstand/Søknadsinformasjon.tsx
@@ -11,110 +11,131 @@ interface Props {
     søknad: ISivilstandSøknadsgrunnlag;
 }
 
-const Søknadsinformasjon: FC<Props> = ({ sivilstandtype, søknad }) => {
-    const { tidligereSamboer, erUformeltSeparertEllerSkilt, erUformeltGift } = søknad;
-
+export const Søknadsinformasjon: FC<Props> = ({ sivilstandtype, søknad }) => {
     switch (sivilstandtype) {
         case SivilstandType.UGIFT:
         case SivilstandType.UOPPGITT:
         case SivilstandType.ENKE_ELLER_ENKEMANN:
         case SivilstandType.SKILT:
         case SivilstandType.SKILT_PARTNER:
-            return (
-                <>
-                    <Informasjonsrad
-                        ikon={VilkårInfoIkon.SØKNAD}
-                        label="Gift uten at det er registrert i folkeregisteret"
-                        verdi={erUformeltGift !== undefined && mapTrueFalse(erUformeltGift)}
-                    />
-                    <Informasjonsrad
-                        ikon={VilkårInfoIkon.SØKNAD}
-                        label="Separert eller skilt uten at det er registrert i folkeregisteret"
-                        verdi={
-                            erUformeltSeparertEllerSkilt !== undefined &&
-                            mapTrueFalse(erUformeltSeparertEllerSkilt)
-                        }
-                    />
-                </>
-            );
+            return <IkkeRegistrertGiftInformasjon søknad={søknad} />;
         case SivilstandType.GIFT:
         case SivilstandType.REGISTRERT_PARTNER:
-            return (
-                <>
-                    <Informasjonsrad
-                        ikon={VilkårInfoIkon.SØKNAD}
-                        label="Søkt separasjon, skilsmisse eller reist sak"
-                        verdi={
-                            søknad.søktOmSkilsmisseSeparasjon !== undefined &&
-                            (søknad.søktOmSkilsmisseSeparasjon
-                                ? `${hentBooleanTekst(søknad.søktOmSkilsmisseSeparasjon)}, 
-                            ${formaterNullableIsoDato(søknad.datoSøktSeparasjon)}`
-                                : hentBooleanTekst(søknad.søktOmSkilsmisseSeparasjon))
-                        }
-                    />
-                    {søknad.fraflytningsdato && (
-                        <Informasjonsrad
-                            ikon={VilkårInfoIkon.SØKNAD}
-                            label="Dato for fraflytting"
-                            verdi={formaterNullableIsoDato(søknad.fraflytningsdato)}
-                        />
-                    )}
-                </>
-            );
+            return <RegistrertGiftInformasjon søknad={søknad} />;
         case SivilstandType.SEPARERT:
         case SivilstandType.SEPARERT_PARTNER:
-            return (
-                <>
-                    <Informasjonsrad
-                        ikon={VilkårInfoIkon.SØKNAD}
-                        label="Gift uten at det er registrert i folkeregisteret"
-                        verdi={erUformeltGift !== undefined && mapTrueFalse(erUformeltGift)}
-                    />
-                    <Informasjonsrad
-                        ikon={VilkårInfoIkon.SØKNAD}
-                        label="Separert eller skilt uten at det er registrert i folkeregisteret"
-                        verdi={
-                            erUformeltSeparertEllerSkilt !== undefined &&
-                            mapTrueFalse(erUformeltSeparertEllerSkilt)
-                        }
-                    />
-
-                    {søknad.årsakEnslig === EÅrsakEnslig.samlivsbruddAndre && (
-                        <>
-                            <Informasjonsrad
-                                ikon={VilkårInfoIkon.SØKNAD}
-                                label="Tidligere samboer"
-                                verdi={`${tidligereSamboer?.navn} - ${
-                                    tidligereSamboer?.personIdent
-                                        ? tidligereSamboer?.personIdent
-                                        : formaterNullableIsoDato(tidligereSamboer?.fødselsdato)
-                                }`}
-                            />
-                            <Informasjonsrad
-                                ikon={VilkårInfoIkon.SØKNAD}
-                                label="Dato for fraflytting"
-                                verdi={formaterNullableIsoDato(søknad.fraflytningsdato)}
-                            />
-                        </>
-                    )}
-
-                    {søknad.årsakEnslig === EÅrsakEnslig.endringISamværsordning && (
-                        <Informasjonsrad
-                            ikon={VilkårInfoIkon.SØKNAD}
-                            label="Endringen skjedde"
-                            verdi={
-                                søknad.endringSamværsordningDato
-                                    ? formaterNullableIsoDato(søknad.endringSamværsordningDato)
-                                    : '-'
-                            }
-                        />
-                    )}
-                </>
-            );
-
+            return <Separasjonsinformasjon søknad={søknad} />;
         default:
             return <></>;
     }
 };
 
-export default Søknadsinformasjon;
+const IkkeRegistrertGiftInformasjon: FC<{ søknad: ISivilstandSøknadsgrunnlag }> = ({ søknad }) => {
+    const { erUformeltGift, erUformeltSeparertEllerSkilt, søktOmSkilsmisseSeparasjon } = søknad;
+    const harBesvartSkillsmisseSpørsmål = søktOmSkilsmisseSeparasjon !== undefined;
+
+    // Dersom brukeren var gift på søknadstidspunktet men senere blir registrert som skilt,
+    // så ønsker vi fortsatt å vise hva brukeren svarte på spørsmålet om hen har søkt separasjon, skillsmisse
+    // eller reist sak.
+    if (harBesvartSkillsmisseSpørsmål) {
+        return <RegistrertGiftInformasjon søknad={søknad} />;
+    }
+
+    return (
+        <>
+            <Informasjonsrad
+                ikon={VilkårInfoIkon.SØKNAD}
+                label="Gift uten at det er registrert i folkeregisteret"
+                verdi={erUformeltGift !== undefined && mapTrueFalse(erUformeltGift)}
+            />
+            <Informasjonsrad
+                ikon={VilkårInfoIkon.SØKNAD}
+                label="Separert eller skilt uten at det er registrert i folkeregisteret"
+                verdi={
+                    erUformeltSeparertEllerSkilt !== undefined &&
+                    mapTrueFalse(erUformeltSeparertEllerSkilt)
+                }
+            />
+        </>
+    );
+};
+
+const RegistrertGiftInformasjon: FC<{ søknad: ISivilstandSøknadsgrunnlag }> = ({ søknad }) => {
+    const { søktOmSkilsmisseSeparasjon, datoSøktSeparasjon, fraflytningsdato } = søknad;
+
+    return (
+        <>
+            <Informasjonsrad
+                ikon={VilkårInfoIkon.SØKNAD}
+                label="Søkt separasjon, skilsmisse eller reist sak"
+                verdi={
+                    søktOmSkilsmisseSeparasjon !== undefined &&
+                    (søktOmSkilsmisseSeparasjon
+                        ? `${hentBooleanTekst(søktOmSkilsmisseSeparasjon)}, 
+                            ${formaterNullableIsoDato(datoSøktSeparasjon)}`
+                        : hentBooleanTekst(søktOmSkilsmisseSeparasjon))
+                }
+            />
+            {fraflytningsdato && (
+                <Informasjonsrad
+                    ikon={VilkårInfoIkon.SØKNAD}
+                    label="Dato for fraflytting"
+                    verdi={formaterNullableIsoDato(fraflytningsdato)}
+                />
+            )}
+        </>
+    );
+};
+
+const Separasjonsinformasjon: FC<{ søknad: ISivilstandSøknadsgrunnlag }> = ({ søknad }) => {
+    const { tidligereSamboer, erUformeltSeparertEllerSkilt, erUformeltGift } = søknad;
+
+    return (
+        <>
+            <Informasjonsrad
+                ikon={VilkårInfoIkon.SØKNAD}
+                label="Gift uten at det er registrert i folkeregisteret"
+                verdi={erUformeltGift !== undefined && mapTrueFalse(erUformeltGift)}
+            />
+            <Informasjonsrad
+                ikon={VilkårInfoIkon.SØKNAD}
+                label="Separert eller skilt uten at det er registrert i folkeregisteret"
+                verdi={
+                    erUformeltSeparertEllerSkilt !== undefined &&
+                    mapTrueFalse(erUformeltSeparertEllerSkilt)
+                }
+            />
+
+            {søknad.årsakEnslig === EÅrsakEnslig.samlivsbruddAndre && (
+                <>
+                    <Informasjonsrad
+                        ikon={VilkårInfoIkon.SØKNAD}
+                        label="Tidligere samboer"
+                        verdi={`${tidligereSamboer?.navn} - ${
+                            tidligereSamboer?.personIdent
+                                ? tidligereSamboer?.personIdent
+                                : formaterNullableIsoDato(tidligereSamboer?.fødselsdato)
+                        }`}
+                    />
+                    <Informasjonsrad
+                        ikon={VilkårInfoIkon.SØKNAD}
+                        label="Dato for fraflytting"
+                        verdi={formaterNullableIsoDato(søknad.fraflytningsdato)}
+                    />
+                </>
+            )}
+
+            {søknad.årsakEnslig === EÅrsakEnslig.endringISamværsordning && (
+                <Informasjonsrad
+                    ikon={VilkårInfoIkon.SØKNAD}
+                    label="Endringen skjedde"
+                    verdi={
+                        søknad.endringSamværsordningDato
+                            ? formaterNullableIsoDato(søknad.endringSamværsordningDato)
+                            : '-'
+                    }
+                />
+            )}
+        </>
+    );
+};


### PR DESCRIPTION
…ndvilkåret. Dersom brukeren har svart på dette spørsmålet skal svaret til brukeren vises.

### Hvorfor er denne endringen nødvendig? ✨
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-21776)

På sivilstandsvilkåret har følgende skjedd:
En søknad har blitt sendt inn av en bruker registrert som gift. Etter innsendelse av søknad har brukeren gått over til å bli registrert som skilt. Da har vi vist feil for sivilstandsvilkåret:
<img width="1434" alt="Skjermbilde 2024-07-08 kl  12 48 06" src="https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/b348f7e8-c9b0-42ee-98af-56fa8fc6b0f9">

Jeg har lagt til en sjekk på om bruker har svart på spørsmålet om skillsmisse fra søknaden. Dette spørsmålet får man bare dersom man er registrert som gift på søknadstidspunktet. Dersom dette spørsmålet er besvart er det dette som skal vises frem. Da viser vi riktig:
<img width="1431" alt="Skjermbilde 2024-07-08 kl  16 31 07" src="https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/2a870fed-96b4-4f42-9e1e-26f06e6c74b2">

