### PR TITLE
rader i samværskalkulator skal holde seg til fire uker per rad.

### DIFF
--- a/src/frontend/Felles/Kalkulator/Samværskalkulator.tsx
+++ b/src/frontend/Felles/Kalkulator/Samværskalkulator.tsx
@@ -62,6 +62,14 @@ const IkonKnapp = styled(Button)`
     height: fit-content;
 `;
 
+const Spacer = styled.div`
+    width: calc(100% - 1600px);
+
+    @media screen and (max-width: 1900px) {
+        display: none;
+    }
+`;
+
 const VARIGHETER_SAMVÆRSAVTALE = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18];
 
 export const kalkulerSamværsandeler = (samværsuker: Samværsuke[]) => {
@@ -116,16 +124,19 @@ export const Samværskalkulator: React.FC<Props> = ({
         />
         <HStack gap="4">
             {samværsuker.map((samværsuke, index) => (
-                <Uke
-                    key={index}
-                    index={index}
-                    samværsuke={samværsuke}
-                    oppdaterSamværsdag={(dag: string, samværsandeler: Samværsandel[]) =>
-                        oppdaterSamværsuke(index, dag, samværsandeler)
-                    }
-                    visValgmuligheter={index % 4 === 0}
-                    erLesevisning={erLesevisning}
-                />
+                <>
+                    <Uke
+                        key={index}
+                        index={index}
+                        samværsuke={samværsuke}
+                        oppdaterSamværsdag={(dag: string, samværsandeler: Samværsandel[]) =>
+                            oppdaterSamværsuke(index, dag, samværsandeler)
+                        }
+                        visValgmuligheter={index % 4 === 0}
+                        erLesevisning={erLesevisning}
+                    />
+                    {(index + 1) % 4 === 0 && <Spacer />}
+                </>
             ))}
         </HStack>
         <Oppsummering


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Rader i samværskalkulator skal se bra ut ved stor skjerm. Foreløpig støtter den kun fire uker i bredden så smal skjerm ser ikke veldig bra ut enn så lenge.

FØR:
![Skjermbilde 2025-02-17 kl  12 24 29](https://github.com/user-attachments/assets/a9d9f9a4-fe83-443f-affb-020c8fb003ee)

ETTER:
![Skjermbilde 2025-02-17 kl  12 24 21](https://github.com/user-attachments/assets/348723e4-6a92-4dfb-9b14-4bab91f6d93d)
