### PR TITLE
Feat/samværskalkulator grid

### DIFF
--- a/src/frontend/Felles/Kalkulator/Samværskalkulator.tsx
+++ b/src/frontend/Felles/Kalkulator/Samværskalkulator.tsx
@@ -64,6 +64,8 @@ const Grid = styled.div`
     column-gap: 1rem;
     overflow: hidden;
 
+    // Styler slik at første element på hver rad er beskrivelsestekster
+    // Støtter fra to kolonner ved smal skjerm og opp til fem kolonner ved bred skjerm
     span {
         display: none;
     }
@@ -93,6 +95,7 @@ const Grid = styled.div`
         }
     }
 
+    // Styler interne borders for gridden
     .gridItem {
         position: relative;
     }
@@ -191,7 +194,7 @@ export const Samværskalkulator: React.FC<Props> = ({
                     </span>
                     <Uke
                         key={index}
-                        index={index}
+                        ukenummer={index + 1}
                         samværsuke={samværsuke}
                         oppdaterSamværsdag={(dag: string, samværsandeler: Samværsandel[]) =>
                             oppdaterSamværsuke(index, dag, samværsandeler)
@@ -212,12 +215,12 @@ export const Samværskalkulator: React.FC<Props> = ({
 
 const Uke: React.FC<{
     samværsuke: Samværsuke;
-    index: number;
+    ukenummer: number;
     oppdaterSamværsdag: (dag: string, samværsandeler: Samværsandel[]) => void;
     erLesevisning: boolean;
-}> = ({ samværsuke, index, oppdaterSamværsdag, erLesevisning }) => (
+}> = ({ samværsuke, ukenummer, oppdaterSamværsdag, erLesevisning }) => (
     <VStack gap="2" className="gridItem">
-        <UkeTittel>{`Uke ${index + 1}`}</UkeTittel>
+        <UkeTittel>{`Uke ${ukenummer}`}</UkeTittel>
         <UkedagContainer gap="1">
             {Object.entries(samværsuke).map(([ukedag, samvær]: [string, Samværsdag], index) => (
                 <Ukedag

--- a/src/frontend/Felles/Kalkulator/Samværskalkulator.tsx
+++ b/src/frontend/Felles/Kalkulator/Samværskalkulator.tsx
@@ -95,7 +95,7 @@ const Grid = styled.div`
         }
     }
 
-    // Styler interne borders for gridden
+    // Styler interne borders mellom elementene
     .gridItem {
         position: relative;
     }
@@ -121,10 +121,6 @@ const Grid = styled.div`
         inset-inline-start: 0;
         inset-block-start: -1rem;
     }
-`;
-
-const UkedagContainer = styled(HStack)`
-    // border-right: solid 2px ${ABorderDivider};
 `;
 
 const VARIGHETER_SAMVÆRSAVTALE = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18];
@@ -171,47 +167,51 @@ export const Samværskalkulator: React.FC<Props> = ({
     oppdaterSamværsuke,
     oppdaterVarighet,
     erLesevisning,
-}) => (
-    <VStack className={className} gap="4">
-        <VarighetSelect
-            oppdaterVarighet={oppdaterVarighet}
-            onDelete={onDelete}
-            samværsuker={samværsuker}
-            erLesevisning={erLesevisning}
-        />
-        <Grid>
-            {samværsuker.map((samværsuke, index) => (
-                <>
-                    <span className="gridItem">
-                        <VStack gap="6">
-                            <Div />
-                            {Object.keys(Samværsandel).map((andel) => (
-                                <Label key={andel}>
-                                    {samværsandelTilTekst[andel as Samværsandel]}
-                                </Label>
-                            ))}
-                        </VStack>
-                    </span>
-                    <Uke
-                        key={index}
-                        ukenummer={index + 1}
-                        samværsuke={samværsuke}
-                        oppdaterSamværsdag={(dag: string, samværsandeler: Samværsandel[]) =>
-                            oppdaterSamværsuke(index, dag, samværsandeler)
-                        }
-                        erLesevisning={erLesevisning}
-                    />
-                </>
-            ))}
-        </Grid>
-        <Oppsummering
-            samværsuker={samværsuker}
-            onSave={onSave}
-            onClose={onClose}
-            erLesevisning={erLesevisning}
-        />
-    </VStack>
-);
+}) => {
+    const samværsandeler = Object.keys(Samværsandel);
+
+    return (
+        <VStack className={className} gap="4">
+            <VarighetSelect
+                oppdaterVarighet={oppdaterVarighet}
+                onDelete={onDelete}
+                samværsuker={samværsuker}
+                erLesevisning={erLesevisning}
+            />
+            <Grid>
+                {samværsuker.map((samværsuke, index) => (
+                    <>
+                        <span className="gridItem">
+                            <VStack gap="6">
+                                <Div />
+                                {samværsandeler.map((andel) => (
+                                    <Label key={andel}>
+                                        {samværsandelTilTekst[andel as Samværsandel]}
+                                    </Label>
+                                ))}
+                            </VStack>
+                        </span>
+                        <Uke
+                            key={index}
+                            ukenummer={index + 1}
+                            samværsuke={samværsuke}
+                            oppdaterSamværsdag={(dag: string, samværsandeler: Samværsandel[]) =>
+                                oppdaterSamværsuke(index, dag, samværsandeler)
+                            }
+                            erLesevisning={erLesevisning}
+                        />
+                    </>
+                ))}
+            </Grid>
+            <Oppsummering
+                samværsuker={samværsuker}
+                onSave={onSave}
+                onClose={onClose}
+                erLesevisning={erLesevisning}
+            />
+        </VStack>
+    );
+};
 
 const Uke: React.FC<{
     samværsuke: Samværsuke;
@@ -221,7 +221,7 @@ const Uke: React.FC<{
 }> = ({ samværsuke, ukenummer, oppdaterSamværsdag, erLesevisning }) => (
     <VStack gap="2" className="gridItem">
         <UkeTittel>{`Uke ${ukenummer}`}</UkeTittel>
-        <UkedagContainer gap="1">
+        <HStack gap="1">
             {Object.entries(samværsuke).map(([ukedag, samvær]: [string, Samværsdag], index) => (
                 <Ukedag
                     key={ukedag + index}
@@ -233,7 +233,7 @@ const Uke: React.FC<{
                     erLesevisning={erLesevisning}
                 />
             ))}
-        </UkedagContainer>
+        </HStack>
     </VStack>
 );
 

--- a/src/frontend/Felles/Kalkulator/Samværskalkulator.tsx
+++ b/src/frontend/Felles/Kalkulator/Samværskalkulator.tsx
@@ -22,7 +22,7 @@ import { formaterStrengMedStorForbokstav } from '../../App/utils/formatter';
 import { CalculatorIcon, TrashIcon } from '@navikt/aksel-icons';
 
 const Div = styled.div`
-    height: 1.25rem;
+    height: 3.25rem;
 `;
 
 const StyledSelect = styled(Select)`

--- a/src/frontend/Felles/Kalkulator/Samværskalkulator.tsx
+++ b/src/frontend/Felles/Kalkulator/Samværskalkulator.tsx
@@ -4,7 +4,6 @@ import {
     Button,
     Checkbox,
     CheckboxGroup,
-    Heading,
     HStack,
     Label,
     Select,
@@ -20,7 +19,7 @@ import {
     Samværsuke,
 } from '../../App/typer/samværsavtale';
 import { formaterStrengMedStorForbokstav } from '../../App/utils/formatter';
-import { TrashIcon } from '@navikt/aksel-icons';
+import { CalculatorIcon, TrashIcon } from '@navikt/aksel-icons';
 
 const Div = styled.div`
     height: 1.25rem;
@@ -40,7 +39,7 @@ const SelectContainer = styled(HStack)`
 `;
 
 const OppsummeringContainer = styled(HStack)`
-    padding: 1rem 1.5rem 1.5rem 1.5rem;
+    padding: 1rem 1.5rem 1rem 1.5rem;
     background: ${ASurfaceInfoSubtle};
 `;
 
@@ -260,6 +259,7 @@ const VarighetSelect: React.FC<{
         </StyledSelect>
         {onDelete && !erLesevisning && (
             <IkonKnapp
+                size="small"
                 icon={<TrashIcon title="Slett" />}
                 variant="tertiary"
                 type="button"
@@ -282,18 +282,20 @@ const Oppsummering: React.FC<{
     const visningstekstAvbrytKnapp = erLesevisning ? 'Lukk' : 'Avbryt';
 
     return (
-        <OppsummeringContainer justify="space-between" align="baseline">
-            <HStack align="baseline" gap="4">
-                <Heading size="medium">Total:</Heading>
-                <BodyShort size="large">{samværsandelerDagVisning}</BodyShort>
-                <BodyShort size="large">{samværsandelProsentVisning}</BodyShort>
+        <OppsummeringContainer justify="space-between" align="center">
+            <HStack align="center" gap="4">
+                <HStack gap="2" align="center">
+                    <CalculatorIcon aria-hidden />
+                    <Label>Samvær:</Label>
+                </HStack>
+                <BodyShort size="medium">{`${samværsandelerDagVisning} = ${samværsandelProsentVisning}`}</BodyShort>
             </HStack>
             <HStack gap="4">
-                <Button variant="tertiary" onClick={onClose}>
+                <Button size="small" variant="tertiary" onClick={onClose}>
                     {visningstekstAvbrytKnapp}
                 </Button>
                 {!erLesevisning && (
-                    <Button type="button" onClick={onSave} disabled={erLesevisning}>
+                    <Button size="small" type="button" onClick={onSave} disabled={erLesevisning}>
                         Lagre
                     </Button>
                 )}

--- a/src/frontend/Felles/Kalkulator/Samværskalkulator.tsx
+++ b/src/frontend/Felles/Kalkulator/Samværskalkulator.tsx
@@ -25,10 +25,6 @@ const Div = styled.div`
     height: 1.25rem;
 `;
 
-const Valgmuligheter = styled(VStack)`
-    margin-right: 0.5rem;
-`;
-
 const StyledSelect = styled(Select)`
     width: 10rem;
 `;
@@ -41,11 +37,6 @@ const SelectContainer = styled(HStack)`
 const OppsummeringContainer = styled(HStack)`
     padding: 1rem 1.5rem 1rem 1.5rem;
     background: ${ASurfaceInfoSubtle};
-`;
-
-const UkeContainer = styled(HStack)<{ $border: boolean }>`
-    border-right: ${(props) => props.$border && `2px solid ${ABorderDivider}`};
-    margin-bottom: 2rem;
 `;
 
 const CheckboxGruppe = styled(CheckboxGroup)`
@@ -61,19 +52,76 @@ const IkonKnapp = styled(Button)`
     height: fit-content;
 `;
 
-const Spacer = styled.div`
-    width: calc(100% - 1600px);
-
-    @media screen and (max-width: 1900px) {
-        display: none;
-    }
-`;
-
-const UkeTittel = styled(Label)<{ $marginLeft: boolean }>`
+const UkeTittel = styled(Label)`
     text-decoration: underline;
     text-decoration-thickness: 0.125rem;
     text-underline-offset: 0.25rem;
-    margin-left: ${(props) => props.$marginLeft && `16.8rem`};
+`;
+
+const Grid = styled.div`
+    display: grid;
+    row-gap: 1rem;
+    column-gap: 1rem;
+    overflow: hidden;
+
+    span {
+        display: none;
+    }
+
+    @media screen and (max-width: 1409px) {
+        grid-template-columns: repeat(2, 305px);
+        span {
+            display: block;
+        }
+    }
+    @media screen and (min-width: 1410px) and (max-width: 1739px) {
+        grid-template-columns: repeat(3, 305px);
+        span:nth-of-type(2n + 1) {
+            display: block;
+        }
+    }
+    @media screen and (min-width: 1740px) and (max-width: 2059px) {
+        grid-template-columns: repeat(4, 305px);
+        span:nth-of-type(3n + 1) {
+            display: block;
+        }
+    }
+    @media screen and (min-width: 2060px) {
+        grid-template-columns: repeat(5, 305px);
+        span:nth-of-type(4n + 1) {
+            display: block;
+        }
+    }
+
+    .gridItem {
+        position: relative;
+    }
+
+    .gridItem::before,
+    .gridItem::after {
+        content: '';
+        position: absolute;
+        background-color: ${ABorderDivider};
+        z-index: 1;
+    }
+
+    .gridItem::before {
+        inline-size: 2px;
+        block-size: 17rem;
+        inset-block-start: 0;
+        inset-inline-start: -1rem;
+    }
+
+    .gridItem::after {
+        inline-size: 20.075rem;
+        block-size: 2px;
+        inset-inline-start: 0;
+        inset-block-start: -1rem;
+    }
+`;
+
+const UkedagContainer = styled(HStack)`
+    // border-right: solid 2px ${ABorderDivider};
 `;
 
 const VARIGHETER_SAMVÆRSAVTALE = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18];
@@ -128,9 +176,19 @@ export const Samværskalkulator: React.FC<Props> = ({
             samværsuker={samværsuker}
             erLesevisning={erLesevisning}
         />
-        <HStack gap="4">
+        <Grid>
             {samværsuker.map((samværsuke, index) => (
                 <>
+                    <span className="gridItem">
+                        <VStack gap="6">
+                            <Div />
+                            {Object.keys(Samværsandel).map((andel) => (
+                                <Label key={andel}>
+                                    {samværsandelTilTekst[andel as Samværsandel]}
+                                </Label>
+                            ))}
+                        </VStack>
+                    </span>
                     <Uke
                         key={index}
                         index={index}
@@ -138,13 +196,11 @@ export const Samværskalkulator: React.FC<Props> = ({
                         oppdaterSamværsdag={(dag: string, samværsandeler: Samværsandel[]) =>
                             oppdaterSamværsuke(index, dag, samværsandeler)
                         }
-                        visValgmuligheter={index % 4 === 0}
                         erLesevisning={erLesevisning}
                     />
-                    {(index + 1) % 4 === 0 && <Spacer />}
                 </>
             ))}
-        </HStack>
+        </Grid>
         <Oppsummering
             samværsuker={samværsuker}
             onSave={onSave}
@@ -158,34 +214,23 @@ const Uke: React.FC<{
     samværsuke: Samværsuke;
     index: number;
     oppdaterSamværsdag: (dag: string, samværsandeler: Samværsandel[]) => void;
-    visValgmuligheter: boolean;
     erLesevisning: boolean;
-}> = ({ samværsuke, index, oppdaterSamværsdag, visValgmuligheter, erLesevisning }) => (
-    <VStack gap="2">
-        <UkeTittel $marginLeft={visValgmuligheter}>{`Uke ${index + 1}`}</UkeTittel>
-        <UkeContainer gap="1" $border={(index + 1) % 4 !== 0}>
-            {visValgmuligheter && (
-                <Valgmuligheter gap="6">
-                    <Div />
-                    {Object.keys(Samværsandel).map((andel) => (
-                        <Label key={andel}>{samværsandelTilTekst[andel as Samværsandel]}</Label>
-                    ))}
-                </Valgmuligheter>
-            )}
-            {Object.entries(samværsuke).map(([ukedag, samvær]: [string, Samværsdag], index) => {
-                return (
-                    <Ukedag
-                        key={ukedag + index}
-                        ukedag={ukedag}
-                        oppdaterSamværsandeler={(samværsandeler: Samværsandel[]) =>
-                            oppdaterSamværsdag(ukedag, samværsandeler)
-                        }
-                        samværsandeler={samvær.andeler}
-                        erLesevisning={erLesevisning}
-                    />
-                );
-            })}
-        </UkeContainer>
+}> = ({ samværsuke, index, oppdaterSamværsdag, erLesevisning }) => (
+    <VStack gap="2" className="gridItem">
+        <UkeTittel>{`Uke ${index + 1}`}</UkeTittel>
+        <UkedagContainer gap="1">
+            {Object.entries(samværsuke).map(([ukedag, samvær]: [string, Samværsdag], index) => (
+                <Ukedag
+                    key={ukedag + index}
+                    ukedag={ukedag}
+                    oppdaterSamværsandeler={(samværsandeler: Samværsandel[]) =>
+                        oppdaterSamværsdag(ukedag, samværsandeler)
+                    }
+                    samværsandeler={samvær.andeler}
+                    erLesevisning={erLesevisning}
+                />
+            ))}
+        </UkedagContainer>
     </VStack>
 );
 

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/SamværskalkulatorAleneomsorg.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/SamværskalkulatorAleneomsorg.tsx
@@ -335,7 +335,7 @@ const SamværsavtaleSelect: React.FC<{
     settSamværsavtaleMal: React.Dispatch<React.SetStateAction<Samværsavtale | undefined>>;
 }> = ({ samværsavtaler, behandlingBarn, settSamværsavtaleMal }) => (
     <BehandlingBarnSelect
-        label="Mal"
+        label="Velg mal"
         size="small"
         onChange={(event: ChangeEvent<HTMLSelectElement>) =>
             settSamværsavtaleMal(

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/SamværskalkulatorAleneomsorg.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/SamværskalkulatorAleneomsorg.tsx
@@ -6,7 +6,12 @@ import {
     Samværskalkulator,
     kalkulerSamværsandeler,
 } from '../../../../Felles/Kalkulator/Samværskalkulator';
-import { AGray300, AGray50, ASurfaceDefault } from '@navikt/ds-tokens/dist/tokens';
+import {
+    AGray300,
+    AGray50,
+    ASurfaceDefault,
+    ASurfaceInfoSubtle,
+} from '@navikt/ds-tokens/dist/tokens';
 import {
     Samværsandel,
     Samværsavtale,
@@ -35,7 +40,7 @@ const Divider = styled.div`
 
 const OppsummeringContainer = styled(HStack)`
     padding-left: 1rem;
-    background: ${ASurfaceDefault};
+    background: ${ASurfaceInfoSubtle};
     border: 1rem solid ${AGray50};
 `;
 

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/SamværskalkulatorAleneomsorg.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/SamværskalkulatorAleneomsorg.tsx
@@ -281,10 +281,9 @@ export const SamværskalkulatorAleneomsorg: React.FC<Props> = ({
                         <HStack align="center" gap="4">
                             <HStack gap="2" align="center">
                                 <CalculatorIcon aria-hidden />
-                                <Label>Samværsandel:</Label>
+                                <Label>Samvær:</Label>
                             </HStack>
-                            <BodyShort size="medium">{samværsandelerDagVisning}</BodyShort>
-                            <BodyShort size="medium">{samværsandelProsentVisning}</BodyShort>
+                            <BodyShort size="medium">{`${samværsandelerDagVisning} = ${samværsandelProsentVisning}`}</BodyShort>
                         </HStack>
                         <HStack gap="4">
                             <Button


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Etter tilbakemeldinger fra fag:
- Lagt til titler på uker
- Endre tekst på oppsummering av samværskalkulatoren til "Samvær"
- Endre bakgrunnsfarge på oppsummering av samværskalkulatoren til blå
- Endre tekst på valg av kopieringsfunksjon for samværskalkulator til "Velg mal"
- Gjort samværskalkulatoren responsiv og litt penere, se før og etter bilder. Har prøvd å kommentere CSS-endringene for samværskalkulatoren slik at man forstår hva hver del i CSSen gjør

FØR:
![Skjermbilde 2025-02-20 kl  09 07 10](https://github.com/user-attachments/assets/8daa9b64-fbf9-4e9a-9871-9d1b386555f4)
![Skjermbilde 2025-02-20 kl  09 07 04](https://github.com/user-attachments/assets/90a48317-89f8-4819-b24c-e3b306ede3fd)
![Skjermbilde 2025-02-20 kl  09 06 52](https://github.com/user-attachments/assets/8fc9e51a-6bb7-448f-b350-3ba546602226)

ETTER:
![Skjermbilde 2025-02-20 kl  09 06 08](https://github.com/user-attachments/assets/e38b076d-f883-4276-9830-1fc08ec98e64)
![Skjermbilde 2025-02-20 kl  09 06 16](https://github.com/user-attachments/assets/62b5264b-7166-4a6c-9efb-8f6dbf349e7c)
![Skjermbilde 2025-02-20 kl  09 06 00](https://github.com/user-attachments/assets/9f96e22c-a6e1-4592-bbca-ec3fffcfda19)
![Skjermbilde 2025-02-20 kl  09 05 47](https://github.com/user-attachments/assets/5cdaa209-2f52-470c-833c-efaeba0f25be)
