### PR TITLE
Skal vise infotekst når simuleringstjenesten ikke har noen resultater

### DIFF
--- a/src/frontend/Komponenter/Behandling/Simulering/Simulering.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/Simulering.tsx
@@ -82,6 +82,8 @@ const Simulering: React.FC<{
 
     const harFeilutbetaling = simuleringsresultat.feilutbetaling > 0;
 
+    const harIngenResultater = simuleringsresultat.perioder.length === 0;
+
     const skalViseValgForAutomatiskBehandlingUnder4xRettsgebyr =
         simuleringsresultat.feilutbetaling < RETTSGEBYR_BELØP * 4 &&
         simuleringsresultat.etterbetaling === 0 &&
@@ -100,6 +102,13 @@ const Simulering: React.FC<{
     return (
         <Container>
             <VStack gap="4">
+                {harIngenResultater && (
+                    <AlertWarning variant={'info'}>
+                        Simuleringstjenesten i økonomi ga ingen resultater for dette vedtaket.
+                        Simuleringsresultatet vil bare foreligge dersom det er reelle
+                        utbetalinger/endring i utbetalinger tilbake i tid, inklusiv nåværende måned.
+                    </AlertWarning>
+                )}
                 <SimuleringOversikt simulering={simuleringsresultat} />
                 {harManuellePosteringer && (
                     <AlertWarning variant={'warning'}>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-22397

![image](https://github.com/user-attachments/assets/f41793e3-95f7-46d1-a55d-68bfefe3322d)
