### PR TITLE
Refaktorert Toast - Skal legge seg på midten og kunne krysses ut

### DIFF
--- a/src/frontend/Felles/Toast/Toast.tsx
+++ b/src/frontend/Felles/Toast/Toast.tsx
@@ -1,17 +1,8 @@
 import React, { useEffect } from 'react';
-
 import styled from 'styled-components';
-
 import { useApp } from '../../App/context/AppContext';
 import { EToast, toastTilTekst } from '../../App/typer/toast';
 import { AlertError, AlertSuccess } from '../Visningskomponenter/Alerts';
-
-const ContainerTopRight = styled.div`
-    z-index: 9999;
-    position: fixed;
-    right: 2rem;
-    top: 4rem;
-`;
 
 const ContainerTopMiddle = styled.div`
     z-index: 9999;
@@ -56,9 +47,9 @@ export const Toast: React.FC = () => {
             );
         default:
             return (
-                <ContainerTopRight>
+                <ContainerTopMiddle>
                     <AlertSuccess>{toastTilTekst[toast]}</AlertSuccess>
-                </ContainerTopRight>
+                </ContainerTopMiddle>
             );
     }
 };

--- a/src/frontend/Felles/Toast/Toast.tsx
+++ b/src/frontend/Felles/Toast/Toast.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { useApp } from '../../App/context/AppContext';
 import { EToast, toastTilTekst } from '../../App/typer/toast';
-import { AlertErrorMedLukkeknapp, AlertSuccessMedLukkeknapp } from '../Visningskomponenter/Alerts';
+import { AlertMedLukkeknapp } from '../Visningskomponenter/Alerts';
 
 const ContainerTopMiddle = styled.div`
     z-index: 9999;
@@ -14,14 +14,13 @@ const ContainerTopMiddle = styled.div`
 `;
 
 const ToastAlert: React.FC<{ toast: EToast }> = ({ toast }) => {
-    const Alert =
-        toast === EToast.REDIRECT_ANNEN_RELASJON_FEILET
-            ? AlertErrorMedLukkeknapp
-            : AlertSuccessMedLukkeknapp;
+    const variant = toast === EToast.REDIRECT_ANNEN_RELASJON_FEILET ? 'error' : 'success';
 
     return (
         <ContainerTopMiddle>
-            <Alert>{toastTilTekst[toast]}</Alert>
+            <AlertMedLukkeknapp variant={variant} keyProp={toast}>
+                {toastTilTekst[toast]}
+            </AlertMedLukkeknapp>
         </ContainerTopMiddle>
     );
 };

--- a/src/frontend/Felles/Toast/Toast.tsx
+++ b/src/frontend/Felles/Toast/Toast.tsx
@@ -13,6 +13,16 @@ const ContainerTopMiddle = styled.div`
     transform: translate(-50%, 0%);
 `;
 
+const ToastAlert: React.FC<{ toast: EToast }> = ({ toast }) => {
+    const Alert = toast === EToast.REDIRECT_ANNEN_RELASJON_FEILET ? AlertError : AlertSuccess;
+
+    return (
+        <ContainerTopMiddle>
+            <Alert>{toastTilTekst[toast]}</Alert>
+        </ContainerTopMiddle>
+    );
+};
+
 export const Toast: React.FC = () => {
     const { toast, settToast } = useApp();
 
@@ -21,35 +31,11 @@ export const Toast: React.FC = () => {
             settToast(undefined);
         }, 5000);
         return () => clearTimeout(timer);
-    });
+    }, [settToast]);
 
-    switch (toast) {
-        case null:
-        case undefined:
-            return null;
-        case EToast.REDIRECT_ANNEN_RELASJON_FEILET:
-            return (
-                <ContainerTopMiddle>
-                    <AlertError>{toastTilTekst[toast]}</AlertError>
-                </ContainerTopMiddle>
-            );
-        case EToast.INNGANGSVILKÅR_GJENBRUKT:
-            return (
-                <ContainerTopMiddle>
-                    <AlertSuccess>{toastTilTekst[toast]}</AlertSuccess>
-                </ContainerTopMiddle>
-            );
-        case EToast.TILDEL_OPPGAVE_VELlYKKET:
-            return (
-                <ContainerTopMiddle>
-                    <AlertSuccess>{toastTilTekst[toast]}</AlertSuccess>
-                </ContainerTopMiddle>
-            );
-        default:
-            return (
-                <ContainerTopMiddle>
-                    <AlertSuccess>{toastTilTekst[toast]}</AlertSuccess>
-                </ContainerTopMiddle>
-            );
+    if (toast === null || toast === undefined) {
+        return null;
     }
+
+    return <ToastAlert toast={toast} />;
 };

--- a/src/frontend/Felles/Toast/Toast.tsx
+++ b/src/frontend/Felles/Toast/Toast.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import styled from 'styled-components';
 import { useApp } from '../../App/context/AppContext';
 import { EToast, toastTilTekst } from '../../App/typer/toast';
-import { AlertError, AlertSuccess } from '../Visningskomponenter/Alerts';
+import { AlertErrorMedLukkeknapp, AlertSuccessMedLukkeknapp } from '../Visningskomponenter/Alerts';
 
 const ContainerTopMiddle = styled.div`
     z-index: 9999;
@@ -14,7 +14,10 @@ const ContainerTopMiddle = styled.div`
 `;
 
 const ToastAlert: React.FC<{ toast: EToast }> = ({ toast }) => {
-    const Alert = toast === EToast.REDIRECT_ANNEN_RELASJON_FEILET ? AlertError : AlertSuccess;
+    const Alert =
+        toast === EToast.REDIRECT_ANNEN_RELASJON_FEILET
+            ? AlertErrorMedLukkeknapp
+            : AlertSuccessMedLukkeknapp;
 
     return (
         <ContainerTopMiddle>
@@ -31,7 +34,7 @@ export const Toast: React.FC = () => {
             settToast(undefined);
         }, 5000);
         return () => clearTimeout(timer);
-    }, [settToast]);
+    });
 
     if (toast === null || toast === undefined) {
         return null;

--- a/src/frontend/Felles/Visningskomponenter/Alerts.tsx
+++ b/src/frontend/Felles/Visningskomponenter/Alerts.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, ReactNode, useEffect, useState } from 'react';
 import { Alert, AlertProps } from '@navikt/ds-react';
 
 export const AlertError = forwardRef<HTMLDivElement, Omit<AlertProps, 'variant'>>((props, ref) => {
@@ -19,7 +19,44 @@ export const AlertWarning = forwardRef<HTMLDivElement, Omit<AlertProps, 'variant
         return <Alert variant={'warning'} {...props} ref={ref} />;
     }
 );
+
+export const AlertErrorMedLukkeknapp = forwardRef<HTMLDivElement, Omit<AlertProps, 'variant'>>(
+    (props) => {
+        return <AlertMedLukkeknapp variant={'error'} {...props} />;
+    }
+);
+
+export const AlertSuccessMedLukkeknapp = forwardRef<HTMLDivElement, Omit<AlertProps, 'variant'>>(
+    (props) => {
+        return <AlertMedLukkeknapp variant={'success'} {...props} />;
+    }
+);
+
+const AlertMedLukkeknapp = ({
+    children,
+    variant,
+}: {
+    children?: ReactNode;
+    variant: AlertProps['variant'];
+}) => {
+    const [skalVise, settSkalVise] = useState(true);
+
+    useEffect(() => {
+        settSkalVise(true);
+    }, [children]);
+
+    return (
+        skalVise && (
+            <Alert variant={variant} closeButton onClose={() => settSkalVise(false)}>
+                {children}
+            </Alert>
+        )
+    );
+};
+
 AlertError.displayName = 'AlertError';
 AlertSuccess.displayName = 'AlertSuccess';
 AlertInfo.displayName = 'AlertInfo';
 AlertWarning.displayName = 'AlertWarning';
+AlertErrorMedLukkeknapp.displayName = 'AlertErrorMedLukkeknapp';
+AlertSuccessMedLukkeknapp.displayName = 'AlertSuccessMedLukkeknapp';

--- a/src/frontend/Felles/Visningskomponenter/Alerts.tsx
+++ b/src/frontend/Felles/Visningskomponenter/Alerts.tsx
@@ -14,36 +14,27 @@ export const AlertSuccess = forwardRef<HTMLDivElement, Omit<AlertProps, 'variant
 export const AlertInfo = forwardRef<HTMLDivElement, Omit<AlertProps, 'variant'>>((props, ref) => {
     return <Alert variant={'info'} {...props} ref={ref} />;
 });
+
 export const AlertWarning = forwardRef<HTMLDivElement, Omit<AlertProps, 'variant'>>(
     (props, ref) => {
         return <Alert variant={'warning'} {...props} ref={ref} />;
     }
 );
 
-export const AlertErrorMedLukkeknapp = forwardRef<HTMLDivElement, Omit<AlertProps, 'variant'>>(
-    (props) => {
-        return <AlertMedLukkeknapp variant={'error'} {...props} />;
-    }
-);
-
-export const AlertSuccessMedLukkeknapp = forwardRef<HTMLDivElement, Omit<AlertProps, 'variant'>>(
-    (props) => {
-        return <AlertMedLukkeknapp variant={'success'} {...props} />;
-    }
-);
-
-const AlertMedLukkeknapp = ({
-    children,
+export const AlertMedLukkeknapp = ({
     variant,
+    children,
+    keyProp,
 }: {
-    children?: ReactNode;
     variant: AlertProps['variant'];
+    children: ReactNode;
+    keyProp: string;
 }) => {
     const [skalVise, settSkalVise] = useState(true);
 
     useEffect(() => {
         settSkalVise(true);
-    }, [children]);
+    }, [keyProp]);
 
     return (
         skalVise && (
@@ -58,5 +49,4 @@ AlertError.displayName = 'AlertError';
 AlertSuccess.displayName = 'AlertSuccess';
 AlertInfo.displayName = 'AlertInfo';
 AlertWarning.displayName = 'AlertWarning';
-AlertErrorMedLukkeknapp.displayName = 'AlertErrorMedLukkeknapp';
-AlertSuccessMedLukkeknapp.displayName = 'AlertSuccessMedLukkeknapp';
+AlertMedLukkeknapp.displayName = 'AlertMedLukkeknapp';


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

- Alle toster vises på midten av skjermen
- Kan krysse ut toaster
- Refaktorert Toast

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-22041)

Bildene viser at toasten legger seg på midten av skjermen og har mulighet til å krysses ut.

![image](https://github.com/user-attachments/assets/cfaa607a-0a3f-4a95-82d1-0591836687a6)
![image](https://github.com/user-attachments/assets/bd983be5-082d-4863-b13d-9f6cc8bdb338)

