### PR TITLE
Skal gjøre tabellene _quill-vennlige_ - bytter ut th med td, selv om …

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/UtregningstabellBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/UtregningstabellBarnetilsyn.tsx
@@ -21,22 +21,22 @@ const lagInntektsperioder = (beløpsperioder: IBeregningsperiodeBarnetilsyn[]): 
     return `<table style="margin-left: 2px; margin-right: 2px; border-collapse: collapse; ${borderStylingCompact}">
                 <thead>
                     <tr>
-                        <th style="width: 100px; ${borderStylingCompact}">Periode</th>
-                        <th style="width: 40px; ${borderStylingCompact}">Ant. barn</th>
-                        <th style="width: 45px; word-wrap: break-word; ${borderStylingCompact}">Utgifter</th>
+                        <td style="width: 100px; ${borderStylingCompact}"><strong>Periode</strong></td>
+                        <td style="width: 40px; ${borderStylingCompact}"><strong>Ant. barn</strong></td>
+                        <td style="width: 45px; word-wrap: break-word; ${borderStylingCompact}"><strong>Utgifter</strong></td>
                         ${
                             harKontantStøtte
-                                ? `<th style="width: 60px; word-wrap: break-word; ${borderStylingCompact}">
-                                    Kontantstøtte
-                                </th>`
+                                ? `<td style="width: 60px; word-wrap: break-word; ${borderStylingCompact}">
+                                    <strong>Kontantstøtte</strong>
+                                </td>`
                                 : ''
                         }
                         ${
                             harTilleggsstønad
-                                ? `<th style="width: 60px; word-wrap: break-word; ${borderStylingCompact}">Tilleggsstønad</th>`
+                                ? `<td style="width: 60px; word-wrap: break-word; ${borderStylingCompact}"><strong>Tilleggsstønad</strong></td>`
                                 : ''
                         }
-                        <th style="width: 65px; word-wrap: break-word; ${borderStylingCompact}">Dette får du utbetalt pr. måned</th>
+                        <td style="width: 65px; word-wrap: break-word; ${borderStylingCompact}"><strong>Dette får du utbetalt pr. måned</strong></td>
                     </tr>
                 </thead>
                 <tbody>

--- a/src/frontend/Komponenter/Behandling/Brev/UtregningstabellOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/UtregningstabellOvergangsstønad.tsx
@@ -25,13 +25,13 @@ const lagInntektsperioder = (beløpsperioder?: IBeløpsperiode[]): string => {
     return `<table style="margin-left: 2px; margin-right: 2px; border-collapse: collapse; ${borderStylingCompact}">
                 <thead>
                     <tr>
-                        <th style="width: 110px; ${borderStylingCompact}">Periode</th>
-                        <th style="width: 55px; word-wrap: break-word; ${borderStylingCompact}">Beregnet inntekt</th>
+                        <td style="width: 110px; ${borderStylingCompact}" class="charlietest"><strong>Periode</strong></td>
+                        <td style="width: 55px; word-wrap: break-word; ${borderStylingCompact}"><strong>Beregnet inntekt</strong></td>
                         ${
                             samordningskolonneTittel &&
-                            `<th style="width: 90px; word-wrap: break-word; ${borderStylingCompact}">${samordningskolonneTittel}</th>`
+                            `<td style="width: 90px; word-wrap: break-word; ${borderStylingCompact}"><strong>${samordningskolonneTittel}</strong></td>`
                         }
-                        <th style="width: 55px; word-wrap: break-word; ${borderStylingCompact}">Dette får du utbetalt pr. måned</th>
+                        <td style="width: 55px; word-wrap: break-word; ${borderStylingCompact}"><strong>Dette får du utbetalt pr. måned</strong></td>
                     </tr>
                 </thead>
                 <tbody>

--- a/src/frontend/Komponenter/Behandling/Brev/UtregningstabellOvergangsstønad.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/UtregningstabellOvergangsstønad.tsx
@@ -25,7 +25,7 @@ const lagInntektsperioder = (beløpsperioder?: IBeløpsperiode[]): string => {
     return `<table style="margin-left: 2px; margin-right: 2px; border-collapse: collapse; ${borderStylingCompact}">
                 <thead>
                     <tr>
-                        <td style="width: 110px; ${borderStylingCompact}" class="charlietest"><strong>Periode</strong></td>
+                        <td style="width: 110px; ${borderStylingCompact}"><strong>Periode</strong></td>
                         <td style="width: 55px; word-wrap: break-word; ${borderStylingCompact}"><strong>Beregnet inntekt</strong></td>
                         ${
                             samordningskolonneTittel &&


### PR DESCRIPTION
…det semantisk sett ikke er riktig så er dette kun innhold til pdf-generering

### Hvorfor er denne endringen nødvendig? ✨

Quill støtter ikke `th` og mister dermed øverste rad i tabellen ved konvertering til html-felt. Med `td` så funker dette, men legger på fet tekst på overskriftene for at det skal bli likt som før. 