### PR TITLE
Når det er - 105px vises scrollbar for hele siden på større skjermer.…

### DIFF
--- a/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingContainer.tsx
@@ -23,7 +23,7 @@ const Container = styled.div`
     display: flex;
     flex-shrink: 2;
     height: calc(
-        100vh - ${105}px
+        100vh - ${106}px
     ); // Magisk tall som er høyden på header pluss PersonHeaderComponent
 `;
 


### PR DESCRIPTION
… Scrollbaren blir borte med - 106px.

### Hvorfor er denne endringen nødvendig? ✨

Før - scrollbar for hele siden 
![image](https://github.com/user-attachments/assets/15ad5dc3-46b1-4d15-bc37-be41fbfb00d4)

Etter - ingen scrollbar for hele siden på større skjermer.
![image](https://github.com/user-attachments/assets/f9072283-44c7-4d41-b67f-d46fc3382aa2)
