### PR TITLE
skal kunne vise frem henleggelsesårsaken for klagebehandlinger

### DIFF
--- a/src/frontend/Komponenter/Personoversikt/BehandlingsoversiktTabell.tsx
+++ b/src/frontend/Komponenter/Personoversikt/BehandlingsoversiktTabell.tsx
@@ -161,12 +161,22 @@ export const BehandlingsoversiktTabell: React.FC<{
         return lagKlagebehandlingsLenke(behandlingId);
     };
 
-    const finnÅrsak = (behandling: BehandlingsoversiktTabellBehandling): string =>
-        behandling.type === TilbakekrevingBehandlingstype.TILBAKEKREVING
-            ? 'Feilutbetaling'
-            : behandling.årsak
-              ? behandlingOgTilbakekrevingsårsakTilTekst[behandling.årsak]
-              : '-';
+    const finnÅrsak = (behandling: BehandlingsoversiktTabellBehandling): string => {
+        if (behandling.type === TilbakekrevingBehandlingstype.TILBAKEKREVING) {
+            return 'Feilutbetaling';
+        }
+        if (
+            behandling.type === 'Klage' &&
+            behandling.resultat === BehandlingResultat.HENLAGT &&
+            behandling.henlagtÅrsak
+        ) {
+            return henlagtÅrsakTilTekst[behandling.henlagtÅrsak];
+        }
+        if (behandling.årsak) {
+            return behandlingOgTilbakekrevingsårsakTilTekst[behandling.årsak];
+        }
+        return '-';
+    };
 
     const finnHenlagtÅrsak = (behandling: BehandlingsoversiktTabellBehandling): string =>
         behandling.henlagtÅrsak ? ` (${henlagtÅrsakTilTekst[behandling.henlagtÅrsak]})` : '';


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker å vise frem årsak til henleggelse for klagebehandlinger i behandlingsoversikten.
[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-9822)

Før: 
<img width="1119" alt="Skjermbilde 2024-08-28 kl  16 01 56" src="https://github.com/user-attachments/assets/c60cb865-9046-4d66-bd82-f11a3a71f2b0">

Etter:
<img width="1138" alt="Skjermbilde 2024-08-28 kl  16 02 10" src="https://github.com/user-attachments/assets/30a22140-816a-41fd-85ba-6bfb270261a9">
