### PR TITLE
Knapp for tildel oppgave på behandling i preprod

### DIFF
--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -14,6 +14,7 @@ export enum ToggleName {
     // Miljø-toggles - la stå
     visIkkePubliserteBrevmaler = 'familie.ef.sak.frontend-vis-ikke-publiserte-brevmaler',
     visAutomatiskUtfylleVilkår = 'familie.ef.sak.frontend-automatisk-utfylle-vilkar',
+    visTildelOppgaveKnapp = 'familie.ef.sak.frontend-tildel-oppgave-knapp',
 
     // Release-toggles
     // Midlertidige toggles - kan fjernes etterhvert

--- a/src/frontend/App/hooks/useHentOppgave.tsx
+++ b/src/frontend/App/hooks/useHentOppgave.tsx
@@ -1,0 +1,36 @@
+import { RessursStatus } from '../typer/ressurs';
+import { useApp } from '../context/AppContext';
+import { useCallback, useState } from 'react';
+import { IOppgave } from '../../Komponenter/Oppgavebenk/typer/oppgave';
+
+const tomOppgave: IOppgave = {
+    id: 0,
+    behandlesAvApplikasjon: '',
+};
+
+export const useHentOppgave = (behandlingId: string) => {
+    const { axiosRequest } = useApp();
+    const [oppgave, settOppgave] = useState<IOppgave>(tomOppgave);
+    const [laster, settLaster] = useState(false);
+    const [feilmelding, settFeilmelding] = useState<string | null>(null);
+
+    const hentOppgave = useCallback(async () => {
+        settLaster(true);
+        settFeilmelding(null);
+        try {
+            const res = await axiosRequest<IOppgave, { behandlingId: string }>({
+                method: 'GET',
+                url: `/familie-ef-sak/api/oppgave/behandling/${behandlingId}`,
+            });
+            if (res.status === RessursStatus.SUKSESS) {
+                settOppgave(res.data);
+            } else {
+                settFeilmelding(res.frontendFeilmelding);
+            }
+        } finally {
+            settLaster(false);
+        }
+    }, [axiosRequest, behandlingId]);
+
+    return { hentOppgave, oppgave, laster, feilmelding };
+};

--- a/src/frontend/Komponenter/Behandling/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/Høyremeny.tsx
@@ -74,7 +74,7 @@ const Høyremeny: React.FC<Props> = ({ behandling, åpenHøyremeny }) => {
         <>
             {åpenHøyremeny ? (
                 <>
-                    <TildelOppgave behandlingId={behandling.id} />
+                    <TildelOppgave behandling={behandling} />
                     <Totrinnskontroll />
                     <StyledHøyremeny>
                         <StyledButton

--- a/src/frontend/Komponenter/Behandling/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/Høyremeny.tsx
@@ -11,6 +11,7 @@ import { erBehandlingUnderArbeid } from '../../../App/typer/behandlingstatus';
 import { ABlue400 } from '@navikt/ds-tokens/dist/tokens';
 import { Behandling } from '../../../App/typer/fagsak';
 import TilegnetSaksbehandler from './TilegnetSaksbehandler';
+import TildelOppgave from './TildelOppgave';
 
 interface Props {
     behandling: Behandling;
@@ -73,6 +74,7 @@ const Høyremeny: React.FC<Props> = ({ behandling, åpenHøyremeny }) => {
         <>
             {åpenHøyremeny ? (
                 <>
+                    <TildelOppgave behandlingId={behandling.id} />
                     <Totrinnskontroll />
                     <StyledHøyremeny>
                         <StyledButton

--- a/src/frontend/Komponenter/Behandling/Høyremeny/TildelOppgave.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/TildelOppgave.tsx
@@ -28,7 +28,7 @@ const TildelOppgave: React.FC<{ behandlingId: string }> = ({ behandlingId }) => 
 
     const erTilordnetOgInnloggetSaksbehandlerDenSamme =
         oppgave?.tilordnetRessurs === innloggetSaksbehandler.navIdent;
-    const erTogglet = toggles[ToggleName.visTildelOppgaveKnapp];
+    const erIkkeTogglet = !toggles[ToggleName.visTildelOppgaveKnapp];
 
     useEffect(() => {
         hentOppgave();
@@ -39,7 +39,7 @@ const TildelOppgave: React.FC<{ behandlingId: string }> = ({ behandlingId }) => 
         window.location.reload();
     };
 
-    if (erTogglet || laster || erTilordnetOgInnloggetSaksbehandlerDenSamme) {
+    if (erIkkeTogglet || laster || erTilordnetOgInnloggetSaksbehandlerDenSamme) {
         return null;
     }
 

--- a/src/frontend/Komponenter/Behandling/Høyremeny/TildelOppgave.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/TildelOppgave.tsx
@@ -6,8 +6,8 @@ import { ABorderSubtle } from '@navikt/ds-tokens/dist/tokens';
 import styled from 'styled-components';
 import { BodyShortSmall } from '../../../Felles/Visningskomponenter/Tekster';
 import { useApp } from '../../../App/context/AppContext';
-// import { useToggles } from '../../../App/context/TogglesContext';
-// import { ToggleName } from '../../../App/context/toggles';
+import { useToggles } from '../../../App/context/TogglesContext';
+import { ToggleName } from '../../../App/context/toggles';
 import { Behandling, BehandlingResultat } from '../../../App/typer/fagsak';
 
 const Container = styled.div`
@@ -26,11 +26,11 @@ const TildelOppgave: React.FC<{ behandling: Behandling }> = ({ behandling }) => 
     const { innloggetSaksbehandler } = useApp();
     const { hentOppgave, oppgave, laster, feilmelding } = useHentOppgave(behandlingId);
     const { settOppgaveTilSaksbehandler } = useOppgave(oppgave);
-    // const { toggles } = useToggles();
+    const { toggles } = useToggles();
 
     const erTilordnetOgInnloggetSaksbehandlerDenSamme =
         oppgave?.tilordnetRessurs === innloggetSaksbehandler.navIdent;
-    // const erIkkeTogglet = !toggles[ToggleName.visTildelOppgaveKnapp];
+    const erIkkeTogglet = !toggles[ToggleName.visTildelOppgaveKnapp];
     const erBehandlingFortsattAktiv =
         resultat === BehandlingResultat.IKKE_SATT || resultat === BehandlingResultat.AVSLÅTT;
 
@@ -58,6 +58,7 @@ const TildelOppgave: React.FC<{ behandling: Behandling }> = ({ behandling }) => 
     }, [behandlingId, erBehandlingFortsattAktiv, hentOppgave]);
 
     if (
+        erIkkeTogglet ||
         laster ||
         erTilordnetOgInnloggetSaksbehandlerDenSamme ||
         !erBehandlingFortsattAktiv ||

--- a/src/frontend/Komponenter/Behandling/Høyremeny/TildelOppgave.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/TildelOppgave.tsx
@@ -6,8 +6,8 @@ import { ABorderSubtle } from '@navikt/ds-tokens/dist/tokens';
 import styled from 'styled-components';
 import { BodyShortSmall } from '../../../Felles/Visningskomponenter/Tekster';
 import { useApp } from '../../../App/context/AppContext';
-import { useToggles } from '../../../App/context/TogglesContext';
-import { ToggleName } from '../../../App/context/toggles';
+// import { useToggles } from '../../../App/context/TogglesContext';
+// import { ToggleName } from '../../../App/context/toggles';
 import { Behandling, BehandlingResultat } from '../../../App/typer/fagsak';
 
 const Container = styled.div`
@@ -22,17 +22,34 @@ const Container = styled.div`
 `;
 
 const TildelOppgave: React.FC<{ behandling: Behandling }> = ({ behandling }) => {
-    const { id: behandlingId, resultat } = behandling;
+    const { id: behandlingId, resultat, opprettet } = behandling;
     const { innloggetSaksbehandler } = useApp();
     const { hentOppgave, oppgave, laster, feilmelding } = useHentOppgave(behandlingId);
     const { settOppgaveTilSaksbehandler } = useOppgave(oppgave);
-    const { toggles } = useToggles();
+    // const { toggles } = useToggles();
 
     const erTilordnetOgInnloggetSaksbehandlerDenSamme =
         oppgave?.tilordnetRessurs === innloggetSaksbehandler.navIdent;
-    const erIkkeTogglet = !toggles[ToggleName.visTildelOppgaveKnapp];
+    // const erIkkeTogglet = !toggles[ToggleName.visTildelOppgaveKnapp];
     const erBehandlingFortsattAktiv =
         resultat === BehandlingResultat.IKKE_SATT || resultat === BehandlingResultat.AVSLÅTT;
+
+    const handleTildelOppgave = () => {
+        settOppgaveTilSaksbehandler();
+        window.location.reload();
+    };
+
+    const sjekkOmDetHarGåttMistTiSekunderSidenBehandlingBleOpprettet = (
+        opprettet: string
+    ): boolean => {
+        const opprettetDate = new Date(opprettet);
+        const nå = new Date();
+        const tiSekunder = 10 * 1000;
+        return nå.getTime() - opprettetDate.getTime() > tiSekunder;
+    };
+
+    const erBehandlingOpprettetForMerEnnTiSekunderSiden =
+        sjekkOmDetHarGåttMistTiSekunderSidenBehandlingBleOpprettet(opprettet);
 
     useEffect(() => {
         if (erBehandlingFortsattAktiv) {
@@ -40,18 +57,17 @@ const TildelOppgave: React.FC<{ behandling: Behandling }> = ({ behandling }) => 
         }
     }, [behandlingId, erBehandlingFortsattAktiv, hentOppgave]);
 
-    const handleTildelOppgave = () => {
-        settOppgaveTilSaksbehandler();
-        window.location.reload();
-    };
-
-    if (laster || erTilordnetOgInnloggetSaksbehandlerDenSamme || !erBehandlingFortsattAktiv) {
+    if (
+        laster ||
+        erTilordnetOgInnloggetSaksbehandlerDenSamme ||
+        !erBehandlingFortsattAktiv ||
+        !erBehandlingOpprettetForMerEnnTiSekunderSiden
+    ) {
         return null;
     }
 
     return (
         <Container>
-            <BodyShortSmall>toggle: {erIkkeTogglet}</BodyShortSmall>
             <BodyShortSmall>KUN PREPROD - Overta oppgaven</BodyShortSmall>
             <Button size="small" onClick={handleTildelOppgave}>
                 Tildel oppgave

--- a/src/frontend/Komponenter/Behandling/Høyremeny/TildelOppgave.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/TildelOppgave.tsx
@@ -35,15 +35,10 @@ const TildelOppgave: React.FC<{ behandling: Behandling }> = ({ behandling }) => 
         resultat === BehandlingResultat.IKKE_SATT || resultat === BehandlingResultat.AVSLÅTT;
 
     useEffect(() => {
-        if (erTilordnetOgInnloggetSaksbehandlerDenSamme && erBehandlingFortsattAktiv) {
+        if (erBehandlingFortsattAktiv) {
             hentOppgave();
         }
-    }, [
-        behandlingId,
-        erBehandlingFortsattAktiv,
-        erTilordnetOgInnloggetSaksbehandlerDenSamme,
-        hentOppgave,
-    ]);
+    }, [behandlingId, erBehandlingFortsattAktiv, hentOppgave]);
 
     const handleTildelOppgave = () => {
         settOppgaveTilSaksbehandler();

--- a/src/frontend/Komponenter/Behandling/Høyremeny/TildelOppgave.tsx
+++ b/src/frontend/Komponenter/Behandling/Høyremeny/TildelOppgave.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect } from 'react';
+import { useHentOppgave } from '../../../App/hooks/useHentOppgave';
+import { Alert, Button } from '@navikt/ds-react';
+import { useOppgave } from '../../../App/hooks/useOppgave';
+import { ABorderSubtle } from '@navikt/ds-tokens/dist/tokens';
+import styled from 'styled-components';
+import { BodyShortSmall } from '../../../Felles/Visningskomponenter/Tekster';
+import { useApp } from '../../../App/context/AppContext';
+import { useToggles } from '../../../App/context/TogglesContext';
+import { ToggleName } from '../../../App/context/toggles';
+
+const Container = styled.div`
+    border: 1px solid ${ABorderSubtle};
+    padding: 0.5rem 1rem;
+    margin: 1rem 0.5rem;
+    border-radius: 0.125rem;
+
+    & > *:not(:first-child) {
+        margin-top: 1rem;
+    }
+`;
+
+const TildelOppgave: React.FC<{ behandlingId: string }> = ({ behandlingId }) => {
+    const { innloggetSaksbehandler } = useApp();
+    const { hentOppgave, oppgave, laster, feilmelding } = useHentOppgave(behandlingId);
+    const { settOppgaveTilSaksbehandler } = useOppgave(oppgave);
+    const { toggles } = useToggles();
+
+    const erTilordnetOgInnloggetSaksbehandlerDenSamme =
+        oppgave?.tilordnetRessurs === innloggetSaksbehandler.navIdent;
+    const erTogglet = toggles[ToggleName.visTildelOppgaveKnapp];
+
+    useEffect(() => {
+        hentOppgave();
+    }, [behandlingId, hentOppgave]);
+
+    const handleTildelOppgave = () => {
+        settOppgaveTilSaksbehandler();
+        window.location.reload();
+    };
+
+    if (erTogglet || laster || erTilordnetOgInnloggetSaksbehandlerDenSamme) {
+        return null;
+    }
+
+    return (
+        <Container>
+            <BodyShortSmall>KUN PREPROD - Overta oppgaven</BodyShortSmall>
+            <Button size="small" onClick={handleTildelOppgave}>
+                Tildel oppgave
+            </Button>
+            {feilmelding && (
+                <Alert size="small" variant={'error'}>
+                    {feilmelding}
+                </Alert>
+            )}
+        </Container>
+    );
+};
+
+export default TildelOppgave;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Ønsker en knapp for å overta/tildel oppgave fra behandling, i stedet for å gå via oppgavebenken.

![image](https://github.com/user-attachments/assets/74107117-ec55-4ac8-8d7a-d0235ed2101a)

[PR Backend](https://github.com/navikt/familie-ef-sak/pull/2638)