### PR TITLE
skal kun utføre sjekk på om simuleringsresultat har endret seg dersom…

### DIFF
--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/FatterVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/FatterVedtak.tsx
@@ -19,8 +19,12 @@ import { ÅrsakUnderkjent, årsakUnderkjentTilTekst } from '../../../App/typer/t
 import { useNavigate } from 'react-router-dom';
 import { RessursStatus } from '../../../App/typer/ressurs';
 import { Behandling } from '../../../App/typer/fagsak';
-import { Steg } from '../Høyremeny/Steg';
 import { ABorderSubtle } from '@navikt/ds-tokens/dist/tokens';
+import {
+    harVedtaksresultatMedTilkjentYtelse,
+    useHentVedtak,
+} from '../../../App/hooks/useHentVedtak';
+import { Steg } from '../Høyremeny/Steg';
 
 const SubmitButtonWrapper = styled.div`
     display: flex;
@@ -65,14 +69,9 @@ const FatterVedtak: React.FC<{
 
     const { axiosRequest, settToast } = useApp();
     const { hentBehandlingshistorikk, hentTotrinnskontroll } = useBehandling();
+    const { hentVedtak, vedtaksresultat } = useHentVedtak(behandling.id);
 
     const navigate = useNavigate();
-
-    const erUtfylt =
-        totrinnsresultat === Totrinnsresultat.GODKJENT ||
-        (totrinnsresultat === Totrinnsresultat.UNDERKJENT &&
-            (begrunnelse || '').length > 0 &&
-            årsakerUnderkjent.length > 0);
 
     const hentSammenlignSimuleringsresultater = useCallback(
         (behandlingId: string) => {
@@ -89,10 +88,23 @@ const FatterVedtak: React.FC<{
     );
 
     useEffect(() => {
-        if (behandling.steg === Steg.BESLUTTE_VEDTAK) {
+        hentVedtak();
+    }, [hentVedtak]);
+
+    useEffect(() => {
+        if (
+            harVedtaksresultatMedTilkjentYtelse(vedtaksresultat) &&
+            behandling.steg === Steg.BESLUTTE_VEDTAK
+        ) {
             hentSammenlignSimuleringsresultater(behandling.id);
         }
-    }, [hentSammenlignSimuleringsresultater, behandling.id, behandling.steg]);
+    }, [vedtaksresultat, hentSammenlignSimuleringsresultater, behandling.id, behandling.steg]);
+
+    const erUtfylt =
+        totrinnsresultat === Totrinnsresultat.GODKJENT ||
+        (totrinnsresultat === Totrinnsresultat.UNDERKJENT &&
+            (begrunnelse || '').length > 0 &&
+            årsakerUnderkjent.length > 0);
 
     const fatteTotrinnsKontroll = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();


### PR DESCRIPTION
… behandlingen har et vedtaksresultat med tilkjent ytelse og er i steg for beslutte vedtak

### Hvorfor er denne endringen nødvendig? ✨
La til en sjekk for at behandlingen har et vedtaksresultat med tilkjent ytelse før vi gjør en eventuelt sjekk på endret simulering. Uten denne sjekken risikerer vi å prøve å hente ut et simuleringsresultat som ikke eksisterer i datbasen (f.eks. ved avslag) - noe som fører til unødvendige errors i loggene. 

Denne PRen fjerner derfor unødvendige støy fra loggene.