### PR TITLE
Ønsker at border på høyre meny alltid skal gå helt ned på siden. Har …

### DIFF
--- a/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
@@ -22,9 +22,9 @@ import { NyEierModal } from './Modal/NyEierModal';
 const Container = styled.div`
     display: flex;
     flex-shrink: 2;
-    max-height: calc(
-        100vh - ${110}px
-    ); // Magisk tall som er høyden på header pluss PersonHeaderComponent og litt til
+    height: calc(
+        100vh - ${105}px
+    ); // Magisk tall som er høyden på header pluss PersonHeaderComponent
 `;
 
 interface InnholdWrapperProps {


### PR DESCRIPTION
…derfor endret fra max-height til height. Fjernet ekstra pikseler på høyden slik at border går helt ned.

### Hvorfor er denne endringen nødvendig? ✨

Ny:
<img width="1728" alt="image" src="https://github.com/navikt/familie-ef-sak-frontend/assets/141132903/2fc9e8e7-0b4f-4b89-b838-cc24fa69b565">

<img width="1728" alt="image" src="https://github.com/navikt/familie-ef-sak-frontend/assets/141132903/f662036b-f61e-4617-9ee5-2c4b573cf0e6">

<img width="1728" alt="image" src="https://github.com/navikt/familie-ef-sak-frontend/assets/141132903/75f9dab3-8703-4f22-a77b-316db0e6452b">


Gammel: 
<img width="1728" alt="image" src="https://github.com/navikt/familie-ef-sak-frontend/assets/141132903/6326f01a-ff62-4154-b79e-ddcd61e84d2e">

<img width="1728" alt="image" src="https://github.com/navikt/familie-ef-sak-frontend/assets/141132903/642c11f2-01c3-4384-b24b-46b5f45a9264">

NB: kan se den grå baren under høyre meny, fordi ikke hele høyden blir brukt
<img width="1728" alt="image" src="https://github.com/navikt/familie-ef-sak-frontend/assets/141132903/cd7ac167-34c2-4bf4-b584-a9fc6dcb82c2">

