### PR TITLE
Skal vise korrekt komponenter i modal avhenging av avslag

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/BrevFane.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevFane.tsx
@@ -8,7 +8,7 @@ import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { useApp } from '../../../App/context/AppContext';
 import { TotrinnskontrollStatus } from '../../../App/typer/totrinnskontroll';
 import { BrevmottakereForBehandling } from '../Brevmottakere/BrevmottakereForBehandling';
-import { skalFerdigstilleUtenBeslutter } from '../VedtakOgBeregning/Felles/utils';
+import { utledAvslagValg } from '../VedtakOgBeregning/Felles/utils';
 import { HøyreKolonne, StyledBrev, VenstreKolonne } from './StyledBrev';
 import { Behandling } from '../../../App/typer/fagsak';
 import { OverstyrtBrevmalVarsel } from './OverstyrtBrevmalVarsel';
@@ -72,55 +72,61 @@ export const BrevFane: React.FC<Props> = ({ behandling }) => {
                 vedtak,
             }}
         >
-            {({ personopplysningerResponse, vedtak }) => (
-                <>
-                    <StyledBrev>
-                        <VenstreKolonne>
-                            {feilmelding && <AlertError size="small">{feilmelding}</AlertError>}
-                            <VStack gap="4">
-                                <BrevmottakereForBehandling
-                                    behandlingId={behandling.id}
-                                    personopplysninger={personopplysningerResponse}
-                                />
-                                {!behandlingErRedigerbar && (
-                                    <>
-                                        <FremleggoppgaverSomOpprettes
-                                            oppgavetyperSomSkalOpprettes={
-                                                oppfølgingsoppgave?.oppgaverForOpprettelse
-                                                    .oppgavetyperSomSkalOpprettes ?? []
-                                            }
-                                        />
-                                        <OppgaverForFerdigstilling behandlingId={behandling.id} />
-                                    </>
-                                )}
-                                {!behandlingErRedigerbar && (
-                                    <OverstyrtBrevmalVarsel behandlingId={behandling.id} />
-                                )}
-                                {behandlingErRedigerbar && (
-                                    <Brevmeny
-                                        oppdaterBrevRessurs={oppdaterBrevRessurs}
+            {({ personopplysningerResponse, vedtak }) => {
+                const avslagValg = utledAvslagValg(vedtak);
+
+                return (
+                    <>
+                        <StyledBrev>
+                            <VenstreKolonne>
+                                {feilmelding && <AlertError size="small">{feilmelding}</AlertError>}
+                                <VStack gap="4">
+                                    <BrevmottakereForBehandling
+                                        behandlingId={behandling.id}
                                         personopplysninger={personopplysningerResponse}
-                                        settKanSendesTilBeslutter={settKanSendesTilBeslutter}
-                                        behandling={behandling}
-                                        vedtaksresultat={vedtak?.resultatType}
                                     />
-                                )}
-                            </VStack>
-                        </VenstreKolonne>
-                        <HøyreKolonne>
-                            <PdfVisning pdfFilInnhold={brevRessurs} />
-                        </HøyreKolonne>
-                    </StyledBrev>
-                    <SendTilBeslutterFooter
-                        behandling={behandling}
-                        kanSendesTilBeslutter={kanSendesTilBeslutter}
-                        ferdigstillUtenBeslutter={skalFerdigstilleUtenBeslutter(vedtak)}
-                        behandlingErRedigerbar={behandlingErRedigerbar}
-                        hentOppfølgingsoppgave={hentOppfølgingsoppgave}
-                        oppfølgingsoppgave={oppfølgingsoppgave}
-                    />
-                </>
-            )}
+                                    {!behandlingErRedigerbar && (
+                                        <>
+                                            <FremleggoppgaverSomOpprettes
+                                                oppgavetyperSomSkalOpprettes={
+                                                    oppfølgingsoppgave?.oppgaverForOpprettelse
+                                                        .oppgavetyperSomSkalOpprettes ?? []
+                                                }
+                                            />
+                                            <OppgaverForFerdigstilling
+                                                behandlingId={behandling.id}
+                                            />
+                                        </>
+                                    )}
+                                    {!behandlingErRedigerbar && (
+                                        <OverstyrtBrevmalVarsel behandlingId={behandling.id} />
+                                    )}
+                                    {behandlingErRedigerbar && (
+                                        <Brevmeny
+                                            oppdaterBrevRessurs={oppdaterBrevRessurs}
+                                            personopplysninger={personopplysningerResponse}
+                                            settKanSendesTilBeslutter={settKanSendesTilBeslutter}
+                                            behandling={behandling}
+                                            vedtaksresultat={vedtak?.resultatType}
+                                        />
+                                    )}
+                                </VStack>
+                            </VenstreKolonne>
+                            <HøyreKolonne>
+                                <PdfVisning pdfFilInnhold={brevRessurs} />
+                            </HøyreKolonne>
+                        </StyledBrev>
+                        <SendTilBeslutterFooter
+                            behandling={behandling}
+                            kanSendesTilBeslutter={kanSendesTilBeslutter}
+                            avslagValg={avslagValg}
+                            behandlingErRedigerbar={behandlingErRedigerbar}
+                            hentOppfølgingsoppgave={hentOppfølgingsoppgave}
+                            oppfølgingsoppgave={oppfølgingsoppgave}
+                        />
+                    </>
+                );
+            }}
         </DataViewer>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Fanemeny/KorrigeringFane.tsx
+++ b/src/frontend/Komponenter/Behandling/Fanemeny/KorrigeringFane.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import SendTilBeslutterFooter from '../Totrinnskontroll/SendTilBeslutterFooter';
 import { useBehandling } from '../../../App/context/BehandlingContext';
 import { AlertInfo } from '../../../Felles/Visningskomponenter/Alerts';
-import { skalFerdigstilleUtenBeslutter } from '../VedtakOgBeregning/Felles/utils';
+import { utledAvslagValg } from '../VedtakOgBeregning/Felles/utils';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { Behandlingsårsak } from '../../../App/typer/behandlingsårsak';
 import { Behandling } from '../../../App/typer/fagsak';
@@ -27,7 +27,7 @@ export const KorrigeringFane: React.FC<Props> = ({ behandling }) => {
                         behandling={behandling}
                         kanSendesTilBeslutter={behandlingErRedigerbar}
                         behandlingErRedigerbar={behandlingErRedigerbar}
-                        ferdigstillUtenBeslutter={skalFerdigstilleUtenBeslutter(vedtak)}
+                        avslagValg={utledAvslagValg(vedtak)}
                     />
                 </>
             )}

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/ModalOpprettOgFerdigstilleOppgaver.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/ModalOpprettOgFerdigstilleOppgaver.tsx
@@ -22,7 +22,11 @@ export const ModalOpprettOgFerdigstilleOppgaver: FC<{
     >;
     oppgaverSomSkalAutomatiskFerdigstilles: number[];
     settOppgaverSomSkalAutomatiskFerdigstilles: React.Dispatch<React.SetStateAction<number[]>>;
-    ferdigstillUtenBeslutter: boolean;
+    avslagValg: {
+        ferdigstillUtenBeslutter: boolean;
+        erAvslagSkalSendeTilBeslutter: boolean;
+        erAvslag: boolean;
+    };
 }> = ({
     open,
     setOpen,
@@ -33,7 +37,7 @@ export const ModalOpprettOgFerdigstilleOppgaver: FC<{
     settOppgavetyperSomSkalOpprettes,
     oppgaverSomSkalAutomatiskFerdigstilles,
     settOppgaverSomSkalAutomatiskFerdigstilles,
-    ferdigstillUtenBeslutter,
+    avslagValg,
 }) => {
     const [
         årForInntektskontrollSelvstendigNæringsdrivende,
@@ -42,6 +46,8 @@ export const ModalOpprettOgFerdigstilleOppgaver: FC<{
     const [beskrivelseMarkeringer, settBeskrivelseMarkeringer] = useState<BeskrivelseMarkeringer[]>(
         []
     );
+
+    const { ferdigstillUtenBeslutter, erAvslagSkalSendeTilBeslutter, erAvslag } = avslagValg;
 
     const handleSettOppgaverSomSkalFerdigstilles = (oppgaveId: number) =>
         settOppgaverSomSkalAutomatiskFerdigstilles((prevOppgaver) =>
@@ -72,6 +78,9 @@ export const ModalOpprettOgFerdigstilleOppgaver: FC<{
         ? 'Ferdigstill behandling'
         : 'Send til beslutter';
 
+    const skalViseFremleggsoppgaverForOpprettelseOgFerdigstilling =
+        !erAvslag || !erAvslagSkalSendeTilBeslutter;
+
     return (
         <DataViewer response={{ fremleggsOppgaver }}>
             {({ fremleggsOppgaver }) => {
@@ -84,34 +93,45 @@ export const ModalOpprettOgFerdigstilleOppgaver: FC<{
                     >
                         <Modal.Body>
                             <VStack gap="4">
-                                <FremleggsoppgaverForOpprettelse
-                                    årForInntektskontrollSelvstendigNæringsdrivende={
-                                        årForInntektskontrollSelvstendigNæringsdrivende
-                                    }
-                                    oppgavetyperSomKanOpprettes={oppgavetyperSomKanOpprettes}
-                                    oppgavetyperSomSkalOpprettes={oppgavetyperSomSkalOpprettes}
-                                    settOppgavetyperSomSkalOpprettes={
-                                        settOppgavetyperSomSkalOpprettes
-                                    }
-                                    settÅrForInntektskontrollSelvstendigNæringsdrivende={
-                                        settÅrForInntektskontrollSelvstendigNæringsdrivende
-                                    }
-                                />
-                                <Divider />
-                                {fremleggsOppgaver.oppgaver.length > 0 && (
-                                    <TabellFerdigstilleOppgaver
-                                        fremleggsOppgaver={fremleggsOppgaver}
-                                        oppgaverSomSkalAutomatiskFerdigstilles={
-                                            oppgaverSomSkalAutomatiskFerdigstilles
-                                        }
-                                        handleSettOppgaverSomSkalFerdigstilles={
-                                            handleSettOppgaverSomSkalFerdigstilles
-                                        }
-                                    />
+                                {skalViseFremleggsoppgaverForOpprettelseOgFerdigstilling && (
+                                    <>
+                                        <FremleggsoppgaverForOpprettelse
+                                            årForInntektskontrollSelvstendigNæringsdrivende={
+                                                årForInntektskontrollSelvstendigNæringsdrivende
+                                            }
+                                            oppgavetyperSomKanOpprettes={
+                                                oppgavetyperSomKanOpprettes
+                                            }
+                                            oppgavetyperSomSkalOpprettes={
+                                                oppgavetyperSomSkalOpprettes
+                                            }
+                                            settOppgavetyperSomSkalOpprettes={
+                                                settOppgavetyperSomSkalOpprettes
+                                            }
+                                            settÅrForInntektskontrollSelvstendigNæringsdrivende={
+                                                settÅrForInntektskontrollSelvstendigNæringsdrivende
+                                            }
+                                        />
+                                        <Divider />
+                                        {fremleggsOppgaver.oppgaver.length > 0 && (
+                                            <TabellFerdigstilleOppgaver
+                                                fremleggsOppgaver={fremleggsOppgaver}
+                                                oppgaverSomSkalAutomatiskFerdigstilles={
+                                                    oppgaverSomSkalAutomatiskFerdigstilles
+                                                }
+                                                handleSettOppgaverSomSkalFerdigstilles={
+                                                    handleSettOppgaverSomSkalFerdigstilles
+                                                }
+                                            />
+                                        )}
+                                    </>
                                 )}
+
                                 {!ferdigstillUtenBeslutter && (
                                     <>
-                                        <Divider />
+                                        {skalViseFremleggsoppgaverForOpprettelseOgFerdigstilling && (
+                                            <Divider />
+                                        )}
                                         <BeskrivelseOppgave
                                             beskrivelseMarkeringer={beskrivelseMarkeringer}
                                             settBeskrivelseMarkeringer={settBeskrivelseMarkeringer}

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutterFooter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutterFooter.tsx
@@ -66,16 +66,20 @@ const SendTilBeslutterFooter: React.FC<{
     behandling: Behandling;
     kanSendesTilBeslutter?: boolean;
     behandlingErRedigerbar: boolean;
-    ferdigstillUtenBeslutter: boolean;
     hentOppfølgingsoppgave?: { rerun: () => void };
     oppfølgingsoppgave?: Oppfølgingsoppgave;
+    avslagValg: {
+        ferdigstillUtenBeslutter: boolean;
+        erAvslagSkalSendeTilBeslutter: boolean;
+        erAvslag: boolean;
+    };
 }> = ({
     behandling,
     kanSendesTilBeslutter,
     behandlingErRedigerbar,
-    ferdigstillUtenBeslutter,
     hentOppfølgingsoppgave,
     oppfølgingsoppgave,
+    avslagValg,
 }) => {
     const { axiosRequest } = useApp();
     const navigate = useNavigate();
@@ -102,6 +106,8 @@ const SendTilBeslutterFooter: React.FC<{
     >(utledDefaultOppgavetyperSomSkalOpprettes(oppgavetyperSomKanOpprettes));
     const [oppgaverSomSkalAutomatiskFerdigstilles, settOppgaverSomSkalAutomatiskFerdigstilles] =
         useState<number[]>(oppfølgingsoppgave?.oppgaveIderForFerdigstilling || []);
+
+    const { ferdigstillUtenBeslutter } = avslagValg;
 
     const sendTilBeslutter = (data: SendTilBeslutterRequest) => {
         settLaster(true);
@@ -231,7 +237,7 @@ const SendTilBeslutterFooter: React.FC<{
                     settOppgaverSomSkalAutomatiskFerdigstilles={
                         settOppgaverSomSkalAutomatiskFerdigstilles
                     }
-                    ferdigstillUtenBeslutter={ferdigstillUtenBeslutter}
+                    avslagValg={avslagValg}
                 />
             )}
         </>

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
@@ -191,6 +191,26 @@ export const skalFerdigstilleUtenBeslutter = (vedtak?: IVedtak | undefined): boo
     );
 };
 
+export const utledErAvslagSkalSendeTilBeslutter = (vedtak?: IVedtak | undefined): boolean => {
+    return (
+        !!vedtak &&
+        vedtak._type === IVedtakType.Avslag &&
+        vedtak.resultatType === EBehandlingResultat.AVSLÅ &&
+        vedtak.avslåÅrsak !== EAvslagÅrsak.MINDRE_INNTEKTSENDRINGER
+    );
+};
+
+export const utledAvslagValg = (vedtak?: IVedtak | undefined) => {
+    return {
+        ferdigstillUtenBeslutter: skalFerdigstilleUtenBeslutter(vedtak),
+        erAvslagSkalSendeTilBeslutter: utledErAvslagSkalSendeTilBeslutter(vedtak),
+        erAvslag:
+            !!vedtak &&
+            vedtak._type === IVedtakType.Avslag &&
+            vedtak.resultatType === EBehandlingResultat.AVSLÅ,
+    };
+};
+
 export const validerGyldigTallverdi = (verdi: string | number | undefined | null) => {
     const ugyldigVerdiFeilmelding = `Ugyldig verdi - kun heltall tillatt`;
     if (typeof verdi === 'number') {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Laget nytt objekt for å samle props. Bruker properties fra objektet til å avgjøre hva som skal vises på modal.

Avslag 10% endring inntekt:
![image](https://github.com/user-attachments/assets/75c8a342-8d8f-4645-8ea6-5b62651713b8)

Avslag andre grunner: 
![image](https://github.com/user-attachments/assets/962134e2-e483-4243-9072-1267a3d8c38e)

Innvilgelse/ikke avslag:
![image](https://github.com/user-attachments/assets/5cf12dd7-d3c7-4fba-878b-c1d184a7d336)

