### PR TITLE
Vil vise oppgave-pagineringsinfo. Hvor mange hentet vi, hvor mange fi…

### DIFF
--- a/src/frontend/Komponenter/Oppgavebenk/OppgaveTabell.tsx
+++ b/src/frontend/Komponenter/Oppgavebenk/OppgaveTabell.tsx
@@ -5,17 +5,15 @@ import { useSorteringState } from '../../App/hooks/felles/useSorteringState';
 import { usePagineringState } from '../../App/hooks/felles/usePaginerState';
 import { OppgaveHeaderConfig } from './OppgaveHeaderConfig';
 import { IMappe } from './typer/mappe';
-import { Pagination, SortState, Table } from '@navikt/ds-react';
-import styled from 'styled-components';
+import { HStack, Pagination, SortState, Table } from '@navikt/ds-react';
 import { useApp } from '../../App/context/AppContext';
 import { RessursFeilet, RessursStatus, RessursSuksess } from '../../App/typer/ressurs';
+import styled from 'styled-components';
+import { ANTALL_OPPGAVER_PR_SIDE } from './utils';
 
-const FlexBox = styled.div`
-    display: flex;
-    justify-content: center;
+const PaginationContainer = styled(HStack)`
+    margin-bottom: 1rem;
 `;
-
-const ANTALL_OPPGAVER_PR_SIDE = 15;
 
 export interface IOppgaverResponse {
     antallTreffTotalt: number;
@@ -85,23 +83,25 @@ const OppgaveTabell: React.FC<Props> = ({
     };
 
     const fra = (valgtSide - 1) * ANTALL_OPPGAVER_PR_SIDE;
-    const til = Math.min(fra + ANTALL_OPPGAVER_PR_SIDE, oppgaveListe.length);
+    const oppgavenummerTil = Math.min(fra + ANTALL_OPPGAVER_PR_SIDE, oppgaveListe.length);
+    const oppgavenummerFra = oppgaveListe.length === 0 ? 0 : fra + 1;
 
     return (
         <>
-            <FlexBox>
-                {fra} til {til} av {oppgaveListe.length} ({antallTreffTotalt})
-            </FlexBox>
-            {antallSider > 1 && (
-                <FlexBox>
+            <PaginationContainer justify={'center'} gap={'16'}>
+                {antallSider > 1 && (
                     <Pagination
                         size={'xsmall'}
                         page={valgtSide}
                         count={antallSider}
                         onPageChange={settValgtSide}
                     />
-                </FlexBox>
-            )}
+                )}
+                <>
+                    {oppgavenummerFra} til {oppgavenummerTil} av {oppgaveListe.length} (
+                    {antallTreffTotalt})
+                </>
+            </PaginationContainer>
             <Table
                 zebraStripes={true}
                 sort={sortConfig as SortState}

--- a/src/frontend/Komponenter/Oppgavebenk/OppgaveTabell.tsx
+++ b/src/frontend/Komponenter/Oppgavebenk/OppgaveTabell.tsx
@@ -24,9 +24,15 @@ interface Props {
     oppgaver: IOppgave[];
     mapper: IMappe[];
     settFeilmelding: (feilmelding: string) => void;
+    antallTreffTotalt?: number;
 }
 
-const OppgaveTabell: React.FC<Props> = ({ oppgaver, mapper, settFeilmelding }) => {
+const OppgaveTabell: React.FC<Props> = ({
+    oppgaver,
+    mapper,
+    settFeilmelding,
+    antallTreffTotalt,
+}) => {
     const { axiosRequest } = useApp();
 
     const [oppgaveListe, settOppgaveListe] = useState<IOppgave[]>(oppgaver);
@@ -76,11 +82,22 @@ const OppgaveTabell: React.FC<Props> = ({ oppgaver, mapper, settFeilmelding }) =
         });
     };
 
+    const fra = (valgtSide - 1) * 15;
+    const til = Math.min(fra + 15, oppgaveListe.length);
+
     return (
         <>
+            <FlexBox>
+                {fra} til {til} av {oppgaveListe.length} ({antallTreffTotalt})
+            </FlexBox>
             {antallSider > 1 && (
                 <FlexBox>
-                    <Pagination page={valgtSide} count={antallSider} onPageChange={settValgtSide} />
+                    <Pagination
+                        size={'xsmall'}
+                        page={valgtSide}
+                        count={antallSider}
+                        onPageChange={settValgtSide}
+                    />
                 </FlexBox>
             )}
             <Table

--- a/src/frontend/Komponenter/Oppgavebenk/OppgaveTabell.tsx
+++ b/src/frontend/Komponenter/Oppgavebenk/OppgaveTabell.tsx
@@ -15,6 +15,8 @@ const FlexBox = styled.div`
     justify-content: center;
 `;
 
+const ANTALL_OPPGAVER_PR_SIDE = 15;
+
 export interface IOppgaverResponse {
     antallTreffTotalt: number;
     oppgaver: IOppgave[];
@@ -49,7 +51,7 @@ const OppgaveTabell: React.FC<Props> = ({
     const { valgtSide, settValgtSide, slicedListe, antallSider } = usePagineringState(
         sortertListe,
         1,
-        15
+        ANTALL_OPPGAVER_PR_SIDE
     );
     const mapperAsRecord = (mapper: IMappe[]): Record<number, string> =>
         mapper.reduce(
@@ -82,8 +84,8 @@ const OppgaveTabell: React.FC<Props> = ({
         });
     };
 
-    const fra = (valgtSide - 1) * 15;
-    const til = Math.min(fra + 15, oppgaveListe.length);
+    const fra = (valgtSide - 1) * ANTALL_OPPGAVER_PR_SIDE;
+    const til = Math.min(fra + ANTALL_OPPGAVER_PR_SIDE, oppgaveListe.length);
 
     return (
         <>

--- a/src/frontend/Komponenter/Oppgavebenk/OppgavebenkSide.tsx
+++ b/src/frontend/Komponenter/Oppgavebenk/OppgavebenkSide.tsx
@@ -69,6 +69,7 @@ export const OppgavebenkSide: React.FC = () => {
                     {({ oppgaveRessurs }) => (
                         <OppgaveTabell
                             oppgaver={oppgaveRessurs.oppgaver}
+                            antallTreffTotalt={oppgaveRessurs.antallTreffTotalt}
                             mapper={mapper}
                             settFeilmelding={settFeilmelding}
                         />

--- a/src/frontend/Komponenter/Oppgavebenk/OpprettDummyBehandling.tsx
+++ b/src/frontend/Komponenter/Oppgavebenk/OpprettDummyBehandling.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { byggTomRessurs, Ressurs, RessursStatus } from '../../App/typer/ressurs';
-import { Button, Select, TextField } from '@navikt/ds-react';
+import { Button, Select, TextField, Accordion } from '@navikt/ds-react';
 import { useApp } from '../../App/context/AppContext';
 import { useNavigate } from 'react-router-dom';
 import AlertStripeFeilPreWrap from '../../Felles/Visningskomponenter/AlertStripeFeilPreWrap';
@@ -55,38 +55,51 @@ export const OpprettDummyBehandling: React.FC = () => {
 
     return (
         <StyledOpprettDummyBehandling>
-            <StyledFnrInput
-                label={'[Test] Opprett dummy-behandling'}
-                value={personIdent}
-                onChange={(e) => {
-                    const verdi = e.target.value;
-                    settPersonIdent(verdi);
-                    settFeilmelding(
-                        fnr(verdi).status === 'invalid' ? 'Ugyldig fødselsnummer' : undefined
-                    );
-                }}
-                autoComplete="off"
-            />
+            <Accordion>
+                <Accordion.Item>
+                    <Accordion.Header>[Test] Opprett dummy-behandling</Accordion.Header>
+                    <Accordion.Content>
+                        <StyledFnrInput
+                            label={'[Test] Opprett dummy-behandling'}
+                            value={personIdent}
+                            onChange={(e) => {
+                                const verdi = e.target.value;
+                                settPersonIdent(verdi);
+                                settFeilmelding(
+                                    fnr(verdi).status === 'invalid'
+                                        ? 'Ugyldig fødselsnummer'
+                                        : undefined
+                                );
+                            }}
+                            autoComplete="off"
+                        />
 
-            <Select
-                value={behandlingsType}
-                className="flex-item"
-                label="Type"
-                onChange={(event) => {
-                    event.persist();
-                    settBehandlingstype(event.target.value);
-                }}
-            >
-                <option value="FØRSTEGANGSBEHANDLING">Førstegangsbehandling</option>
-                <option value="MIGRERING">Migrering</option>
-                <option value="BARNETILSYN">Barnetilsyn</option>
-                <option value="SKOLEPENGER">Skolepenger</option>
-            </Select>
+                        <Select
+                            value={behandlingsType}
+                            className="flex-item"
+                            label="Type"
+                            onChange={(event) => {
+                                event.persist();
+                                settBehandlingstype(event.target.value);
+                            }}
+                        >
+                            <option value="FØRSTEGANGSBEHANDLING">Førstegangsbehandling</option>
+                            <option value="MIGRERING">Migrering</option>
+                            <option value="BARNETILSYN">Barnetilsyn</option>
+                            <option value="SKOLEPENGER">Skolepenger</option>
+                        </Select>
 
-            <Button type={'button'} disabled={!harSattPersonIdent} onClick={opprettBehandling}>
-                Lag behandling
-            </Button>
-            {harFeil && <AlertStripeFeilPreWrap>{feilmelding}</AlertStripeFeilPreWrap>}
+                        <Button
+                            type={'button'}
+                            disabled={!harSattPersonIdent}
+                            onClick={opprettBehandling}
+                        >
+                            Lag behandling
+                        </Button>
+                        {harFeil && <AlertStripeFeilPreWrap>{feilmelding}</AlertStripeFeilPreWrap>}
+                    </Accordion.Content>
+                </Accordion.Item>
+            </Accordion>
         </StyledOpprettDummyBehandling>
     );
 };

--- a/src/frontend/Komponenter/Oppgavebenk/utils.ts
+++ b/src/frontend/Komponenter/Oppgavebenk/utils.ts
@@ -39,3 +39,5 @@ export const sorterMapperPåNavn = (a: IMappe, b: IMappe) => {
     else if (a.navn < b.navn) return -1;
     return 0;
 };
+
+export const ANTALL_OPPGAVER_PR_SIDE = 15;


### PR DESCRIPTION
…nnes og hvilke nummer i rekkefølge ser vi på nå.

### Hvorfor er denne endringen nødvendig? ✨
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-22077

Ønsker litt informasjon om hvor mange oppgaver vi har hentet og hvor mange som finnes totalt (ikke hentet) 
Legger derfor inn: 

Hvor mange hentet vi, hvor mange finnes i oppgave og hvilke nummer i rekkefølge ser vi på nå.

**Avgørelser/innspill** 
* Lager hele pagineringsbar mindre (xsmall) - tok veldig stor plassmed default størrelse : hva tenker dere?  

* Ser kanskje litt rart ut at vi starter på fra 0 - 15, men følte det ble litt mye kode for å endre til 1-15 på første side (jada - ikke sååå mye, men alle bekker små) - likevel: hva tenker dere?  
* Fortsatt sentert center. Kunne eksperinentert med andre plasseringer? 
* Annet? 

![image](https://github.com/user-attachments/assets/119e154c-1945-4caf-8af6-91482d0812f2)

PS. skjuler "Opprett Dummy" i Accordion. Ble vanskelig å se hvordan dette egentlig ser ut når den tok så stor plass. 

