### PR TITLE
skal ikke bruke /sok endepunktet for å utlede om fagsaken er migrert

### DIFF
--- a/src/frontend/App/context/BehandlingContext.tsx
+++ b/src/frontend/App/context/BehandlingContext.tsx
@@ -21,6 +21,7 @@ import { useHentAnsvarligSaksbehandler } from '../hooks/useHentAnsvarligSaksbeha
 import { useApp } from './AppContext';
 import { ModalState, utledModalState } from '../../Komponenter/Behandling/Modal/NyEierModal';
 import { useHentVedtak } from '../hooks/useHentVedtak';
+import { useHentFagsak } from '../hooks/useHentFagsak';
 
 const [BehandlingProvider, useBehandling] = constate(() => {
     const { innloggetSaksbehandler } = useApp();
@@ -31,6 +32,7 @@ const [BehandlingProvider, useBehandling] = constate(() => {
     const { hentPersonopplysninger, personopplysningerResponse } =
         useHentPersonopplysninger(behandlingId);
     const { hentBehandlingCallback, behandling } = useHentBehandling(behandlingId);
+    const { hentFagsak, fagsak } = useHentFagsak();
     const { hentBehandlingshistorikkCallback, behandlingHistorikk } =
         useHentBehandlingHistorikk(behandlingId);
     const { hentTotrinnskontrollCallback, totrinnskontroll } =
@@ -82,6 +84,7 @@ const [BehandlingProvider, useBehandling] = constate(() => {
             ) {
                 hentEndringerForPersonopplysninger(behandling.data.id);
             }
+            hentFagsak(behandling.data.fagsakId);
             settVisSettPåVent(behandling.data.status === BehandlingStatus.SATT_PÅ_VENT);
         }
 
@@ -143,6 +146,7 @@ const [BehandlingProvider, useBehandling] = constate(() => {
         hentVedtak,
         vedtak,
         vedtaksresultat,
+        fagsak,
     };
 });
 

--- a/src/frontend/App/hooks/useHentFagsak.ts
+++ b/src/frontend/App/hooks/useHentFagsak.ts
@@ -5,27 +5,45 @@ import { Stønadstype } from '../typer/behandlingstema';
 import { Fagsak } from '../typer/fagsak';
 
 interface HentFagsakResponse {
-    hentFagsak: (personIdent: string, stønadstype: Stønadstype) => void;
+    hentFagsakPåPersonIdent: (personIdent: string, stønadstype: Stønadstype) => void;
+    fagsakPåPersonIdent: Ressurs<Fagsak>;
+    hentFagsak: (fagsakId: string) => void;
     fagsak: Ressurs<Fagsak>;
 }
+
 export const useHentFagsak = (): HentFagsakResponse => {
     const { axiosRequest } = useApp();
+    const [fagsakPåPersonIdent, settFagsakPåPersonIdent] =
+        useState<Ressurs<Fagsak>>(byggTomRessurs());
     const [fagsak, settFagsak] = useState<Ressurs<Fagsak>>(byggTomRessurs());
 
-    const hentFagsak = useCallback(
+    const hentFagsakPåPersonIdent = useCallback(
         (personIdent: string, stønadstype: Stønadstype) => {
-            settFagsak(byggHenterRessurs());
+            settFagsakPåPersonIdent(byggHenterRessurs());
             axiosRequest<Fagsak, { personIdent: string; stønadstype: string }>({
                 method: 'POST',
                 url: `/familie-ef-sak/api/fagsak`,
                 data: { personIdent, stønadstype },
+            }).then((res: Ressurs<Fagsak>) => settFagsakPåPersonIdent(res));
+        },
+        [axiosRequest]
+    );
+
+    const hentFagsak = useCallback(
+        (fagsakId: string) => {
+            settFagsak(byggHenterRessurs());
+            axiosRequest<Fagsak, null>({
+                method: 'GET',
+                url: `/familie-ef-sak/api/fagsak/${fagsakId}`,
             }).then((res: Ressurs<Fagsak>) => settFagsak(res));
         },
         [axiosRequest]
     );
 
     return {
-        hentFagsak,
+        hentFagsakPåPersonIdent,
+        fagsakPåPersonIdent,
         fagsak,
+        hentFagsak,
     };
 };

--- a/src/frontend/App/hooks/useJournalføringState.ts
+++ b/src/frontend/App/hooks/useJournalføringState.ts
@@ -110,7 +110,7 @@ export const useJournalføringState = (
         dokumenter.length > 0 ? dokumenter[0].dokumentInfoId : '';
 
     const { axiosRequest, innloggetSaksbehandler } = useApp();
-    const { fagsak, hentFagsak } = useHentFagsak();
+    const { fagsakPåPersonIdent: fagsak, hentFagsakPåPersonIdent: hentFagsak } = useHentFagsak();
     const hentDokumentResponse = useHentDokument(journalpost);
 
     const [fagsakId, settFagsakId] = useState<string>('');

--- a/src/frontend/App/hooks/useOppgave.ts
+++ b/src/frontend/App/hooks/useOppgave.ts
@@ -17,7 +17,7 @@ export const useOppgave = (oppgave: IOppgave) => {
     const navigate = useNavigate();
     const [feilmelding, settFeilmelding] = useState<string>('');
     const [laster, settLaster] = useState<boolean>(false);
-    const { fagsak, hentFagsak } = useHentFagsak();
+    const { fagsakPåPersonIdent: fagsak, hentFagsakPåPersonIdent: hentFagsak } = useHentFagsak();
 
     const settOppgaveTilSaksbehandler = () => {
         settLaster(true);

--- a/src/frontend/Komponenter/Behandling/BehandlingSide.tsx
+++ b/src/frontend/Komponenter/Behandling/BehandlingSide.tsx
@@ -5,8 +5,7 @@ import styled from 'styled-components';
 import BehandlingRoutes from './BehandlingRoutes';
 import { BehandlingProvider, useBehandling } from '../../App/context/BehandlingContext';
 import DataViewer from '../../Felles/DataViewer/DataViewer';
-import PersonHeaderComponent from '../../Felles/PersonHeader/PersonHeader';
-import { Behandling } from '../../App/typer/fagsak';
+import { Behandling, Fagsak } from '../../App/typer/fagsak';
 import { IPersonopplysninger } from '../../App/typer/personopplysninger';
 import { HenleggModal } from './Modal/HenleggModal';
 import { useSetValgtFagsakId } from '../../App/hooks/useSetValgtFagsakId';
@@ -18,6 +17,7 @@ import Personopplysningsendringer from './Endring/EndringPersonopplysninger';
 import { SettPåVent } from './SettPåVent/SettPåVent';
 import { NyEierModal } from './Modal/NyEierModal';
 import { Fanemeny } from './Fanemeny/Fanemeny';
+import { PersonHeader } from '../../Felles/PersonHeader/PersonHeader';
 
 const Container = styled.div`
     display: flex;
@@ -73,17 +73,18 @@ export const BehandlingSide: FC = () => (
 );
 
 const Side: FC = () => {
-    const { behandling, personopplysningerResponse } = useBehandling();
+    const { behandling, fagsak, personopplysningerResponse } = useBehandling();
 
     useEffect(() => {
         document.title = 'Behandling';
     }, []);
 
     return (
-        <DataViewer response={{ personopplysningerResponse, behandling }}>
-            {({ personopplysningerResponse, behandling }) => (
+        <DataViewer response={{ personopplysningerResponse, behandling, fagsak }}>
+            {({ personopplysningerResponse, behandling, fagsak }) => (
                 <SideInnhold
                     behandling={behandling}
+                    fagsak={fagsak}
                     personopplysninger={personopplysningerResponse}
                 />
             )}
@@ -93,17 +94,23 @@ const Side: FC = () => {
 
 interface Props {
     behandling: Behandling;
+    fagsak: Fagsak;
     personopplysninger: IPersonopplysninger;
 }
 
-const SideInnhold: FC<Props> = ({ behandling, personopplysninger }) => {
+const SideInnhold: FC<Props> = ({ behandling, personopplysninger, fagsak }) => {
     useSetValgtFagsakId(behandling.fagsakId);
     useSetPersonIdent(personopplysninger.personIdent);
     const { åpenHøyremeny } = useBehandling();
 
     return (
         <>
-            <PersonHeaderComponent data={personopplysninger} behandling={behandling} />
+            <PersonHeader
+                fagsakPersonId={fagsak.fagsakPersonId}
+                personopplysninger={personopplysninger}
+                behandling={behandling}
+                fagsak={fagsak}
+            />
             <Container>
                 <InnholdWrapper $åpenHøyremeny={åpenHøyremeny}>
                     <Fanemeny behandling={behandling} />

--- a/src/frontend/Komponenter/Behandling/Førstegangsbehandling/VelgPersonOgStønadstypeSide.tsx
+++ b/src/frontend/Komponenter/Behandling/Førstegangsbehandling/VelgPersonOgStønadstypeSide.tsx
@@ -33,7 +33,7 @@ export const VelgPersonOgStønadstypeSide = () => {
     const [personIdent, settPersonIdent] = useState<string>('');
     const [feilmelding, settFeilmelding] = useState<string>();
     const [laster, settLaster] = useState<boolean>(false);
-    const { fagsak, hentFagsak } = useHentFagsak();
+    const { fagsakPåPersonIdent: fagsak, hentFagsakPåPersonIdent: hentFagsak } = useHentFagsak();
     const navigate = useNavigate();
     const harSattPersonIdent = personIdent.length === 11;
     const harFeil = feilmelding !== undefined && harSattPersonIdent;

--- a/src/frontend/Komponenter/Journalføring/Admin/JournalføringAdmin.tsx
+++ b/src/frontend/Komponenter/Journalføring/Admin/JournalføringAdmin.tsx
@@ -40,7 +40,7 @@ export const JournalføringAdmin: React.FC = () => {
     const { axiosRequest, innloggetSaksbehandler } = useApp();
     const navigate = useNavigate();
     const { hentJournalPost, journalResponse } = useHentJournalpost(journalpostid);
-    const { hentFagsak, fagsak } = useHentFagsak();
+    const { hentFagsakPåPersonIdent: hentFagsak, fagsakPåPersonIdent: fagsak } = useHentFagsak();
     const [nyBehandlingstype, settNyBehandlingstype] = useState<Behandlingstype | undefined>();
     const [senderInn, settSenderInn] = useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState<string>('');

--- a/src/frontend/Komponenter/Personoversikt/PersonOversiktSide.tsx
+++ b/src/frontend/Komponenter/Personoversikt/PersonOversiktSide.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useMemo } from 'react';
 import { Navigate, Route, Routes, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { IPersonopplysninger } from '../../App/typer/personopplysninger';
-import PersonHeaderComponent from '../../Felles/PersonHeader/PersonHeader';
 import DataViewer from '../../Felles/DataViewer/DataViewer';
 import Behandlingsoversikt from './Behandlingsoversikt';
 import Personopplysninger from './Personopplysninger';
@@ -20,6 +19,7 @@ import { Tabs } from '@navikt/ds-react';
 import { InntektForPerson } from './InntektForPerson';
 import { loggNavigereTabEvent } from '../../App/utils/amplitude/amplitudeLoggEvents';
 import styled from 'styled-components';
+import { PersonHeader } from '../../Felles/PersonHeader/PersonHeader';
 
 type TabWithRouter = {
     label: string;
@@ -150,7 +150,10 @@ const PersonOversikt: React.FC<Props> = ({ fagsakPerson, personopplysninger }) =
 
     return (
         <>
-            <PersonHeaderComponent data={personopplysninger} />
+            <PersonHeader
+                fagsakPersonId={fagsakPerson.id}
+                personopplysninger={personopplysninger}
+            />
             <Container>
                 <Tabs
                     value={path}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-9962)

/sok endepunktet er egentlig forbeholdt personsøk så da blir det feil å bruke dette endepunktet for å utlede om en fagsak er migrert i peronHeaderen. 

Etter denne PRen kalles `agsak-person/4d7ef1c7-c0a7-4b3b-b61f-2347536ff6ee/utvidet` to ganger parallellt på behandlingsoversikten. Tror dette kan utbedres ved en liten omskrivning så lager en PR på det etter at denne er merget:
![Skjermbilde 2024-07-30 kl  14 31 54](https://github.com/user-attachments/assets/c1748952-fb11-42b4-8f15-33710fb1923b)
