### PR TITLE
Vise infoboks om tilbud utdanning

### DIFF
--- a/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/AktivitetInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/AktivitetInfo.tsx
@@ -156,6 +156,10 @@ const AktivitetInfo: FC<Props> = ({ aktivitet, stønadstype, dokumentasjon }) =>
                 dokumentasjon={dokumentasjon?.virksomhet}
                 tittel={'Næringsfaglig vurdering av virksomheten du etablerer'}
             />
+            <DokumentasjonSendtInn
+                dokumentasjon={dokumentasjon?.utdanningstilbud}
+                tittel={'Dokumentasjon på utdanning'}
+            />
         </InformasjonContainer>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Aktivitet/Skolepenger/DokumentasjonUtdanningInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Skolepenger/DokumentasjonUtdanningInfo.tsx
@@ -10,15 +10,27 @@ interface Props {
     dokumentasjon?: IDokumentasjonGrunnlag;
 }
 
+const dokumentasjonUtdanning = (dokumentasjon: IDokumentasjonGrunnlag) => {
+    return [
+        { tittel: 'Utgifter til utdanning', dokumentasjon: dokumentasjon.utdanningsutgifter },
+        { tittel: 'Dokumentasjon utdanning tilbud', dokumentasjon: dokumentasjon.utdanningstilbud },
+    ];
+};
+
 const DokumentasjonUtdanningInfo: FC<Props> = ({ aktivitet, dokumentasjon }) => {
     return (
         <InformasjonContainer>
             <Dokumentasjonsvisning aktivitet={aktivitet} />
-
-            <DokumentasjonSendtInn
-                dokumentasjon={dokumentasjon?.utdanningsutgifter}
-                tittel={'Utgifter til skolepenger'}
-            />
+            {dokumentasjon &&
+                dokumentasjonUtdanning(dokumentasjon).map((dokumentasjon, index) => {
+                    return (
+                        <DokumentasjonSendtInn
+                            key={index}
+                            dokumentasjon={dokumentasjon.dokumentasjon}
+                            tittel={dokumentasjon.tittel}
+                        />
+                    );
+                })}
         </InformasjonContainer>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Aktivitet/Skolepenger/DokumentasjonUtdanningInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Skolepenger/DokumentasjonUtdanningInfo.tsx
@@ -12,8 +12,8 @@ interface Props {
 
 const dokumentasjonUtdanning = (dokumentasjon: IDokumentasjonGrunnlag) => {
     return [
-        { tittel: 'Utgifter til utdanning', dokumentasjon: dokumentasjon.utdanningsutgifter },
-        { tittel: 'Dokumentasjon utdanning tilbud', dokumentasjon: dokumentasjon.utdanningstilbud },
+        { tittel: 'Utgifter til skolepenger', dokumentasjon: dokumentasjon.utdanningsutgifter },
+        { tittel: 'Dokumentasjon på utdanning', dokumentasjon: dokumentasjon.utdanningstilbud },
     ];
 };
 

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/DokumentasjonSendtInn.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/DokumentasjonSendtInn.tsx
@@ -1,20 +1,16 @@
 import React, { FC } from 'react';
 import { IDokumentasjon } from '../../../App/typer/felles';
 import { Alert, BodyLong, Heading } from '@navikt/ds-react';
-import styled from 'styled-components';
 
 interface Props {
     tittel: string;
     dokumentasjon?: IDokumentasjon;
 }
 
-const DokumentasjonSendtInnWrapper = styled.div`
-    margin-bottom: 1rem;
-`;
-
 const DokumentasjonSendtInn: FC<Props> = ({ tittel, dokumentasjon }) => {
-    return dokumentasjon && dokumentasjon.harSendtInn ? (
-        <DokumentasjonSendtInnWrapper>
+    return (
+        dokumentasjon &&
+        dokumentasjon.harSendtInn && (
             <Alert variant={'info'} size={'small'}>
                 <Heading size={'xsmall'} level={'4'}>
                     {tittel}
@@ -24,7 +20,7 @@ const DokumentasjonSendtInn: FC<Props> = ({ tittel, dokumentasjon }) => {
                     tidligere
                 </BodyLong>
             </Alert>
-        </DokumentasjonSendtInnWrapper>
-    ) : null;
+        )
+    );
 };
 export default DokumentasjonSendtInn;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal vise at søker har huket av for tilbud om utdanning, hvis det er tilfellet.

Laget en liste med dokumentasjon for utdanning. Mapper over listen og lager DokumentasjonSendtInn for hvert element.

Skal vises for både skolepenger og overgangsstønad.

![image](https://github.com/user-attachments/assets/f9343f3a-b423-41fa-9538-dcb6ae729652)
