### PR TITLE
Når vi redirecter på personinfo-fanen må vi bruke fagsakPersonId fra …

### DIFF
--- a/src/frontend/Felles/HeaderMedSøk/PersonSøk.tsx
+++ b/src/frontend/Felles/HeaderMedSøk/PersonSøk.tsx
@@ -13,7 +13,7 @@ import { ISøkPerson } from '../../App/typer/personsøk';
 import { useApp } from '../../App/context/AppContext';
 import { IPersonIdent } from '../../App/typer/felles';
 import { v4 as uuidv4 } from 'uuid';
-// import { useNavigate } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { MannIkon } from '../Ikoner/MannIkon';
 import { KvinneIkon } from '../Ikoner/KvinneIkon';
 import { Kjønn } from '../../App/typer/personopplysninger';
@@ -41,7 +41,7 @@ const SøkContainer = styled.div`
 
 const PersonSøk: React.FC = () => {
     const { axiosRequest, settToast } = useApp();
-    // const navigate = useNavigate();
+    const navigate = useNavigate();
     const [resultat, settResultat] = useState<Ressurs<ISøkeresultat[]>>(byggTomRessurs());
     const [uuidSøk, settUuidSøk] = useState(uuidv4());
     const [fokuserSøkeresultat, settFokuserSøkeresultat] = useState<boolean>(false);
@@ -88,8 +88,7 @@ const PersonSøk: React.FC = () => {
 
     const søkeresultatOnClick = (søkeresultat: ISøkeresultat) => {
         if (søkeresultat.fagsakId) {
-            // navigate(`/person/${søkeresultat.fagsakId}`); // fagsakId er mappet fra fagsakPersonId
-            window.location.href = `${window.location.origin}/person/${søkeresultat.fagsakId}`;
+            navigate(`/person/${søkeresultat.fagsakId}`); // fagsakId er mappet fra fagsakPersonId
         } else {
             settPersonIdentUtenFagsak(søkeresultat.ident);
             settVisModal(true);

--- a/src/frontend/Komponenter/Personoversikt/PersonOversiktSide.tsx
+++ b/src/frontend/Komponenter/Personoversikt/PersonOversiktSide.tsx
@@ -139,6 +139,7 @@ export const PersonOversiktSide: React.FC = () => {
         <DataViewer response={{ personopplysninger, fagsakPerson }}>
             {({ personopplysninger, fagsakPerson }) => (
                 <PersonOversikt
+                    fagsakPersonId={fagsakPersonId}
                     fagsakPerson={fagsakPerson}
                     hentFagsakPerson={hentFagsakPerson}
                     personopplysninger={personopplysninger}
@@ -149,12 +150,14 @@ export const PersonOversiktSide: React.FC = () => {
 };
 
 interface Props {
+    fagsakPersonId: string;
     fagsakPerson: FagsakPerson;
     hentFagsakPerson: (fagsakPersonId: string) => void;
     personopplysninger: IPersonopplysninger;
 }
 
 const PersonOversikt: React.FC<Props> = ({
+    fagsakPersonId,
     fagsakPerson,
     hentFagsakPerson,
     personopplysninger,
@@ -172,7 +175,7 @@ const PersonOversikt: React.FC<Props> = ({
                 <Tabs
                     value={path}
                     onChange={(fane) => {
-                        navigate(`/person/${fagsakPerson.id}/${fane}`);
+                        navigate(`/person/${fagsakPersonId}/${fane}`);
                         loggNavigereTabEvent({
                             side: 'person',
                             forrigeFane: path,
@@ -203,7 +206,7 @@ const PersonOversikt: React.FC<Props> = ({
                         path="*"
                         element={
                             <Navigate
-                                to={`/person/${fagsakPerson.id}/behandlinger`}
+                                to={`/person/${fagsakPersonId}/behandlinger`}
                                 replace={true}
                             />
                         }


### PR DESCRIPTION
…urlen - ikke den lokale staten. Dette fordi den lokale staten kan inneholde en gammel fagsakpersonId fra før, og da får vi en rerender med FEIL id første gang - og følgelig redirecter vi tilbake til personsiden man kom fra. Feilen ble innført som en bugfix på oppgradering av react-router, men ikke tenkt over hvilken fagsakperson vi bruker

### Hvorfor er denne endringen nødvendig? ✨
Før endringen:
1. Står på fagsakPerson A (state: A)
2. Skriver inn fnr til B og velger denne
3. Redirecter til B `/person/B`
4. Router i personopplysningene redirecter med fagsakPersonId fra state (A)  til `/person/A/behandlinger`

To litt mer hacky fix: hard redirect (forrige løsning) eller lenke direkte til `../behandlinger`. Men da ville vi ikke ha løst det underliggende problemet og kan treffe på noe tilsvarende senere også...