### PR TITLE
justerer bordererBottom-visning for aleneomsorgsvilkår

### DIFF
--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/Aleneomsorg.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/Aleneomsorg.tsx
@@ -14,6 +14,7 @@ import { Vilkårpanel } from '../../Vilkårpanel/Vilkårpanel';
 import { SamværskalkulatorAleneomsorg } from './SamværskalkulatorAleneomsorg';
 import { useToggles } from '../../../../App/context/TogglesContext';
 import { ToggleName } from '../../../../App/context/toggles';
+import { useBehandling } from '../../../../App/context/BehandlingContext';
 
 export const Aleneomsorg: React.FC<VilkårPropsAleneomsorg> = ({
     vurderinger,
@@ -29,6 +30,7 @@ export const Aleneomsorg: React.FC<VilkårPropsAleneomsorg> = ({
     slettSamværsavtale,
 }) => {
     const { axiosRequest } = useApp();
+    const { behandlingErRedigerbar } = useBehandling();
     const { toggles } = useToggles();
     const skalViseSamværskalkulator = toggles[ToggleName.visSamværskalkulator];
 
@@ -71,11 +73,18 @@ export const Aleneomsorg: React.FC<VilkårPropsAleneomsorg> = ({
                     indeks !== grunnlag.barnMedSamvær.length - 1 &&
                     grunnlag.barnMedSamvær.length > 1;
 
+                const lagretSamværsavtale = lagredeSamværsavtaler.find(
+                    (avtale) => avtale.behandlingBarnId === barn.barnId
+                );
+
+                // TODO: Fjern når feature toggle for skalViseSamværskalkulator fjernes
+                const vilkårpanelSkalViseBorderBottom = skalViseSamværskalkulator
+                    ? !behandlingErRedigerbar && !lagretSamværsavtale && skalViseBorderBottom
+                    : skalViseBorderBottom;
+
                 return (
                     <React.Fragment key={barn.barnId}>
-                        <VilkårpanelInnhold
-                            borderBottom={skalViseSamværskalkulator ? false : skalViseBorderBottom}
-                        >
+                        <VilkårpanelInnhold borderBottom={vilkårpanelSkalViseBorderBottom}>
                             {{
                                 venstre: (
                                     <>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Mens ny feature for samværskalkulator er feature-togglet trenger vi en ekstra sjekk for å justere hvordan aleneomsorgsvilkåret viser sin borderBottom:

Før:
<img width="1351" alt="Skjermbilde 2025-02-17 kl  09 54 36" src="https://github.com/user-attachments/assets/a5835215-5924-4274-8a68-d0c3789845fc" />

Etter:
<img width="1340" alt="Skjermbilde 2025-02-17 kl  09 54 25" src="https://github.com/user-attachments/assets/c4d6e997-46e8-47d7-b3e6-e996265eede1" />
