### PR TITLE
Flippe checkbox 'Vis uaktuelle perioder' på vedtaksperioder

### DIFF
--- a/src/frontend/Komponenter/Personoversikt/Vedtaksperioderoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Vedtaksperioderoversikt.tsx
@@ -27,6 +27,10 @@ const BehandlingSelect = styled(Select)`
     padding-top: 0.75rem;
 `;
 
+const StyledCheckbox = styled(Checkbox)`
+    align-content: end;
+`;
+
 const erAktuell = (periode: AndelHistorikk) => !skalMarkeresSomFjernet(periode.endring?.type);
 
 const skalMarkeresSomFjernet = (type?: AndelEndringType) =>
@@ -187,7 +191,7 @@ export const Vedtaksperioderoversikt: React.FC<{ fagsakPerson: FagsakPerson }> =
                     ))}
                 </BehandlingSelect>
                 {valgtFagsak && valgtFagsak.stønadstype !== Stønadstype.SKOLEPENGER ? (
-                    <Checkbox
+                    <StyledCheckbox
                         size="small"
                         onChange={() => {
                             settVisUaktuelle((prevState) => !prevState);
@@ -195,7 +199,7 @@ export const Vedtaksperioderoversikt: React.FC<{ fagsakPerson: FagsakPerson }> =
                         checked={visUaktuelle}
                     >
                         Vis uaktuelle perioder
-                    </Checkbox>
+                    </StyledCheckbox>
                 ) : (
                     <div />
                 )}

--- a/src/frontend/Komponenter/Personoversikt/Vedtaksperioderoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Vedtaksperioderoversikt.tsx
@@ -128,8 +128,9 @@ export const Vedtaksperioderoversikt: React.FC<{ fagsakPerson: FagsakPerson }> =
 
     return (
         <>
-            <HStack gap="4">
+            <HStack gap="8">
                 <StønadSelect
+                    size="small"
                     label="Stønad"
                     className="flex-item"
                     defaultValue={valgtFagsak?.stønadstype}
@@ -170,6 +171,7 @@ export const Vedtaksperioderoversikt: React.FC<{ fagsakPerson: FagsakPerson }> =
                     </option>
                 </StønadSelect>
                 <BehandlingSelect
+                    size="small"
                     label="Behandling"
                     className="flex-item"
                     onChange={(event) => {
@@ -186,6 +188,7 @@ export const Vedtaksperioderoversikt: React.FC<{ fagsakPerson: FagsakPerson }> =
                 </BehandlingSelect>
                 {valgtFagsak && valgtFagsak.stønadstype !== Stønadstype.SKOLEPENGER ? (
                     <Checkbox
+                        size="small"
                         onChange={() => {
                             settVisUaktuelle((prevState) => !prevState);
                         }}

--- a/src/frontend/Komponenter/Personoversikt/Vedtaksperioderoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Vedtaksperioderoversikt.tsx
@@ -126,7 +126,7 @@ export const Vedtaksperioderoversikt: React.FC<{ fagsakPerson: FagsakPerson }> =
         fagsakPerson.overgangsstønad || fagsakPerson.barnetilsyn || fagsakPerson.skolepenger
     );
     const [valgtBehandlingId, settValgtBehandlingId] = useState<string>();
-    const [visUaktuelle, settVisUaktuelle] = useState<boolean>(true);
+    const [visUaktuelle, settVisUaktuelle] = useState<boolean>(false);
 
     const behandlinger = useMemo(
         () => (valgtFagsak ? filtrerOgSorterBehandlinger(valgtFagsak) : []),

--- a/src/frontend/Komponenter/Personoversikt/Vedtaksperioderoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Vedtaksperioderoversikt.tsx
@@ -13,29 +13,18 @@ import VedtaksperioderBarnetilsyn from './HistorikkVedtaksperioder/Vedtaksperiod
 import VedtaksperioderOvergangsstønad from './HistorikkVedtaksperioder/VedtaksperioderOvergangsstønad';
 import { IVedtakForSkolepenger } from '../../App/typer/vedtak';
 import VedtaksperioderSkolepenger from './HistorikkVedtaksperioder/VedtaksperioderSkolepeger';
-import { Checkbox, Select } from '@navikt/ds-react';
+import { Checkbox, HStack, Select } from '@navikt/ds-react';
 import { sorterBehandlinger } from '../../App/utils/behandlingutil';
 import { useHentAndelHistorikkPerioder } from '../../App/hooks/useHentAndelHistorikkPerioder';
 
-const StyledInputs = styled.div`
-    display: flex;
-    justify-content: space-between;
-
-    > div {
-        padding: 0.25rem;
-    }
-
-    > div:last-child {
-        margin-left: auto;
-    }
-`;
-
 const StønadSelect = styled(Select)`
     width: 12rem;
+    padding-top: 0.75rem;
 `;
 
 const BehandlingSelect = styled(Select)`
     width: 22rem;
+    padding-top: 0.75rem;
 `;
 
 const erAktuell = (periode: AndelHistorikk) => !skalMarkeresSomFjernet(periode.endring?.type);
@@ -139,7 +128,7 @@ export const Vedtaksperioderoversikt: React.FC<{ fagsakPerson: FagsakPerson }> =
 
     return (
         <>
-            <StyledInputs>
+            <HStack gap="4">
                 <StønadSelect
                     label="Stønad"
                     className="flex-item"
@@ -207,7 +196,7 @@ export const Vedtaksperioderoversikt: React.FC<{ fagsakPerson: FagsakPerson }> =
                 ) : (
                     <div />
                 )}
-            </StyledInputs>
+            </HStack>
             {valgtFagsak && behandlinger.length > 0 && (
                 <Vedtaksperioder
                     fagsak={valgtFagsak}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

- Vil flippe checkboxen for 'Vis uaktuelle perioder' da tabellen ofte oppleves som uoversiktlig og det som oftest kun er relevant med aktuelle perioder.
- Flyttet på Checkboxen slik at den skal være lettere å se.

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/af4da753-a6ca-491c-a574-71214bc20749">

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/e2534a04-9146-4768-86dd-5159f49fa376">

NY:
![image](https://github.com/user-attachments/assets/5dbeec9d-5a6b-45eb-b160-e2457755efad)
