### PR TITLE
Fix - settOppgavetyperSomSkalOpprettes initiell verdi fra oppfølgingsoppgave 

### DIFF
--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutterFooter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutterFooter.tsx
@@ -157,6 +157,12 @@ const SendTilBeslutterFooter: React.FC<{
         hentFremleggsoppgaver(behandling.id);
     }, [behandling.id, hentFremleggsoppgaver]);
 
+    useEffect(() => {
+        settOppgavetyperSomSkalOpprettes(
+            utledDefaultOppgavetyperSomSkalOpprettes(oppgavetyperSomKanOpprettes)
+        );
+    }, [oppgavetyperSomKanOpprettes]);
+
     return (
         <>
             {behandlingErRedigerbar && (


### PR DESCRIPTION
Oppdaterer settOppgavetyperSomSkalOpprettes i en useEffect fordi den ikke kan sette initiell verdi i opprettelsen av staten. oppgavetyperSomSkalOpprettes brukes også som default, INNTEKTSKONTROLL_1_ÅR_FREM_I_TID skal være avhuket.
