### PR TITLE
Ekstra info på beboer-knappen

### DIFF
--- a/src/frontend/App/typer/personopplysninger.ts
+++ b/src/frontend/App/typer/personopplysninger.ts
@@ -53,16 +53,16 @@ export interface IAdresse {
 }
 
 export interface ISøkeresultatPerson {
-    hits: IPersonFraSøk[];
-    totalHints: number;
-    pageNumber: number;
-    totalPages: number;
+    personer: IPersonFraSøk[];
 }
 
 export interface IPersonFraSøk {
     personIdent: string;
     visningsadresse: string;
     visningsnavn: string;
+    fødselsdato?: string;
+    erSøker?: boolean;
+    erBarn?: boolean;
 }
 
 export interface IFullmakt {

--- a/src/frontend/Felles/Personopplysninger/Beboere.tsx
+++ b/src/frontend/Felles/Personopplysninger/Beboere.tsx
@@ -45,7 +45,7 @@ const Beboere: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
                                 </Table.Row>
                             </Table.Header>
                             <Table.Body>
-                                {søkResultat.hits.map((beboer) => {
+                                {søkResultat.personer.map((beboer) => {
                                     return (
                                         <Table.Row key={beboer.personIdent}>
                                             <Table.DataCell textSize={'small'}>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Viser alder på barn av søker
Søker og barn sitt navn er i fet skrift
Listen med beboere er nå sortert - søker er først deretter barn av søker i stigende alder.

[PR backend](https://github.com/navikt/familie-ef-sak/pull/2696)

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-22526)

Slik ser det ut med endringer:
![image](https://github.com/user-attachments/assets/700535be-d565-4bb8-afca-ae0afdbe76ea)
