### PR TITLE
Fix - vis modal 'Vedtaket er sendt til beslutter'

### DIFF
--- a/src/frontend/App/hooks/useHentOppfølgingsoppgave.ts
+++ b/src/frontend/App/hooks/useHentOppfølgingsoppgave.ts
@@ -18,6 +18,7 @@ export interface Oppfølgingsoppgave {
 export const useHentOppfølgingsoppgave = (behandlingId: string) => {
     const { axiosRequest } = useApp();
     const [oppfølgingsoppgave, settOppfølgingsoppgave] = useState<Oppfølgingsoppgave>();
+    const [feilmelding, settFeilmelding] = useState<string>('');
 
     const hentOppfølgingsoppgave = useRerunnableEffect(
         useCallback(() => {
@@ -25,7 +26,11 @@ export const useHentOppfølgingsoppgave = (behandlingId: string) => {
                 method: 'GET',
                 url: `/familie-ef-sak/api/oppfolgingsoppgave/${behandlingId}`,
             }).then((res: Ressurs<Oppfølgingsoppgave>) => {
-                settOppfølgingsoppgave(res.status === RessursStatus.SUKSESS ? res.data : undefined);
+                if (res.status === RessursStatus.SUKSESS) {
+                    settOppfølgingsoppgave(res.data);
+                } else if (res.status === RessursStatus.FEILET) {
+                    settFeilmelding(res.frontendFeilmelding);
+                }
             });
         }, [axiosRequest, behandlingId]),
         [axiosRequest, behandlingId]
@@ -34,5 +39,6 @@ export const useHentOppfølgingsoppgave = (behandlingId: string) => {
     return {
         hentOppfølgingsoppgave,
         oppfølgingsoppgave,
+        feilmelding,
     };
 };

--- a/src/frontend/App/hooks/useHentOppfølgingsoppgave.ts
+++ b/src/frontend/App/hooks/useHentOppfølgingsoppgave.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { useApp } from '../context/AppContext';
-import { byggTomRessurs, byggHenterRessurs, Ressurs } from '../typer/ressurs';
+import { Ressurs, RessursStatus } from '../typer/ressurs';
 import { OppgaveTypeForOpprettelse } from '../../Komponenter/Behandling/Totrinnskontroll/oppgaveForOpprettelseTyper';
 import { useRerunnableEffect } from './felles/useRerunnableEffect';
 
@@ -17,17 +17,15 @@ export interface Oppfølgingsoppgave {
 
 export const useHentOppfølgingsoppgave = (behandlingId: string) => {
     const { axiosRequest } = useApp();
-    const [oppfølgingsoppgave, settOppfølgingsoppgave] =
-        useState<Ressurs<Oppfølgingsoppgave>>(byggTomRessurs());
+    const [oppfølgingsoppgave, settOppfølgingsoppgave] = useState<Oppfølgingsoppgave>();
 
     const hentOppfølgingsoppgave = useRerunnableEffect(
         useCallback(() => {
-            settOppfølgingsoppgave(byggHenterRessurs());
             axiosRequest<Oppfølgingsoppgave, void>({
                 method: 'GET',
                 url: `/familie-ef-sak/api/oppfolgingsoppgave/${behandlingId}`,
             }).then((res: Ressurs<Oppfølgingsoppgave>) => {
-                settOppfølgingsoppgave(res);
+                settOppfølgingsoppgave(res.status === RessursStatus.SUKSESS ? res.data : undefined);
             });
         }, [axiosRequest, behandlingId]),
         [axiosRequest, behandlingId]

--- a/src/frontend/Komponenter/Behandling/Brev/BrevFane.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevFane.tsx
@@ -16,6 +16,7 @@ import { FremleggoppgaverSomOpprettes } from './FremleggoppgaverSomOpprettes';
 import { VStack } from '@navikt/ds-react';
 import { OppgaverForFerdigstilling } from '../Totrinnskontroll/OppgaverForFerdigstilling';
 import { useHentOppfølgingsoppgave } from '../../../App/hooks/useHentOppfølgingsoppgave';
+import { AlertError } from '../../../Felles/Visningskomponenter/Alerts';
 
 interface Props {
     behandling: Behandling;
@@ -27,7 +28,9 @@ export const BrevFane: React.FC<Props> = ({ behandling }) => {
         useBehandling();
     const [brevRessurs, settBrevRessurs] = useState<Ressurs<string>>(byggTomRessurs());
     const [kanSendesTilBeslutter, settKanSendesTilBeslutter] = useState<boolean>(false);
-    const { hentOppfølgingsoppgave, oppfølgingsoppgave } = useHentOppfølgingsoppgave(behandling.id);
+    const { hentOppfølgingsoppgave, oppfølgingsoppgave, feilmelding } = useHentOppfølgingsoppgave(
+        behandling.id
+    );
 
     const lagBeslutterBrev = () => {
         axiosRequest<string, null>({
@@ -73,6 +76,7 @@ export const BrevFane: React.FC<Props> = ({ behandling }) => {
                 <>
                     <StyledBrev>
                         <VenstreKolonne>
+                            {feilmelding && <AlertError size="small">{feilmelding}</AlertError>}
                             <VStack gap="4">
                                 <BrevmottakereForBehandling
                                     behandlingId={behandling.id}

--- a/src/frontend/Komponenter/Behandling/Brev/BrevFane.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevFane.tsx
@@ -67,10 +67,9 @@ export const BrevFane: React.FC<Props> = ({ behandling }) => {
             response={{
                 personopplysningerResponse,
                 vedtak,
-                oppfølgingsoppgave,
             }}
         >
-            {({ personopplysningerResponse, vedtak, oppfølgingsoppgave }) => (
+            {({ personopplysningerResponse, vedtak }) => (
                 <>
                     <StyledBrev>
                         <VenstreKolonne>
@@ -83,7 +82,7 @@ export const BrevFane: React.FC<Props> = ({ behandling }) => {
                                     <>
                                         <FremleggoppgaverSomOpprettes
                                             oppgavetyperSomSkalOpprettes={
-                                                oppfølgingsoppgave.oppgaverForOpprettelse
+                                                oppfølgingsoppgave?.oppgaverForOpprettelse
                                                     .oppgavetyperSomSkalOpprettes
                                             }
                                         />

--- a/src/frontend/Komponenter/Behandling/Brev/BrevFane.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevFane.tsx
@@ -83,7 +83,7 @@ export const BrevFane: React.FC<Props> = ({ behandling }) => {
                                         <FremleggoppgaverSomOpprettes
                                             oppgavetyperSomSkalOpprettes={
                                                 oppfølgingsoppgave?.oppgaverForOpprettelse
-                                                    .oppgavetyperSomSkalOpprettes
+                                                    .oppgavetyperSomSkalOpprettes ?? []
                                             }
                                         />
                                         <OppgaverForFerdigstilling behandlingId={behandling.id} />

--- a/src/frontend/Komponenter/Behandling/Brev/FremleggoppgaverSomOpprettes.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/FremleggoppgaverSomOpprettes.tsx
@@ -13,7 +13,7 @@ const Container = styled.div`
 `;
 
 export const FremleggoppgaverSomOpprettes: FC<{
-    oppgavetyperSomSkalOpprettes?: OppgaveTypeForOpprettelse[];
+    oppgavetyperSomSkalOpprettes: OppgaveTypeForOpprettelse[];
 }> = ({ oppgavetyperSomSkalOpprettes }) => {
     if (!oppgavetyperSomSkalOpprettes || oppgavetyperSomSkalOpprettes.length === 0) {
         return;

--- a/src/frontend/Komponenter/Behandling/Brev/FremleggoppgaverSomOpprettes.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/FremleggoppgaverSomOpprettes.tsx
@@ -13,9 +13,9 @@ const Container = styled.div`
 `;
 
 export const FremleggoppgaverSomOpprettes: FC<{
-    oppgavetyperSomSkalOpprettes: OppgaveTypeForOpprettelse[];
+    oppgavetyperSomSkalOpprettes?: OppgaveTypeForOpprettelse[];
 }> = ({ oppgavetyperSomSkalOpprettes }) => {
-    if (oppgavetyperSomSkalOpprettes.length === 0) {
+    if (!oppgavetyperSomSkalOpprettes || oppgavetyperSomSkalOpprettes.length === 0) {
         return;
     }
 

--- a/src/frontend/Komponenter/Behandling/Brev/FremleggoppgaverSomOpprettes.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/FremleggoppgaverSomOpprettes.tsx
@@ -15,7 +15,7 @@ const Container = styled.div`
 export const FremleggoppgaverSomOpprettes: FC<{
     oppgavetyperSomSkalOpprettes: OppgaveTypeForOpprettelse[];
 }> = ({ oppgavetyperSomSkalOpprettes }) => {
-    if (!oppgavetyperSomSkalOpprettes || oppgavetyperSomSkalOpprettes.length === 0) {
+    if (oppgavetyperSomSkalOpprettes.length === 0) {
         return;
     }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Endre på oppfølgingsoppgave i useHentOppfølgingsoppgave slik at den ikke returnere en ressurs, men pakker den ut hvis status er suksess. Dette er for å unngå å gå gjennom Dataviewer. For når når hentOppfølgingsoppgave?.rerun() kjøres i sendTilBeslutter rerendres alt, og settVisModal(true) blir gjort forgjeves.

![image](https://github.com/user-attachments/assets/8e3f387c-d212-459b-97ed-b0d6e7ccb333)
