### PR TITLE
varsel ved endring i simulering

### DIFF
--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/FatterVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/FatterVedtak.tsx
@@ -138,9 +138,9 @@ const FatterVedtak: React.FC<{
             <Container>
                 {erSimuleringsresultatEndret && (
                     <AlertWarning>
-                        Det har skjedd endringer i simulering mot oppdrag etter at vedtaket ble
-                        sendt til godkjenning. Underkjenn derfor vedtaket slik at saksbehandler kan
-                        ta stilling til om endringene påvirker vedtaket.
+                        Det har skjedd en endring i feilutbetaling ved simulering mot oppdrag etter
+                        at vedtaket ble sendt til godkjenning. Underkjenn derfor vedtaket slik at
+                        saksbehandler kan ta stilling til om endringene påvirker vedtaket.
                     </AlertWarning>
                 )}
                 <div>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨


Tidligere sjekket vi om simulering endret seg mhp etterbetaling og feilutbetaling. Nå sjekker vi kun feilutbetaling .Vil derfor få med at det er feilutbetaling som har endret seg i melding til beslutter.

Se backendPR for mer info: 
https://github.com/navikt/familie-ef-sak/pull/2660