### PR TITLE
skal se på hvilke spørsmål fra søknaden som er besvart for å avgjøre …

### DIFF
--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Sivilstand/SivilstandInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Sivilstand/SivilstandInfo.tsx
@@ -49,10 +49,7 @@ const SivilstandInfo: FC<Props> = ({ sivilstand, skalViseSøknadsdata, dokumenta
                 }
             />
             {skalViseSøknadsdata && søknadsgrunnlag && (
-                <Søknadsinformasjon
-                    sivilstandtype={registergrunnlag.type}
-                    søknad={søknadsgrunnlag}
-                />
+                <Søknadsinformasjon søknad={søknadsgrunnlag} />
             )}
             {skalViseSøknadsdata && (
                 <>

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Sivilstand/Søknadsinformasjon.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Sivilstand/Søknadsinformasjon.tsx
@@ -1,81 +1,88 @@
 import React, { FC } from 'react';
-import { SivilstandType } from '../../../../App/typer/personopplysninger';
-import { EÅrsakEnslig, ISivilstandSøknadsgrunnlag } from './typer';
+import { EÅrsakEnslig, IPersonDetaljer, ISivilstandSøknadsgrunnlag } from './typer';
 import { hentBooleanTekst } from '../utils';
 import { formaterNullableIsoDato, mapTrueFalse } from '../../../../App/utils/formatter';
 import Informasjonsrad from '../../Vilkårpanel/Informasjonsrad';
 import { VilkårInfoIkon } from '../../Vilkårpanel/VilkårInformasjonKomponenter';
 
 interface Props {
-    sivilstandtype: SivilstandType;
     søknad: ISivilstandSøknadsgrunnlag;
 }
 
-export const Søknadsinformasjon: FC<Props> = ({ sivilstandtype, søknad }) => {
-    switch (sivilstandtype) {
-        case SivilstandType.UGIFT:
-        case SivilstandType.UOPPGITT:
-        case SivilstandType.ENKE_ELLER_ENKEMANN:
-        case SivilstandType.SKILT:
-        case SivilstandType.SKILT_PARTNER:
-            return <IkkeRegistrertGiftInformasjon søknad={søknad} />;
-        case SivilstandType.GIFT:
-        case SivilstandType.REGISTRERT_PARTNER:
-            return <RegistrertGiftInformasjon søknad={søknad} />;
-        case SivilstandType.SEPARERT:
-        case SivilstandType.SEPARERT_PARTNER:
-            return <Separasjonsinformasjon søknad={søknad} />;
-        default:
-            return <></>;
-    }
-};
+export const Søknadsinformasjon: FC<Props> = ({ søknad }) => {
+    const {
+        erUformeltGift,
+        erUformeltSeparertEllerSkilt,
+        søktOmSkilsmisseSeparasjon,
+        fraflytningsdato,
+        datoSøktSeparasjon,
+        årsakEnslig,
+        tidligereSamboer,
+    } = søknad;
 
-const IkkeRegistrertGiftInformasjon: FC<{ søknad: ISivilstandSøknadsgrunnlag }> = ({ søknad }) => {
-    const { erUformeltGift, erUformeltSeparertEllerSkilt, søktOmSkilsmisseSeparasjon } = søknad;
-    const harBesvartSkillsmisseSpørsmål = søktOmSkilsmisseSeparasjon !== undefined;
+    const harBesvartErUformeltGiftSpørsmål =
+        erUformeltGift !== undefined && erUformeltGift !== null;
 
-    // Dersom brukeren var gift på søknadstidspunktet men senere blir registrert som skilt,
-    // så ønsker vi fortsatt å vise hva brukeren svarte på spørsmålet om hen har søkt separasjon, skillsmisse
-    // eller reist sak.
-    if (harBesvartSkillsmisseSpørsmål) {
-        return <RegistrertGiftInformasjon søknad={søknad} />;
-    }
+    const harBesvartErUformeltSeparertEllerSkiltSpørsmål =
+        erUformeltSeparertEllerSkilt !== undefined && erUformeltSeparertEllerSkilt !== null;
+
+    const harBesvartSøktSkillsmisseSpørsmål =
+        søktOmSkilsmisseSeparasjon !== undefined && søktOmSkilsmisseSeparasjon !== null;
+
+    const erEnsligPåGrunnAvSamlivsbruddMedNoenAndre =
+        årsakEnslig === EÅrsakEnslig.samlivsbruddAndre;
+
+    const erEnsligPåGrunnAvEndringISamværsordning =
+        årsakEnslig === EÅrsakEnslig.endringISamværsordning;
+
+    const tidligereSamboerInfo = utledTidligereSamboerInformasjon(tidligereSamboer);
 
     return (
         <>
-            <Informasjonsrad
-                ikon={VilkårInfoIkon.SØKNAD}
-                label="Gift uten at det er registrert i folkeregisteret"
-                verdi={erUformeltGift !== undefined && mapTrueFalse(erUformeltGift)}
-            />
-            <Informasjonsrad
-                ikon={VilkårInfoIkon.SØKNAD}
-                label="Separert eller skilt uten at det er registrert i folkeregisteret"
-                verdi={
-                    erUformeltSeparertEllerSkilt !== undefined &&
-                    mapTrueFalse(erUformeltSeparertEllerSkilt)
-                }
-            />
-        </>
-    );
-};
-
-const RegistrertGiftInformasjon: FC<{ søknad: ISivilstandSøknadsgrunnlag }> = ({ søknad }) => {
-    const { søktOmSkilsmisseSeparasjon, datoSøktSeparasjon, fraflytningsdato } = søknad;
-
-    return (
-        <>
-            <Informasjonsrad
-                ikon={VilkårInfoIkon.SØKNAD}
-                label="Søkt separasjon, skilsmisse eller reist sak"
-                verdi={
-                    søktOmSkilsmisseSeparasjon !== undefined &&
-                    (søktOmSkilsmisseSeparasjon
-                        ? `${hentBooleanTekst(søktOmSkilsmisseSeparasjon)}, 
+            {harBesvartErUformeltGiftSpørsmål && (
+                <Informasjonsrad
+                    ikon={VilkårInfoIkon.SØKNAD}
+                    label="Gift uten at det er registrert i folkeregisteret"
+                    verdi={mapTrueFalse(erUformeltGift)}
+                />
+            )}
+            {harBesvartErUformeltSeparertEllerSkiltSpørsmål && (
+                <Informasjonsrad
+                    ikon={VilkårInfoIkon.SØKNAD}
+                    label="Separert eller skilt uten at det er registrert i folkeregisteret"
+                    verdi={mapTrueFalse(erUformeltSeparertEllerSkilt)}
+                />
+            )}
+            {harBesvartSøktSkillsmisseSpørsmål && (
+                <Informasjonsrad
+                    ikon={VilkårInfoIkon.SØKNAD}
+                    label="Søkt separasjon, skilsmisse eller reist sak"
+                    verdi={
+                        søktOmSkilsmisseSeparasjon
+                            ? `${hentBooleanTekst(søktOmSkilsmisseSeparasjon)}, 
                             ${formaterNullableIsoDato(datoSøktSeparasjon)}`
-                        : hentBooleanTekst(søktOmSkilsmisseSeparasjon))
-                }
-            />
+                            : hentBooleanTekst(søktOmSkilsmisseSeparasjon)
+                    }
+                />
+            )}
+            {erEnsligPåGrunnAvSamlivsbruddMedNoenAndre && (
+                <Informasjonsrad
+                    ikon={VilkårInfoIkon.SØKNAD}
+                    label="Tidligere samboer"
+                    verdi={tidligereSamboerInfo}
+                />
+            )}
+            {erEnsligPåGrunnAvEndringISamværsordning && (
+                <Informasjonsrad
+                    ikon={VilkårInfoIkon.SØKNAD}
+                    label="Endringen skjedde"
+                    verdi={
+                        søknad.endringSamværsordningDato
+                            ? formaterNullableIsoDato(søknad.endringSamværsordningDato)
+                            : '-'
+                    }
+                />
+            )}
             {fraflytningsdato && (
                 <Informasjonsrad
                     ikon={VilkårInfoIkon.SØKNAD}
@@ -87,55 +94,14 @@ const RegistrertGiftInformasjon: FC<{ søknad: ISivilstandSøknadsgrunnlag }> = 
     );
 };
 
-const Separasjonsinformasjon: FC<{ søknad: ISivilstandSøknadsgrunnlag }> = ({ søknad }) => {
-    const { tidligereSamboer, erUformeltSeparertEllerSkilt, erUformeltGift } = søknad;
+const utledTidligereSamboerInformasjon = (samboer: IPersonDetaljer | undefined) => {
+    if (!samboer) {
+        return 'ukjent samboer';
+    }
 
-    return (
-        <>
-            <Informasjonsrad
-                ikon={VilkårInfoIkon.SØKNAD}
-                label="Gift uten at det er registrert i folkeregisteret"
-                verdi={erUformeltGift !== undefined && mapTrueFalse(erUformeltGift)}
-            />
-            <Informasjonsrad
-                ikon={VilkårInfoIkon.SØKNAD}
-                label="Separert eller skilt uten at det er registrert i folkeregisteret"
-                verdi={
-                    erUformeltSeparertEllerSkilt !== undefined &&
-                    mapTrueFalse(erUformeltSeparertEllerSkilt)
-                }
-            />
+    const personIdentEllerFødselsdato = samboer.personIdent
+        ? samboer.personIdent
+        : formaterNullableIsoDato(samboer.fødselsdato);
 
-            {søknad.årsakEnslig === EÅrsakEnslig.samlivsbruddAndre && (
-                <>
-                    <Informasjonsrad
-                        ikon={VilkårInfoIkon.SØKNAD}
-                        label="Tidligere samboer"
-                        verdi={`${tidligereSamboer?.navn} - ${
-                            tidligereSamboer?.personIdent
-                                ? tidligereSamboer?.personIdent
-                                : formaterNullableIsoDato(tidligereSamboer?.fødselsdato)
-                        }`}
-                    />
-                    <Informasjonsrad
-                        ikon={VilkårInfoIkon.SØKNAD}
-                        label="Dato for fraflytting"
-                        verdi={formaterNullableIsoDato(søknad.fraflytningsdato)}
-                    />
-                </>
-            )}
-
-            {søknad.årsakEnslig === EÅrsakEnslig.endringISamværsordning && (
-                <Informasjonsrad
-                    ikon={VilkårInfoIkon.SØKNAD}
-                    label="Endringen skjedde"
-                    verdi={
-                        søknad.endringSamværsordningDato
-                            ? formaterNullableIsoDato(søknad.endringSamværsordningDato)
-                            : '-'
-                    }
-                />
-            )}
-        </>
-    );
+    return `${samboer.navn} - ${personIdentEllerFødselsdato ?? 'ukjent fødselsdato'}`;
 };


### PR DESCRIPTION
…hvilke spørsmål vi viser frem under sivilstandsvilkåret. Skal ikke bruke nåværende sivilstand for å utlede hvilke spørsmål som skal vises

### Hvorfor er denne endringen nødvendig? ✨
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-21799)

Ønsker å komme med en generell utbedring av visning av søknadsgrunnlag for sivilstandsvilkåret. Nå viser vi frem spørsmålene bruker har besvart i søknaden. Vi viser også nåværende sivilstand.

Ny (var skilt på søknadstidspunktet - viser riktig):
![Skjermbilde 2024-07-10 kl  15 13 55](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/8fa14ec6-948b-4ae4-a2ee-1a67dd95221b)

Gammel (viser feil - mangler spørsmål brukeren har besvart):
![Skjermbilde 2024-07-10 kl  15 14 00](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/e3dbca82-b383-4551-ac81-547a605ed211)

Ny (bruker har nå status som gift - får med alle besvarte spørsmål):
![Skjermbilde 2024-07-10 kl  15 16 40](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/ab9a493e-f40c-4301-b11f-927338d9383c)

Gammel (bruker har status som gift - mangler spørsmål her også):
![Skjermbilde 2024-07-10 kl  15 16 46](https://github.com/navikt/familie-ef-sak-frontend/assets/32769446/607acf6c-c912-45ae-a08a-b1fc37a9da1f)
