### PR TITLE
Prøver å fikse key verdi for rekomposisjon av PdfVisning

### DIFF
--- a/src/frontend/Felles/Pdf/PdfVisning.tsx
+++ b/src/frontend/Felles/Pdf/PdfVisning.tsx
@@ -59,7 +59,7 @@ const PdfVisning: React.FC<Props> = ({
                         />
                     )}
                     <StyledDokument
-                        key={new Date().getTime().toString()}
+                        key={this}
                         file={`data:application/pdf;base64,${pdfFilInnhold}`}
                         onLoadSuccess={onDocumentLoadSuccess}
                         error={<AlertError>Ukjent feil ved henting av dokument</AlertError>}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

I et forsøk på å fikse flimmer og rekomposisjon av PDF-visningen endrer vi nå nøkkelen til this. Dette burde være lettere for React å tolke, da instansen av objektet er nøkkelen. Dette fikser ikke det store problemet der PDF-visningen konstant blir rekomponert, men gjør at det er litt bedre diffing.
