### PR TITLE
Oppdaterer rettsgebyr til 2025.

### DIFF
--- a/src/frontend/Komponenter/Behandling/Simulering/Simulering.tsx
+++ b/src/frontend/Komponenter/Behandling/Simulering/Simulering.tsx
@@ -21,6 +21,7 @@ import { Stønadstype } from '../../../App/typer/behandlingstema';
 import { BodyLongSmall } from '../../../Felles/Visningskomponenter/Tekster';
 import { ASurfaceWarningSubtle, ASurfaceWarningSubtleHover } from '@navikt/ds-tokens/dist/tokens';
 import { AlertInfo } from '../../../Felles/Visningskomponenter/Alerts';
+
 const Container = styled.div`
     padding: 2rem;
     display: flex;
@@ -40,7 +41,7 @@ const AlertWarning = styled(Alert)`
     max-width: 60rem;
 `;
 
-const RETTSGEBYR_BELØP = 1277;
+const RETTSGEBYR_BELØP = 1314;
 
 const Simulering: React.FC<{
     simuleringsresultat: SimuleringResultat;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Etter kjøring i økonomi i januar kan vi nå få saker som kommer under 2025 rettsgebyr.

https://lovdata.no/dokument/NL/lov/1982-12-17-86#:~:text=Rettsgebyret%20er%20fra%201%20jan,2025%20hevet%20til%201%20314