### PR TITLE
Lagt til toggle og logikk for ha med kopier knapp i alert error

### DIFF
--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -18,5 +18,6 @@ export enum ToggleName {
 
     // Release-toggles
     visMarkereGodkjenneVedtakOppgaveModal = 'familie.ef.sak.vis-markere-godkjenne-vedtak-oppgave-modal',
+    brukErrorAlertMedKopierKnapp = 'familie.ef.sak.frontend-alert-error-med-copy-button',
     visAutomatiskInntektsendring = 'familie.ef.sak.frontend-vis-automatisk-inntektsendring',
 }

--- a/src/frontend/Felles/Visningskomponenter/Alerts.tsx
+++ b/src/frontend/Felles/Visningskomponenter/Alerts.tsx
@@ -1,7 +1,35 @@
 import React, { forwardRef, ReactNode, useEffect, useState } from 'react';
-import { Alert, AlertProps } from '@navikt/ds-react';
+import { Alert, AlertProps, CopyButton, HStack } from '@navikt/ds-react';
+import { BodyShortSmall } from './Tekster';
+import styled from 'styled-components';
+import { useToggles } from '../../App/context/TogglesContext';
+import { ToggleName } from '../../App/context/toggles';
+
+const AlertErrorStyled = styled(Alert)`
+    width: fit-content;
+`;
 
 export const AlertError = forwardRef<HTMLDivElement, Omit<AlertProps, 'variant'>>((props, ref) => {
+    const { toggles } = useToggles();
+    const skalBrukeErrorAlertMedKopierKnapp =
+        toggles[ToggleName.brukErrorAlertMedKopierKnapp] || false;
+    if (skalBrukeErrorAlertMedKopierKnapp) {
+        return (
+            <AlertErrorStyled variant={'error'} ref={ref}>
+                <HStack gap={'1'} align={'center'}>
+                    <BodyShortSmall>{props.children}</BodyShortSmall>
+                    {props.children && (
+                        <CopyButton
+                            size={'xsmall'}
+                            copyText={props.children.toString()}
+                            variant={'action'}
+                            activeText={'kopiert'}
+                        />
+                    )}
+                </HStack>
+            </AlertErrorStyled>
+        );
+    }
     return <Alert variant={'error'} {...props} ref={ref} />;
 });
 

--- a/src/frontend/Komponenter/Behandling/Modal/HenleggModal.tsx
+++ b/src/frontend/Komponenter/Behandling/Modal/HenleggModal.tsx
@@ -19,6 +19,7 @@ import { ABorderSubtle } from '@navikt/ds-tokens/dist/tokens';
 import { VStack, Stack } from '@navikt/ds-react';
 import { IPersonopplysninger } from '../../../App/typer/personopplysninger';
 import { erEtterDagensDato } from '../../../App/utils/dato';
+import { AlertError } from '../../../Felles/Visningskomponenter/Alerts';
 
 const AlertStripe = styled(Alert)`
     margin-top: 1rem;
@@ -195,9 +196,7 @@ export const HenleggModal: FC<{
                                     </Link>
                                 </>
                             )}
-                            {feilmelding && (
-                                <AlertStripe variant={'error'}>{feilmelding}</AlertStripe>
-                            )}
+                            {feilmelding && <AlertError>{feilmelding}</AlertError>}
                             {vergemål.length > 0 && henlagtårsakTrukketTilbake && (
                                 <AlertStripe size={'small'} variant={'warning'}>
                                     {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Gjøre det letter for saksbehandlerer å kopiere feilmelding så vi forhåpentligvis får mindre bilder av feilmeldinger.