### PR TITLE
Foreslå årsinntekt i brev

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
@@ -77,7 +77,7 @@ export const BrevMenyDelmal: React.FC<Props> = ({
             const årsinntektRef = finnFlettefeltRefFraFlettefeltApiNavn(dokument, 'arsinntekt');
             const månedsinntektGangerTolv = (parseInt(verdi) * 12).toString();
 
-            oppdaterFlettefeltÅrsinntekt(årsinntektRef, månedsinntektGangerTolv);
+            oppdaterFlettefeltForGittRef(årsinntektRef, månedsinntektGangerTolv);
         }
 
         settFlettefelter((prevState) =>
@@ -86,7 +86,7 @@ export const BrevMenyDelmal: React.FC<Props> = ({
         settBrevOppdatert(false);
     };
 
-    const oppdaterFlettefeltÅrsinntekt = (flettefeltRef: string, verdi: string) => {
+    const oppdaterFlettefeltForGittRef = (flettefeltRef: string, verdi: string) => {
         settFlettefelter((prevState) =>
             prevState.map((felt) =>
                 felt._ref === flettefeltRef

--- a/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
@@ -15,6 +15,7 @@ import { Accordion, Button, Checkbox } from '@navikt/ds-react';
 import { ABorderRadiusMedium, ABorderStrong } from '@navikt/ds-tokens/dist/tokens';
 import { HtmlEditor } from '../../../Felles/HtmlEditor/HtmlEditor';
 import { ArrowsSquarepathIcon } from '@navikt/aksel-icons';
+import { finnFlettefeltRefFraFlettefeltApiNavn } from './BrevUtils';
 
 const DelmalValg = styled.div`
     display: flex;
@@ -67,11 +68,32 @@ export const BrevMenyDelmal: React.FC<Props> = ({
 
     const [ekspanderbartPanelÅpen, settEkspanderbartPanelÅpen] = useState(false);
 
-    const handleFlettefeltInput = (verdi: string, flettefelt: Flettefeltreferanse) => {
+    const handleFlettefeltInput = (
+        verdi: string,
+        flettefelt: Flettefeltreferanse,
+        flettefeltApiNavn?: string
+    ) => {
+        if (flettefeltApiNavn === 'belopIMaaneden') {
+            const årsinntektRef = finnFlettefeltRefFraFlettefeltApiNavn(dokument, 'arsinntekt');
+            const månedsinntektGangerTolv = (parseInt(verdi) * 12).toString();
+
+            oppdaterFlettefeltÅrsinntekt(årsinntektRef, månedsinntektGangerTolv);
+        }
+
         settFlettefelter((prevState) =>
             prevState.map((felt) => (felt._ref === flettefelt._ref ? { ...felt, verdi } : felt))
         );
         settBrevOppdatert(false);
+    };
+
+    const oppdaterFlettefeltÅrsinntekt = (flettefeltRef: string, verdi: string) => {
+        settFlettefelter((prevState) =>
+            prevState.map((felt) =>
+                felt._ref === flettefeltRef
+                    ? { ...felt, verdi: verdi === 'NaN' ? '' : verdi }
+                    : felt
+            )
+        );
     };
 
     const oppdaterOverstyrtInnhold = (delmal: Delmal, htmlInnhold: string) => {

--- a/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevUtils.ts
@@ -22,7 +22,11 @@ import { delmalTilUtregningstabellBT } from './UtregningstabellBarnetilsyn';
 export const finnFlettefeltNavnOgBeskrivelseFraRef = (
     dokument: BrevStruktur,
     ref: string
-): { flettefeltNavn: string; flettefeltBeskrivelse?: string } => {
+): {
+    flettefeltNavn: string;
+    flettefeltBeskrivelse?: string;
+    flettefeltApiNavn?: string;
+} => {
     const flettefeltFraRef = dokument?.flettefelter?.flettefeltReferanse?.find(
         (felt) => felt._id === ref
     );
@@ -34,7 +38,16 @@ export const finnFlettefeltNavnOgBeskrivelseFraRef = (
             ? flettefeltFraRef.feltVisningsnavn
             : flettefeltFraRef.felt,
         flettefeltBeskrivelse: flettefeltFraRef.beskrivelse,
+        flettefeltApiNavn: flettefeltFraRef.felt,
     };
+};
+
+export const finnFlettefeltRefFraFlettefeltApiNavn = (dokument: BrevStruktur, felt: string) => {
+    const flettefeltFraRef = dokument?.flettefelter?.flettefeltReferanse?.find(
+        (feltRef) => feltRef.felt === felt
+    );
+
+    return flettefeltFraRef ? flettefeltFraRef._id : '';
 };
 
 export const finnFletteFeltApinavnFraRef = (dokument: BrevStruktur, ref: string): string => {

--- a/src/frontend/Komponenter/Behandling/Brev/Flettefelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Flettefelt.tsx
@@ -20,7 +20,11 @@ interface Props {
     flettefelt: Flettefeltreferanse;
     dokument: BrevStruktur;
     flettefelter: FlettefeltMedVerdi[];
-    handleFlettefeltInput: (verdi: string, flettefelt: Flettefeltreferanse) => void;
+    handleFlettefeltInput: (
+        verdi: string,
+        flettefelt: Flettefeltreferanse,
+        flettefeltApiNavn?: string
+    ) => void;
 }
 
 export const Flettefelt: React.FC<Props> = ({
@@ -31,17 +35,15 @@ export const Flettefelt: React.FC<Props> = ({
     handleFlettefeltInput,
 }) => {
     const flettefeltMedVerdi = flettefelter?.find((felt) => felt._ref === flettefelt._ref);
-    const { flettefeltNavn, flettefeltBeskrivelse } = finnFlettefeltNavnOgBeskrivelseFraRef(
-        dokument,
-        flettefelt._ref
-    );
+    const { flettefeltNavn, flettefeltBeskrivelse, flettefeltApiNavn } =
+        finnFlettefeltNavnOgBeskrivelseFraRef(dokument, flettefelt._ref);
 
     if (erFlettefeltFritektsfelt(dokument, flettefelt._ref)) {
         return (
             <Textarea
                 label={flettefeltNavn}
                 onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => {
-                    handleFlettefeltInput(e.target.value, flettefelt);
+                    handleFlettefeltInput(e.target.value, flettefelt, flettefeltApiNavn);
                 }}
                 value={flettefeltMedVerdi?.verdi || ''}
                 maxLength={0}
@@ -62,7 +64,7 @@ export const Flettefelt: React.FC<Props> = ({
                 description={flettefeltBeskrivelse}
                 label={flettefeltNavn}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    handleFlettefeltInput(e.target.value, flettefelt);
+                    handleFlettefeltInput(e.target.value, flettefelt, flettefeltApiNavn);
                 }}
                 value={flettefeltMedVerdi?.verdi || ''}
             />

--- a/src/frontend/Komponenter/Behandling/Brev/ValgfeltSelect.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/ValgfeltSelect.tsx
@@ -25,7 +25,11 @@ interface Props {
     settValgteFelt: Dispatch<SetStateAction<ValgtFelt>>;
     settFlettefelter: Dispatch<SetStateAction<FlettefeltMedVerdi[]>>;
     flettefelter: FlettefeltMedVerdi[];
-    handleFlettefeltInput: (verdi: string, flettefelt: Flettefeltreferanse) => void;
+    handleFlettefeltInput: (
+        verdi: string,
+        flettefelt: Flettefeltreferanse,
+        flettefeltApiNavn?: string
+    ) => void;
     delmal: Delmal;
     settKanSendeTilBeslutter: (kanSendeTilBeslutter: boolean) => void;
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Ønsker å fylle ut flettefeltet 'arsinntekt' basert på 'belopIMaaneden'. Gjør dette ved å gange beløp med 12, slik at saksbehandler slipper å bruke kalkulator. Det er fortsatt mulig å redigere 'arsinntekt' manuelt.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-23292)

![image](https://github.com/user-attachments/assets/7a9366a7-3b34-4738-b9c3-8744bc4cef61)
