### PR TITLE
Fikse menyvisning for utestengning

### DIFF
--- a/src/frontend/Felles/Hamburgermeny/Hamburgermeny.tsx
+++ b/src/frontend/Felles/Hamburgermeny/Hamburgermeny.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 interface HamburgerMenyInnholdProps {
     $åpen: boolean;
+    $plassering: 'bottom-center' | 'right';
 }
 
 const HamburgerMenyIkon = styled(MenuHamburgerIcon)`
@@ -33,7 +34,8 @@ const HamburgerMenyInnhold = styled.div<HamburgerMenyInnholdProps>`
 
     background-color: white;
 
-    right: 1rem;
+    ${(props) =>
+        props.$plassering === 'bottom-center' ? 'right: 1rem;' : 'left: 3rem; bottom: 0.25rem;'}
 
     border: 1px solid grey;
 
@@ -77,10 +79,16 @@ export interface MenyItem {
 export interface Props {
     className?: string;
     items: MenyItem[];
+    plasseringItems?: 'bottom-center' | 'right';
     type?: 'hamburger' | 'ellipsisV';
 }
 
-export const Hamburgermeny: FC<Props> = ({ className, items, type = 'hamburger' }) => {
+export const Hamburgermeny: FC<Props> = ({
+    className,
+    items,
+    type = 'hamburger',
+    plasseringItems = 'bottom-center',
+}) => {
     const ref = useRef(null);
     const [åpenHamburgerMeny, settÅpenHamburgerMeny] = useState<boolean>(false);
 
@@ -118,7 +126,7 @@ export const Hamburgermeny: FC<Props> = ({ className, items, type = 'hamburger' 
                     }}
                 />
             )}
-            <HamburgerMenyInnhold $åpen={åpenHamburgerMeny}>
+            <HamburgerMenyInnhold $åpen={åpenHamburgerMeny} $plassering={plasseringItems}>
                 <ul>
                     {items.map((p) => (
                         <li key={p.tekst}>

--- a/src/frontend/Komponenter/Personoversikt/Utestengelse/Utestengelse.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Utestengelse/Utestengelse.tsx
@@ -66,6 +66,7 @@ const UtestengelseTabell: FC<{
                                                                 ),
                                                         },
                                                     ]}
+                                                    plasseringItems="right"
                                                 />
                                             )}
                                         </Table.DataCell>


### PR DESCRIPTION
# Fikse menyvisning for utestengning

### Hvorfor er denne endringen nødvendig? :sparkles:

Slett valg som vises når du trykker på åpne meny valg på utestengelser vises over neste object i listen sitt åpne meny knapp. Dette gjør det vanskelig å slette utestengelser hvis de er høyt oppe i listen.
Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-23935).

Gammel visning
![image](https://github.com/user-attachments/assets/8e7b4c39-1087-408a-9714-33699241b23c)

Ny visning
![image](https://github.com/user-attachments/assets/8e9d040c-0aef-419d-81d4-7920edc39ff2)
