### PR TITLE
Skal gi feilmelding hvis Tilleggsstønadsforskriften mangler valg og m…

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Tilleggsstønadsvalg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Tilleggsstønadsvalg.tsx
@@ -137,7 +137,7 @@ const TilleggsstønadValg: React.FC<Props> = ({
             </Heading>
             <JaNeiRadioGruppe
                 className={'spacing'}
-                error={valideringsfeil?.harKontantstøtte}
+                error={valideringsfeil?.harTilleggsstønad}
                 legend={erDetSøktOmTekst}
                 lesevisning={erLesevisning}
                 onChange={(event) => tilleggsstønad.onChange(event)}


### PR DESCRIPTION
…an forsøker å lagre vedtak.

### Hvorfor er denne endringen nødvendig? ✨

Ønsker at det skal vises en feilmelding hvis man trykker "Lagre vedtak" uten at det var valgt noe under "Tilleggsstønadsforskriften" 

<img width="1381" alt="image" src="https://github.com/navikt/familie-ef-sak-frontend/assets/141132903/bc723b71-1b06-4e01-a114-862ed8e7ec1f">
