### PR TITLE
skal ta i bruk nytt endepunkt for å få med samordningsfradragstype fr…

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InnvilgeVedtak.tsx
@@ -39,7 +39,7 @@ export const InnvilgeVedtak: React.FC<{
         (revurderesFra: string) => {
             axiosRequest<IInnvilgeVedtakForOvergangsstønad, void>({
                 method: 'GET',
-                url: `/familie-ef-sak/api/vedtak/fagsak/${behandling.fagsakId}/historikk/${revurderesFra}`,
+                url: `/familie-ef-sak/api/vedtak/${behandling.id}/historikk/${revurderesFra}`,
             }).then((res: RessursSuksess<IInnvilgeVedtakForOvergangsstønad> | RessursFeilet) => {
                 if (res.status === RessursStatus.SUKSESS) {
                     settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);


### PR DESCRIPTION
…a forrige vedtak i det nåværende vedtaket på vedtak-og-beregning siden

### Hvorfor er denne endringen nødvendig? ✨
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-12388)
Ønsker å hente samordningsfradragstypen fra det forrige vedtaket på vedtak-og-beregning siden. Venter med å merge denne til i kveld siden sletting av endepunktet i backend PRen er en braking change.

Backend:
* https://github.com/navikt/familie-ef-sak/pull/2639

Preutfylling:
<img width="515" alt="Skjermbilde 2024-07-17 kl  11 28 40" src="https://github.com/user-attachments/assets/daf86dc1-92b7-4f13-af09-4e0dd8c3f062">
