### PR TITLE
Ta i bruk tilbakekreving som er flyttet til nytt nais team i preprod

### DIFF
--- a/src/frontend/App/utils/miljø.ts
+++ b/src/frontend/App/utils/miljø.ts
@@ -3,7 +3,7 @@ export const erProd = (): boolean => window.location.host === 'ensligmorellerfar
 export const tilbakekrevingBaseUrl = (): string =>
     erProd()
         ? 'https://familietilbakekreving.intern.nav.no'
-        : 'https://familie-tilbake-frontend.ansatt.dev.nav.no';
+        : 'https://tilbakekreving.ansatt.dev.nav.no';
 
 export const klageBaseUrl = (): string =>
     erProd() ? 'https://familie-klage.intern.nav.no' : 'https://familie-klage.ansatt.dev.nav.no';


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Team Tilbake skal ta over tilbakekrevingsløsningen. Den eksisterende løsningen kjører nå i teamfamilie nais teamet, og for å ta ordentlig eierskap til løsningen og gjøre det til en NAV fellestjeneste ønsker vi å flytte det til et NAIS team som er mer generelt.
