### PR TITLE
Automatisk varsel aktivitetsplikt

### DIFF
--- a/src/frontend/App/hooks/useHentOppfølgingsoppgave.ts
+++ b/src/frontend/App/hooks/useHentOppfølgingsoppgave.ts
@@ -3,6 +3,7 @@ import { useApp } from '../context/AppContext';
 import { Ressurs, RessursStatus } from '../typer/ressurs';
 import { OppgaveTypeForOpprettelse } from '../../Komponenter/Behandling/Totrinnskontroll/oppgaveForOpprettelseTyper';
 import { useRerunnableEffect } from './felles/useRerunnableEffect';
+import { AutomatiskBrevValg } from '../../Komponenter/Behandling/Totrinnskontroll/AutomatiskBrev';
 
 interface OppgaverForOpprettelse {
     oppgavetyperSomKanOpprettes: OppgaveTypeForOpprettelse[];
@@ -13,7 +14,7 @@ export interface Oppfølgingsoppgave {
     behandlingid: string;
     oppgaverForOpprettelse: OppgaverForOpprettelse;
     oppgaveIderForFerdigstilling: number[];
-    automatiskBrev: string[];
+    automatiskBrev: AutomatiskBrevValg[];
 }
 
 export const useHentOppfølgingsoppgave = (behandlingId: string) => {

--- a/src/frontend/App/hooks/useHentOppfølgingsoppgave.ts
+++ b/src/frontend/App/hooks/useHentOppfølgingsoppgave.ts
@@ -13,6 +13,7 @@ export interface Oppfølgingsoppgave {
     behandlingid: string;
     oppgaverForOpprettelse: OppgaverForOpprettelse;
     oppgaveIderForFerdigstilling: number[];
+    automatiskBrev: string[];
 }
 
 export const useHentOppfølgingsoppgave = (behandlingId: string) => {

--- a/src/frontend/App/utils/dato.ts
+++ b/src/frontend/App/utils/dato.ts
@@ -126,3 +126,9 @@ export const kalkulerAntallMåneder = (
     }
     return undefined;
 };
+
+export const antallMånederSidenDato = (dato: string | Date): number => {
+    const datoSomDate = tilDato(dato);
+    const nåværendeDato = new Date();
+    return Math.abs(differenceInMonths(nåværendeDato, datoSomDate));
+};

--- a/src/frontend/Komponenter/Behandling/Brev/AutomatiskBrevSomSendes.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/AutomatiskBrevSomSendes.tsx
@@ -1,0 +1,30 @@
+import { Checkbox, CheckboxGroup } from '@navikt/ds-react';
+import { ALimegreen100 } from '@navikt/ds-tokens/dist/tokens';
+import React, { FC } from 'react';
+import styled from 'styled-components';
+
+const Container = styled.div`
+    background: ${ALimegreen100};
+    padding: 0.5rem;
+`;
+
+export const AutomatiskBrevSomSendes: FC<{
+    automatiskBrev: string[] | undefined;
+}> = ({ automatiskBrev }) => {
+    return (
+        <Container>
+            <CheckboxGroup
+                legend="Følgende brev sendes automatisk ved godkjenning av dette vedtaket:"
+                value={automatiskBrev}
+                readOnly
+            >
+                {automatiskBrev &&
+                    automatiskBrev.map((brev, idx) => (
+                        <Checkbox key={idx} value={brev}>
+                            {brev}
+                        </Checkbox>
+                    ))}
+            </CheckboxGroup>
+        </Container>
+    );
+};

--- a/src/frontend/Komponenter/Behandling/Brev/AutomatiskBrevSomSendes.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/AutomatiskBrevSomSendes.tsx
@@ -2,7 +2,7 @@ import { Checkbox, CheckboxGroup } from '@navikt/ds-react';
 import { ALimegreen100 } from '@navikt/ds-tokens/dist/tokens';
 import React, { FC } from 'react';
 import styled from 'styled-components';
-import { AutomatiskBrevValg } from '../Totrinnskontroll/AutomatiskBrev';
+import { AutomatiskBrevValg, automatiskBrevValgTekst } from '../Totrinnskontroll/AutomatiskBrev';
 
 const Container = styled.div`
     background: ${ALimegreen100};
@@ -26,7 +26,7 @@ export const AutomatiskBrevSomSendes: FC<{
                 {automatiskBrev &&
                     automatiskBrev.map((brev, idx) => (
                         <Checkbox key={idx} value={brev}>
-                            {brev}
+                            {automatiskBrevValgTekst[brev]}
                         </Checkbox>
                     ))}
             </CheckboxGroup>

--- a/src/frontend/Komponenter/Behandling/Brev/AutomatiskBrevSomSendes.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/AutomatiskBrevSomSendes.tsx
@@ -11,6 +11,10 @@ const Container = styled.div`
 export const AutomatiskBrevSomSendes: FC<{
     automatiskBrev: string[] | undefined;
 }> = ({ automatiskBrev }) => {
+    if (!automatiskBrev || automatiskBrev.length === 0) {
+        return null;
+    }
+
     return (
         <Container>
             <CheckboxGroup

--- a/src/frontend/Komponenter/Behandling/Brev/AutomatiskBrevSomSendes.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/AutomatiskBrevSomSendes.tsx
@@ -2,6 +2,7 @@ import { Checkbox, CheckboxGroup } from '@navikt/ds-react';
 import { ALimegreen100 } from '@navikt/ds-tokens/dist/tokens';
 import React, { FC } from 'react';
 import styled from 'styled-components';
+import { AutomatiskBrevValg } from '../Totrinnskontroll/AutomatiskBrev';
 
 const Container = styled.div`
     background: ${ALimegreen100};
@@ -9,7 +10,7 @@ const Container = styled.div`
 `;
 
 export const AutomatiskBrevSomSendes: FC<{
-    automatiskBrev: string[] | undefined;
+    automatiskBrev?: AutomatiskBrevValg[];
 }> = ({ automatiskBrev }) => {
     if (!automatiskBrev || automatiskBrev.length === 0) {
         return null;

--- a/src/frontend/Komponenter/Behandling/Brev/AutomatiskBrevSomSendes.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/AutomatiskBrevSomSendes.tsx
@@ -14,7 +14,7 @@ export const AutomatiskBrevSomSendes: FC<{
     return (
         <Container>
             <CheckboxGroup
-                legend="Følgende brev sendes automatisk ved godkjenning av dette vedtaket:"
+                legend="Send brev automatisk når vedtaket er godkjent:"
                 value={automatiskBrev}
                 readOnly
             >

--- a/src/frontend/Komponenter/Behandling/Brev/BrevFane.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevFane.tsx
@@ -16,6 +16,7 @@ import { OppgaverForFerdigstilling } from '../Totrinnskontroll/OppgaverForFerdig
 import { useHentOppfølgingsoppgave } from '../../../App/hooks/useHentOppfølgingsoppgave';
 import { AlertError } from '../../../Felles/Visningskomponenter/Alerts';
 import styled from 'styled-components';
+import { AutomatiskBrevSomSendes } from './AutomatiskBrevSomSendes';
 
 const StyledVStack = styled(VStack)`
     position: sticky;
@@ -126,6 +127,10 @@ export const BrevFane: React.FC<Props> = ({ behandling }) => {
                                             }
                                         />
                                         <OppgaverForFerdigstilling behandlingId={behandling.id} />
+
+                                        <AutomatiskBrevSomSendes
+                                            automatiskBrev={oppfølgingsoppgave?.automatiskBrev}
+                                        />
                                     </>
                                 )}
                                 {!behandlingErRedigerbar && (

--- a/src/frontend/Komponenter/Behandling/Brev/BrevFane.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevFane.tsx
@@ -129,7 +129,9 @@ export const BrevFane: React.FC<Props> = ({ behandling }) => {
                                         <OppgaverForFerdigstilling behandlingId={behandling.id} />
 
                                         <AutomatiskBrevSomSendes
-                                            automatiskBrev={oppfølgingsoppgave?.automatiskBrev}
+                                            automatiskBrev={
+                                                oppfølgingsoppgave?.automatiskBrev ?? []
+                                            }
                                         />
                                     </>
                                 )}

--- a/src/frontend/Komponenter/Behandling/Brev/BrevFane.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevFane.tsx
@@ -8,7 +8,6 @@ import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { useApp } from '../../../App/context/AppContext';
 import { TotrinnskontrollStatus } from '../../../App/typer/totrinnskontroll';
 import { BrevmottakereForBehandling } from '../Brevmottakere/BrevmottakereForBehandling';
-import { utledAvslagValg } from '../VedtakOgBeregning/Felles/utils';
 import { Behandling } from '../../../App/typer/fagsak';
 import { OverstyrtBrevmalVarsel } from './OverstyrtBrevmalVarsel';
 import { FremleggoppgaverSomOpprettes } from './FremleggoppgaverSomOpprettes';
@@ -109,8 +108,6 @@ export const BrevFane: React.FC<Props> = ({ behandling }) => {
             }}
         >
             {({ personopplysningerResponse, vedtak, vilkår }) => {
-                const avslagValg = utledAvslagValg(vedtak);
-
                 return (
                     <Container>
                         <LikDelContainer>
@@ -157,8 +154,8 @@ export const BrevFane: React.FC<Props> = ({ behandling }) => {
                                 <SendTilBeslutter
                                     behandling={behandling}
                                     vilkår={vilkår}
+                                    vedtak={vedtak}
                                     kanSendesTilBeslutter={kanSendesTilBeslutter}
-                                    avslagValg={avslagValg}
                                     behandlingErRedigerbar={behandlingErRedigerbar}
                                     hentOppfølgingsoppgave={hentOppfølgingsoppgave}
                                     oppfølgingsoppgave={oppfølgingsoppgave}

--- a/src/frontend/Komponenter/Behandling/Brev/BrevFane.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevFane.tsx
@@ -45,8 +45,14 @@ interface Props {
 
 export const BrevFane: React.FC<Props> = ({ behandling }) => {
     const { axiosRequest } = useApp();
-    const { behandlingErRedigerbar, vedtak, personopplysningerResponse, totrinnskontroll } =
-        useBehandling();
+    const {
+        behandlingErRedigerbar,
+        vedtak,
+        personopplysningerResponse,
+        totrinnskontroll,
+        vilkårState,
+    } = useBehandling();
+    const { vilkår, hentVilkår } = vilkårState;
     const [brevRessurs, settBrevRessurs] = useState<Ressurs<string>>(byggTomRessurs());
     const [kanSendesTilBeslutter, settKanSendesTilBeslutter] = useState<boolean>(false);
     const { hentOppfølgingsoppgave, oppfølgingsoppgave, feilmelding } = useHentOppfølgingsoppgave(
@@ -90,14 +96,19 @@ export const BrevFane: React.FC<Props> = ({ behandling }) => {
         // eslint-disable-next-line
     }, [behandlingErRedigerbar, totrinnskontroll]);
 
+    useEffect(() => {
+        hentVilkår(behandling.id);
+    }, [behandling.id, hentVilkår]);
+
     return (
         <DataViewer
             response={{
                 personopplysningerResponse,
                 vedtak,
+                vilkår,
             }}
         >
-            {({ personopplysningerResponse, vedtak }) => {
+            {({ personopplysningerResponse, vedtak, vilkår }) => {
                 const avslagValg = utledAvslagValg(vedtak);
 
                 return (
@@ -145,6 +156,7 @@ export const BrevFane: React.FC<Props> = ({ behandling }) => {
 
                                 <SendTilBeslutter
                                     behandling={behandling}
+                                    vilkår={vilkår}
                                     kanSendesTilBeslutter={kanSendesTilBeslutter}
                                     avslagValg={avslagValg}
                                     behandlingErRedigerbar={behandlingErRedigerbar}

--- a/src/frontend/Komponenter/Behandling/Brev/FremleggoppgaverSomOpprettes.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/FremleggoppgaverSomOpprettes.tsx
@@ -22,7 +22,7 @@ export const FremleggoppgaverSomOpprettes: FC<{
     return (
         <Container>
             <CheckboxGroup
-                legend="Følgende fremleggsoppgaver opprettes ved godkjenning av dette vedtaket:"
+                legend="Følgende oppgave skal opprettes automatisk når vedtaket er godkjent:"
                 value={oppgavetyperSomSkalOpprettes}
                 readOnly
             >

--- a/src/frontend/Komponenter/Behandling/Fanemeny/KorrigeringFane.tsx
+++ b/src/frontend/Komponenter/Behandling/Fanemeny/KorrigeringFane.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import SendTilBeslutter from '../Totrinnskontroll/SendTilBeslutter';
 import { useBehandling } from '../../../App/context/BehandlingContext';
 import { AlertInfo } from '../../../Felles/Visningskomponenter/Alerts';
-import { utledAvslagValg } from '../VedtakOgBeregning/Felles/utils';
-import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { Behandlingsårsak } from '../../../App/typer/behandlingsårsak';
 import { Behandling } from '../../../App/typer/fagsak';
 
@@ -12,25 +10,20 @@ interface Props {
 }
 
 export const KorrigeringFane: React.FC<Props> = ({ behandling }) => {
-    const { behandlingErRedigerbar, vedtak } = useBehandling();
+    const { behandlingErRedigerbar } = useBehandling();
 
     return (
-        <DataViewer response={{ vedtak }}>
-            {({ vedtak }) => (
-                <>
-                    <AlertInfo>
-                        {behandling.behandlingsårsak === Behandlingsårsak.IVERKSETTE_KA_VEDTAK
-                            ? 'Iverksette KA-vedtak (uten brev)'
-                            : 'Korrigering av vedtak uten brevutsendelse'}
-                    </AlertInfo>
-                    <SendTilBeslutter
-                        behandling={behandling}
-                        kanSendesTilBeslutter={behandlingErRedigerbar}
-                        behandlingErRedigerbar={behandlingErRedigerbar}
-                        avslagValg={utledAvslagValg(vedtak)}
-                    />
-                </>
-            )}
-        </DataViewer>
+        <>
+            <AlertInfo>
+                {behandling.behandlingsårsak === Behandlingsårsak.IVERKSETTE_KA_VEDTAK
+                    ? 'Iverksette KA-vedtak (uten brev)'
+                    : 'Korrigering av vedtak uten brevutsendelse'}
+            </AlertInfo>
+            <SendTilBeslutter
+                behandling={behandling}
+                kanSendesTilBeslutter={behandlingErRedigerbar}
+                behandlingErRedigerbar={behandlingErRedigerbar}
+            />
+        </>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/AutomatiskBrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/AutomatiskBrev.tsx
@@ -1,9 +1,15 @@
 import { CheckboxGroup, Checkbox } from '@navikt/ds-react';
 import React, { FC } from 'react';
 
-export type AutomatiskBrevValg = 'Varsel om aktivitetsplikt';
+export enum AutomatiskBrevValg {
+    VARSEL_OM_AKTIVITETSPLIKT = 'VARSEL_OM_AKTIVITETSPLIKT',
+}
 
-const automatiskBrevAlternativer: AutomatiskBrevValg[] = ['Varsel om aktivitetsplikt'] as const;
+const automatiskBrevValgTekst: Record<AutomatiskBrevValg, string> = {
+    [AutomatiskBrevValg.VARSEL_OM_AKTIVITETSPLIKT]: 'Varsel om aktivitetsplikt',
+};
+
+const automatiskBrevAlternativer: AutomatiskBrevValg[] = Object.values(AutomatiskBrevValg);
 
 export const AutomatiskBrev: FC<{
     automatiskBrev: AutomatiskBrevValg[];
@@ -12,12 +18,12 @@ export const AutomatiskBrev: FC<{
     return (
         <CheckboxGroup
             legend="Send brev automatisk når vedtaket er godkjent:"
-            onChange={settAutomatiskBrev}
+            onChange={(val) => settAutomatiskBrev(val as AutomatiskBrevValg[])}
             value={automatiskBrev}
         >
             {automatiskBrevAlternativer.map((valg) => (
                 <Checkbox key={valg} value={valg}>
-                    {valg}
+                    {automatiskBrevValgTekst[valg]}
                 </Checkbox>
             ))}
         </CheckboxGroup>

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/AutomatiskBrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/AutomatiskBrev.tsx
@@ -1,11 +1,9 @@
 import { CheckboxGroup, Checkbox } from '@navikt/ds-react';
 import React, { FC } from 'react';
-export type AutomatiskBrevValg = 'Varsel om aktivitetsplikt' | 'TEST';
 
-const automatiskBrevAlternativer: AutomatiskBrevValg[] = [
-    'Varsel om aktivitetsplikt',
-    'TEST',
-] as const;
+export type AutomatiskBrevValg = 'Varsel om aktivitetsplikt';
+
+const automatiskBrevAlternativer: AutomatiskBrevValg[] = ['Varsel om aktivitetsplikt'] as const;
 
 export const AutomatiskBrev: FC<{
     automatiskBrev: AutomatiskBrevValg[];

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/AutomatiskBrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/AutomatiskBrev.tsx
@@ -5,7 +5,7 @@ export enum AutomatiskBrevValg {
     VARSEL_OM_AKTIVITETSPLIKT = 'VARSEL_OM_AKTIVITETSPLIKT',
 }
 
-const automatiskBrevValgTekst: Record<AutomatiskBrevValg, string> = {
+export const automatiskBrevValgTekst: Record<AutomatiskBrevValg, string> = {
     [AutomatiskBrevValg.VARSEL_OM_AKTIVITETSPLIKT]: 'Varsel om aktivitetsplikt',
 };
 

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/AutomatiskBrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/AutomatiskBrev.tsx
@@ -1,0 +1,27 @@
+import { CheckboxGroup, Checkbox } from '@navikt/ds-react';
+import React, { FC } from 'react';
+export type AutomatiskBrevValg = 'Varsel om aktivitetsplikt' | 'TEST';
+
+const automatiskBrevAlternativer: AutomatiskBrevValg[] = [
+    'Varsel om aktivitetsplikt',
+    'TEST',
+] as const;
+
+export const AutomatiskBrev: FC<{
+    automatiskBrev: AutomatiskBrevValg[];
+    settAutomatiskBrev: React.Dispatch<React.SetStateAction<AutomatiskBrevValg[]>>;
+}> = ({ automatiskBrev, settAutomatiskBrev }) => {
+    return (
+        <CheckboxGroup
+            legend="Send brev automatisk når vedtaket er godkjent:"
+            onChange={settAutomatiskBrev}
+            value={automatiskBrev}
+        >
+            {automatiskBrevAlternativer.map((valg) => (
+                <Checkbox key={valg} value={valg}>
+                    {valg}
+                </Checkbox>
+            ))}
+        </CheckboxGroup>
+    );
+};

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/ModalSendTilBeslutter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/ModalSendTilBeslutter.tsx
@@ -18,7 +18,7 @@ import { Oppfølgingsoppgave } from '../../../App/hooks/useHentOppfølgingsoppga
 
 export const ModalSendTilBeslutter: FC<{
     behandling: Behandling;
-    vilkår: IVilkår;
+    vilkår?: IVilkår;
     open: boolean;
     setOpen: (open: boolean) => void;
     sendTilBeslutter: (data: SendTilBeslutterRequest) => void;
@@ -59,7 +59,7 @@ export const ModalSendTilBeslutter: FC<{
         []
     );
     const [automatiskBrev, settAutomatiskBrev] = useState<AutomatiskBrevValg[]>(
-        utledAutomatiskBrev(vilkår, behandling, oppfølgingsoppgave?.automatiskBrev)
+        utledAutomatiskBrev(behandling, oppfølgingsoppgave?.automatiskBrev, vilkår)
     );
     const { ferdigstillUtenBeslutter, erAvslagSkalSendeTilBeslutter, erAvslag } = avslagValg;
 
@@ -95,7 +95,7 @@ export const ModalSendTilBeslutter: FC<{
     const skalViseFremleggsoppgaverForOpprettelseOgFerdigstilling =
         !erAvslag || !erAvslagSkalSendeTilBeslutter;
 
-    const harBarnMellomSeksOgTolvMnder = harBarnMellomSeksOgTolvMåneder(vilkår);
+    const harBarnMellomSeksOgTolvMnder = vilkår && harBarnMellomSeksOgTolvMåneder(vilkår);
     const erOvergangsstønad = behandling.stønadstype === Stønadstype.OVERGANGSSTØNAD;
 
     return (

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/ModalSendTilBeslutter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/ModalSendTilBeslutter.tsx
@@ -9,8 +9,15 @@ import { OppgaveTypeForOpprettelse } from './oppgaveForOpprettelseTyper';
 import { FremleggsoppgaverForOpprettelse } from './FremleggsoppgaverForOpprettelse';
 import { TabellFerdigstilleOppgaver } from './TabellFerdigstilleOppgaver';
 import { BeskrivelseMarkeringer, BeskrivelseOppgave } from './BeskrivelseOppgave';
+import { AutomatiskBrev, AutomatiskBrevValg } from './AutomatiskBrev';
+import { Behandling } from '../../../App/typer/fagsak';
+import { IVilkår } from '../Inngangsvilkår/vilkår';
+import { harBarnMellomSeksOgTolvMåneder, utledAutomatiskBrev } from './utils';
+import { Stønadstype } from '../../../App/typer/behandlingstema';
 
-export const ModalOpprettOgFerdigstilleOppgaver: FC<{
+export const ModalSendTilBeslutter: FC<{
+    behandling: Behandling;
+    vilkår: IVilkår;
     open: boolean;
     setOpen: (open: boolean) => void;
     sendTilBeslutter: (data: SendTilBeslutterRequest) => void;
@@ -28,6 +35,8 @@ export const ModalOpprettOgFerdigstilleOppgaver: FC<{
         erAvslag: boolean;
     };
 }> = ({
+    behandling,
+    vilkår,
     open,
     setOpen,
     sendTilBeslutter,
@@ -46,7 +55,9 @@ export const ModalOpprettOgFerdigstilleOppgaver: FC<{
     const [beskrivelseMarkeringer, settBeskrivelseMarkeringer] = useState<BeskrivelseMarkeringer[]>(
         []
     );
-
+    const [automatiskBrev, settAutomatiskBrev] = useState<AutomatiskBrevValg[]>(
+        utledAutomatiskBrev(vilkår, behandling)
+    );
     const { ferdigstillUtenBeslutter, erAvslagSkalSendeTilBeslutter, erAvslag } = avslagValg;
 
     const handleSettOppgaverSomSkalFerdigstilles = (oppgaveId: number) =>
@@ -80,6 +91,9 @@ export const ModalOpprettOgFerdigstilleOppgaver: FC<{
 
     const skalViseFremleggsoppgaverForOpprettelseOgFerdigstilling =
         !erAvslag || !erAvslagSkalSendeTilBeslutter;
+
+    const harBarnMellomSeksOgTolvMnder = harBarnMellomSeksOgTolvMåneder(vilkår);
+    const erOvergangsstønad = behandling.stønadstype === Stønadstype.OVERGANGSSTØNAD;
 
     return (
         <DataViewer response={{ fremleggsOppgaver }}>
@@ -140,6 +154,17 @@ export const ModalOpprettOgFerdigstilleOppgaver: FC<{
                                         />
                                     </>
                                 )}
+
+                                {harBarnMellomSeksOgTolvMnder && erOvergangsstønad && (
+                                    <>
+                                        <Divider />
+                                        {JSON.stringify(automatiskBrev)}
+                                        <AutomatiskBrev
+                                            automatiskBrev={automatiskBrev}
+                                            settAutomatiskBrev={settAutomatiskBrev}
+                                        />
+                                    </>
+                                )}
                             </VStack>
                         </Modal.Body>
                         <Modal.Footer>
@@ -157,6 +182,7 @@ export const ModalOpprettOgFerdigstilleOppgaver: FC<{
                                         fremleggsoppgaveIderSomSkalFerdigstilles:
                                             oppgaverSomSkalAutomatiskFerdigstilles,
                                         beskrivelseMarkeringer: beskrivelseMarkeringer,
+                                        automatiskBrev: automatiskBrev,
                                     })
                                 }
                                 disabled={!erValgIRadioEllerChecboxGroupGyldig}

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/ModalSendTilBeslutter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/ModalSendTilBeslutter.tsx
@@ -1,5 +1,5 @@
 import { Modal, Button, VStack } from '@navikt/ds-react';
-import React, { FC, useState } from 'react';
+import React, { FC, useEffect, useState } from 'react';
 import { Divider } from '../../../Felles/Divider/Divider';
 import { Ressurs } from '../../../App/typer/ressurs';
 import { IOppgaverResponse } from '../../../App/hooks/useHentOppgaver';
@@ -58,10 +58,10 @@ export const ModalSendTilBeslutter: FC<{
     const [beskrivelseMarkeringer, settBeskrivelseMarkeringer] = useState<BeskrivelseMarkeringer[]>(
         []
     );
-    const [automatiskBrev, settAutomatiskBrev] = useState<AutomatiskBrevValg[]>(
-        utledAutomatiskBrev(behandling, oppfølgingsoppgave?.automatiskBrev, vilkår)
-    );
     const { ferdigstillUtenBeslutter, erAvslagSkalSendeTilBeslutter, erAvslag } = avslagValg;
+    const [automatiskBrev, settAutomatiskBrev] = useState<AutomatiskBrevValg[]>(
+        utledAutomatiskBrev(behandling, oppfølgingsoppgave?.automatiskBrev, erAvslag, vilkår)
+    );
 
     const handleSettOppgaverSomSkalFerdigstilles = (oppgaveId: number) =>
         settOppgaverSomSkalAutomatiskFerdigstilles((prevOppgaver) =>
@@ -97,6 +97,12 @@ export const ModalSendTilBeslutter: FC<{
 
     const harBarnMellomSeksOgTolvMnder = vilkår && harBarnMellomSeksOgTolvMåneder(vilkår);
     const erOvergangsstønad = behandling.stønadstype === Stønadstype.OVERGANGSSTØNAD;
+
+    useEffect(() => {
+        settAutomatiskBrev(
+            utledAutomatiskBrev(behandling, oppfølgingsoppgave?.automatiskBrev, erAvslag, vilkår)
+        );
+    }, [behandling, erAvslag, oppfølgingsoppgave?.automatiskBrev, vilkår]);
 
     return (
         <DataViewer response={{ fremleggsOppgaver }}>
@@ -158,7 +164,9 @@ export const ModalSendTilBeslutter: FC<{
                                     </>
                                 )}
 
-                                {harBarnMellomSeksOgTolvMnder && erOvergangsstønad && (
+                                {JSON.stringify(automatiskBrev)}
+                                {JSON.stringify(`erAvslag: ${erAvslag}`)}
+                                {!erAvslag && harBarnMellomSeksOgTolvMnder && erOvergangsstønad && (
                                     <>
                                         <Divider />
                                         <AutomatiskBrev

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/ModalSendTilBeslutter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/ModalSendTilBeslutter.tsx
@@ -14,6 +14,7 @@ import { Behandling } from '../../../App/typer/fagsak';
 import { IVilkår } from '../Inngangsvilkår/vilkår';
 import { harBarnMellomSeksOgTolvMåneder, utledAutomatiskBrev } from './utils';
 import { Stønadstype } from '../../../App/typer/behandlingstema';
+import { Oppfølgingsoppgave } from '../../../App/hooks/useHentOppfølgingsoppgave';
 
 export const ModalSendTilBeslutter: FC<{
     behandling: Behandling;
@@ -34,6 +35,7 @@ export const ModalSendTilBeslutter: FC<{
         erAvslagSkalSendeTilBeslutter: boolean;
         erAvslag: boolean;
     };
+    oppfølgingsoppgave: Oppfølgingsoppgave | undefined;
 }> = ({
     behandling,
     vilkår,
@@ -47,6 +49,7 @@ export const ModalSendTilBeslutter: FC<{
     oppgaverSomSkalAutomatiskFerdigstilles,
     settOppgaverSomSkalAutomatiskFerdigstilles,
     avslagValg,
+    oppfølgingsoppgave,
 }) => {
     const [
         årForInntektskontrollSelvstendigNæringsdrivende,
@@ -56,7 +59,7 @@ export const ModalSendTilBeslutter: FC<{
         []
     );
     const [automatiskBrev, settAutomatiskBrev] = useState<AutomatiskBrevValg[]>(
-        utledAutomatiskBrev(vilkår, behandling)
+        utledAutomatiskBrev(vilkår, behandling, oppfølgingsoppgave?.automatiskBrev)
     );
     const { ferdigstillUtenBeslutter, erAvslagSkalSendeTilBeslutter, erAvslag } = avslagValg;
 

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/ModalSendTilBeslutter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/ModalSendTilBeslutter.tsx
@@ -34,6 +34,7 @@ export const ModalSendTilBeslutter: FC<{
         ferdigstillUtenBeslutter: boolean;
         erAvslagSkalSendeTilBeslutter: boolean;
         erAvslag: boolean;
+        erInnvilgelseOvergangsstønad: boolean;
     };
     oppfølgingsoppgave?: Oppfølgingsoppgave;
 }> = ({
@@ -55,12 +56,24 @@ export const ModalSendTilBeslutter: FC<{
         årForInntektskontrollSelvstendigNæringsdrivende,
         settÅrForInntektskontrollSelvstendigNæringsdrivende,
     ] = useState<number | undefined>();
+
     const [beskrivelseMarkeringer, settBeskrivelseMarkeringer] = useState<BeskrivelseMarkeringer[]>(
         []
     );
-    const { ferdigstillUtenBeslutter, erAvslagSkalSendeTilBeslutter, erAvslag } = avslagValg;
+
+    const {
+        ferdigstillUtenBeslutter,
+        erAvslagSkalSendeTilBeslutter,
+        erAvslag,
+        erInnvilgelseOvergangsstønad,
+    } = avslagValg;
+
     const [automatiskBrev, settAutomatiskBrev] = useState<AutomatiskBrevValg[]>(
-        utledAutomatiskBrev(behandling, oppfølgingsoppgave?.automatiskBrev, erAvslag, vilkår)
+        utledAutomatiskBrev(
+            oppfølgingsoppgave?.automatiskBrev,
+            erInnvilgelseOvergangsstønad,
+            vilkår
+        )
     );
 
     const handleSettOppgaverSomSkalFerdigstilles = (oppgaveId: number) =>
@@ -100,9 +113,13 @@ export const ModalSendTilBeslutter: FC<{
 
     useEffect(() => {
         settAutomatiskBrev(
-            utledAutomatiskBrev(behandling, oppfølgingsoppgave?.automatiskBrev, erAvslag, vilkår)
+            utledAutomatiskBrev(
+                oppfølgingsoppgave?.automatiskBrev,
+                erInnvilgelseOvergangsstønad,
+                vilkår
+            )
         );
-    }, [behandling, erAvslag, oppfølgingsoppgave?.automatiskBrev, vilkår]);
+    }, [behandling, erInnvilgelseOvergangsstønad, oppfølgingsoppgave?.automatiskBrev, vilkår]);
 
     return (
         <DataViewer response={{ fremleggsOppgaver }}>
@@ -164,17 +181,17 @@ export const ModalSendTilBeslutter: FC<{
                                     </>
                                 )}
 
-                                {JSON.stringify(automatiskBrev)}
-                                {JSON.stringify(`erAvslag: ${erAvslag}`)}
-                                {!erAvslag && harBarnMellomSeksOgTolvMnder && erOvergangsstønad && (
-                                    <>
-                                        <Divider />
-                                        <AutomatiskBrev
-                                            automatiskBrev={automatiskBrev}
-                                            settAutomatiskBrev={settAutomatiskBrev}
-                                        />
-                                    </>
-                                )}
+                                {erInnvilgelseOvergangsstønad &&
+                                    harBarnMellomSeksOgTolvMnder &&
+                                    erOvergangsstønad && (
+                                        <>
+                                            <Divider />
+                                            <AutomatiskBrev
+                                                automatiskBrev={automatiskBrev}
+                                                settAutomatiskBrev={settAutomatiskBrev}
+                                            />
+                                        </>
+                                    )}
                             </VStack>
                         </Modal.Body>
                         <Modal.Footer>

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/ModalSendTilBeslutter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/ModalSendTilBeslutter.tsx
@@ -35,7 +35,7 @@ export const ModalSendTilBeslutter: FC<{
         erAvslagSkalSendeTilBeslutter: boolean;
         erAvslag: boolean;
     };
-    oppfølgingsoppgave: Oppfølgingsoppgave | undefined;
+    oppfølgingsoppgave?: Oppfølgingsoppgave;
 }> = ({
     behandling,
     vilkår,
@@ -161,7 +161,6 @@ export const ModalSendTilBeslutter: FC<{
                                 {harBarnMellomSeksOgTolvMnder && erOvergangsstønad && (
                                     <>
                                         <Divider />
-                                        {JSON.stringify(automatiskBrev)}
                                         <AutomatiskBrev
                                             automatiskBrev={automatiskBrev}
                                             settAutomatiskBrev={settAutomatiskBrev}

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutter.tsx
@@ -51,7 +51,7 @@ const utledDefaultOppgavetyperSomSkalOpprettes = (
 
 const SendTilBeslutter: React.FC<{
     behandling: Behandling;
-    vilkår: IVilkår;
+    vilkår?: IVilkår;
     kanSendesTilBeslutter?: boolean;
     behandlingErRedigerbar: boolean;
     hentOppfølgingsoppgave?: { rerun: () => void };

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutter.tsx
@@ -99,6 +99,7 @@ const SendTilBeslutter: React.FC<{
         ferdigstillUtenBeslutter: boolean;
         erAvslagSkalSendeTilBeslutter: boolean;
         erAvslag: boolean;
+        erInnvilgelseOvergangsstønad: boolean;
     }>(utledAvslagValg(vedtak));
 
     const { ferdigstillUtenBeslutter } = avslagValg;

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutter.tsx
@@ -234,6 +234,7 @@ const SendTilBeslutter: React.FC<{
                         settOppgaverSomSkalAutomatiskFerdigstilles
                     }
                     avslagValg={avslagValg}
+                    oppfølgingsoppgave={oppfølgingsoppgave}
                 />
             )}
         </>

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutter.tsx
@@ -21,6 +21,8 @@ import { Oppfølgingsoppgave } from '../../../App/hooks/useHentOppfølgingsoppga
 import { BeskrivelseMarkeringer } from './BeskrivelseOppgave';
 import { AutomatiskBrevValg } from './AutomatiskBrev';
 import { IVilkår } from '../Inngangsvilkår/vilkår';
+import { IVedtak } from '../../../App/typer/vedtak';
+import { utledAvslagValg } from '../VedtakOgBeregning/Felles/utils';
 
 const FlexBox = styled.div`
     display: flex;
@@ -52,24 +54,20 @@ const utledDefaultOppgavetyperSomSkalOpprettes = (
 const SendTilBeslutter: React.FC<{
     behandling: Behandling;
     vilkår?: IVilkår;
+    vedtak?: IVedtak;
     kanSendesTilBeslutter?: boolean;
     behandlingErRedigerbar: boolean;
     hentOppfølgingsoppgave?: { rerun: () => void };
     oppfølgingsoppgave?: Oppfølgingsoppgave;
-    avslagValg: {
-        ferdigstillUtenBeslutter: boolean;
-        erAvslagSkalSendeTilBeslutter: boolean;
-        erAvslag: boolean;
-    };
     settErDokumentInnlastet?: Dispatch<SetStateAction<boolean>>;
 }> = ({
     behandling,
     vilkår,
+    vedtak,
     kanSendesTilBeslutter,
     behandlingErRedigerbar,
     hentOppfølgingsoppgave,
     oppfølgingsoppgave,
-    avslagValg,
     settErDokumentInnlastet,
 }) => {
     const { axiosRequest } = useApp();
@@ -97,6 +95,11 @@ const SendTilBeslutter: React.FC<{
     >(utledDefaultOppgavetyperSomSkalOpprettes(oppgavetyperSomKanOpprettes));
     const [oppgaverSomSkalAutomatiskFerdigstilles, settOppgaverSomSkalAutomatiskFerdigstilles] =
         useState<number[]>(oppfølgingsoppgave?.oppgaveIderForFerdigstilling || []);
+    const [avslagValg, settAvslagValg] = useState<{
+        ferdigstillUtenBeslutter: boolean;
+        erAvslagSkalSendeTilBeslutter: boolean;
+        erAvslag: boolean;
+    }>(utledAvslagValg(vedtak));
 
     const { ferdigstillUtenBeslutter } = avslagValg;
 
@@ -160,6 +163,10 @@ const SendTilBeslutter: React.FC<{
             utledDefaultOppgavetyperSomSkalOpprettes(oppgavetyperSomKanOpprettes)
         );
     }, [oppgavetyperSomKanOpprettes]);
+
+    useEffect(() => {
+        settAvslagValg(utledAvslagValg(vedtak));
+    }, [vedtak]);
 
     return (
         <>

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutter.tsx
@@ -15,10 +15,12 @@ import { OppgaveTypeForOpprettelse } from './oppgaveForOpprettelseTyper';
 import { ModalState } from '../Modal/NyEierModal';
 import { useToggles } from '../../../App/context/TogglesContext';
 import { ToggleName } from '../../../App/context/toggles';
-import { ModalOpprettOgFerdigstilleOppgaver } from './ModalOpprettOgFerdigstilleOppgaver';
+import { ModalSendTilBeslutter } from './ModalSendTilBeslutter';
 import { useHentFremleggsoppgaverForOvergangsstønad } from '../../../App/hooks/useHentFremleggsoppgaverForOvergangsstønad';
 import { Oppfølgingsoppgave } from '../../../App/hooks/useHentOppfølgingsoppgave';
 import { BeskrivelseMarkeringer } from './BeskrivelseOppgave';
+import { AutomatiskBrevValg } from './AutomatiskBrev';
+import { IVilkår } from '../Inngangsvilkår/vilkår';
 
 const FlexBox = styled.div`
     display: flex;
@@ -30,6 +32,7 @@ export interface SendTilBeslutterRequest {
     årForInntektskontrollSelvstendigNæringsdrivende?: number;
     fremleggsoppgaveIderSomSkalFerdigstilles?: number[];
     beskrivelseMarkeringer?: BeskrivelseMarkeringer[];
+    automatiskBrev?: AutomatiskBrevValg[];
 }
 
 const utledDefaultOppgavetyperSomSkalOpprettes = (
@@ -48,6 +51,7 @@ const utledDefaultOppgavetyperSomSkalOpprettes = (
 
 const SendTilBeslutter: React.FC<{
     behandling: Behandling;
+    vilkår: IVilkår;
     kanSendesTilBeslutter?: boolean;
     behandlingErRedigerbar: boolean;
     hentOppfølgingsoppgave?: { rerun: () => void };
@@ -60,6 +64,7 @@ const SendTilBeslutter: React.FC<{
     settErDokumentInnlastet?: Dispatch<SetStateAction<boolean>>;
 }> = ({
     behandling,
+    vilkår,
     kanSendesTilBeslutter,
     behandlingErRedigerbar,
     hentOppfølgingsoppgave,
@@ -214,7 +219,9 @@ const SendTilBeslutter: React.FC<{
                 }}
             />
             {toggleVisKnappForModal && (
-                <ModalOpprettOgFerdigstilleOppgaver
+                <ModalSendTilBeslutter
+                    behandling={behandling}
+                    vilkår={vilkår}
                     open={visMarkereGodkjenneVedtakOppgaveModal}
                     setOpen={settVisMarkereGodkjenneVedtakOppgaveModal}
                     sendTilBeslutter={sendTilBeslutter}

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.test.ts
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.test.ts
@@ -3,12 +3,19 @@ import { harBarnMellomSeksOgTolvMåneder } from './utils';
 import { IVilkår, InngangsvilkårType, Vilkårsresultat } from '../Inngangsvilkår/vilkår';
 
 describe('Har barn mellom seks og tolv måneder', () => {
+    const toÅrGammel = new Date(new Date().setMonth(new Date().getMonth() - 24)).toISOString();
+
     const lagVilkår = (fødselsdato: string | null) => ({
         vurderinger: [
             {
                 vilkårType: InngangsvilkårType.ALENEOMSORG,
                 resultat: Vilkårsresultat.OPPFYLT,
                 barnId: '1',
+            },
+            {
+                vilkårType: InngangsvilkårType.ALENEOMSORG,
+                resultat: Vilkårsresultat.OPPFYLT,
+                barnId: '2 - 2 år',
             },
         ],
         grunnlag: {
@@ -17,6 +24,12 @@ describe('Har barn mellom seks og tolv måneder', () => {
                     barnId: '1',
                     registergrunnlag: {
                         fødselsdato,
+                    },
+                },
+                {
+                    barnId: '2 - 2 år',
+                    registergrunnlag: {
+                        fødselsdato: toÅrGammel,
                     },
                 },
             ],

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.test.ts
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { harBarnMellomSeksOgTolvMåneder } from './utils';
+import { IVilkår, InngangsvilkårType, Vilkårsresultat } from '../Inngangsvilkår/vilkår';
+
+describe('Har barn mellom seks og tolv måneder', () => {
+    const lagVilkår = (fødselsdato: string | null) => ({
+        vurderinger: [
+            {
+                vilkårType: InngangsvilkårType.ALENEOMSORG,
+                resultat: Vilkårsresultat.OPPFYLT,
+                barnId: '1',
+            },
+        ],
+        grunnlag: {
+            barnMedSamvær: [
+                {
+                    barnId: '1',
+                    registergrunnlag: {
+                        fødselsdato,
+                    },
+                },
+            ],
+        },
+    });
+
+    it('skal returnere true når et barn er mellom 6 og 12 måneder gammelt', () => {
+        const fødselsdato = new Date();
+        fødselsdato.setMonth(fødselsdato.getMonth() - 8);
+        const vilkår = lagVilkår(fødselsdato.toISOString());
+
+        expect(harBarnMellomSeksOgTolvMåneder(vilkår as IVilkår)).toBe(true);
+    });
+
+    it('skal returnere false når et barn er yngre enn 6 måneder', () => {
+        const fødselsdato = new Date();
+        fødselsdato.setMonth(fødselsdato.getMonth() - 4);
+        const vilkår = lagVilkår(fødselsdato.toISOString());
+
+        expect(harBarnMellomSeksOgTolvMåneder(vilkår as IVilkår)).toBe(false);
+    });
+
+    it('skal returnere false når et barn er over 12 måneder', () => {
+        const fødselsdato = new Date();
+        fødselsdato.setMonth(fødselsdato.getMonth() - 13);
+        const vilkår = lagVilkår(fødselsdato.toISOString());
+
+        expect(harBarnMellomSeksOgTolvMåneder(vilkår as IVilkår)).toBe(false);
+    });
+
+    it('skal returnere false hvis alder mangler', () => {
+        const vilkår = lagVilkår(null);
+
+        expect(harBarnMellomSeksOgTolvMåneder(vilkår as IVilkår)).toBe(false);
+    });
+});

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.ts
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.ts
@@ -39,15 +39,29 @@ export const harBarnMellomSeksOgTolvMåneder = (vilkår: IVilkår) => {
     });
 };
 
-export const utledAutomatiskBrev = (vilkår: IVilkår, behandling: Behandling) => {
+export const utledAutomatiskBrev = (
+    vilkår: IVilkår,
+    behandling: Behandling,
+    lagretAutomatiskBrev: string[] | undefined
+) => {
+    lagretAutomatiskBrev;
+
     const harBarnMellomSeksOgTolvMnder = harBarnMellomSeksOgTolvMåneder(vilkår);
     const erOvergangsstønad = behandling.stønadstype === Stønadstype.OVERGANGSSTØNAD;
 
-    const automatiskBrev: AutomatiskBrevValg[] = [];
+    const automatiskBrev: Set<AutomatiskBrevValg> = new Set();
 
-    if (harBarnMellomSeksOgTolvMnder && erOvergangsstønad) {
-        automatiskBrev.push('Varsel om aktivitetsplikt');
+    if (lagretAutomatiskBrev && lagretAutomatiskBrev.length > 0) {
+        lagretAutomatiskBrev.forEach((brev) => {
+            automatiskBrev.add(brev as AutomatiskBrevValg);
+        });
     }
 
-    return automatiskBrev;
+    if (harBarnMellomSeksOgTolvMnder && erOvergangsstønad) {
+        automatiskBrev.add('Varsel om aktivitetsplikt');
+    } else {
+        automatiskBrev.delete('Varsel om aktivitetsplikt');
+    }
+
+    return Array.from(automatiskBrev);
 };

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.ts
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.ts
@@ -42,8 +42,13 @@ export const harBarnMellomSeksOgTolvMåneder = (vilkår: IVilkår) => {
 export const utledAutomatiskBrev = (
     behandling: Behandling,
     lagretAutomatiskBrev: string[] | undefined,
+    erAvslag: boolean,
     vilkår?: IVilkår
 ) => {
+    if (erAvslag) {
+        return [];
+    }
+
     lagretAutomatiskBrev;
 
     const harBarnMellomSeksOgTolvMnder = vilkår && harBarnMellomSeksOgTolvMåneder(vilkår);

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.ts
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.ts
@@ -1,0 +1,53 @@
+import { Stønadstype } from '../../../App/typer/behandlingstema';
+import { Behandling } from '../../../App/typer/fagsak';
+import { InngangsvilkårType, IVilkår, IVurdering, Vilkårsresultat } from '../Inngangsvilkår/vilkår';
+import { AutomatiskBrevValg } from './AutomatiskBrev';
+
+const aleneomsorgVurderingerOppfylt = (vilkår: IVilkår) => {
+    return vilkår.vurderinger.filter((vurdering) => {
+        return (
+            vurdering.vilkårType === InngangsvilkårType.ALENEOMSORG &&
+            vurdering.resultat === Vilkårsresultat.OPPFYLT &&
+            vurdering.barnId !== null
+        );
+    });
+};
+
+const oppfyltBarnMedSamvær = (vilkår: IVilkår, oppfyltAleneomsorgVurderinger: IVurdering[]) => {
+    return vilkår.grunnlag.barnMedSamvær.filter((barn) =>
+        oppfyltAleneomsorgVurderinger.some((oppfyltBarn) => oppfyltBarn.barnId === barn.barnId)
+    );
+};
+
+export const harBarnMellomSeksOgTolvMåneder = (vilkår: IVilkår) => {
+    const oppfyltAleneomsorgVurderinger = aleneomsorgVurderingerOppfylt(vilkår);
+    const barnMedSamvær = oppfyltBarnMedSamvær(vilkår, oppfyltAleneomsorgVurderinger);
+
+    return barnMedSamvær.some((barn) => {
+        const barnFødselsdato = barn.registergrunnlag.fødselsdato
+            ? new Date(barn.registergrunnlag.fødselsdato)
+            : null;
+
+        const nåværendeDato = new Date();
+
+        const alderMåneder = Math.floor(
+            barnFødselsdato
+                ? (nåværendeDato.getTime() - barnFødselsdato.getTime()) / (1000 * 3600 * 24 * 30)
+                : 0
+        );
+        return alderMåneder >= 6 && alderMåneder <= 12;
+    });
+};
+
+export const utledAutomatiskBrev = (vilkår: IVilkår, behandling: Behandling) => {
+    const harBarnMellomSeksOgTolvMnder = harBarnMellomSeksOgTolvMåneder(vilkår);
+    const erOvergangsstønad = behandling.stønadstype === Stønadstype.OVERGANGSSTØNAD;
+
+    const automatiskBrev: AutomatiskBrevValg[] = [];
+
+    if (harBarnMellomSeksOgTolvMnder && erOvergangsstønad) {
+        automatiskBrev.push('Varsel om aktivitetsplikt');
+    }
+
+    return automatiskBrev;
+};

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.ts
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.ts
@@ -37,7 +37,7 @@ export const harBarnMellomSeksOgTolvMåneder = (vilkår: IVilkår) => {
 };
 
 export const utledAutomatiskBrev = (
-    lagretAutomatiskBrev: string[] | undefined,
+    lagretAutomatiskBrev: AutomatiskBrevValg[] | undefined,
     erInnvilgelseOvergangsstønad: boolean,
     vilkår?: IVilkår
 ) => {

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.ts
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.ts
@@ -40,13 +40,13 @@ export const harBarnMellomSeksOgTolvMåneder = (vilkår: IVilkår) => {
 };
 
 export const utledAutomatiskBrev = (
-    vilkår: IVilkår,
     behandling: Behandling,
-    lagretAutomatiskBrev: string[] | undefined
+    lagretAutomatiskBrev: string[] | undefined,
+    vilkår?: IVilkår
 ) => {
     lagretAutomatiskBrev;
 
-    const harBarnMellomSeksOgTolvMnder = harBarnMellomSeksOgTolvMåneder(vilkår);
+    const harBarnMellomSeksOgTolvMnder = vilkår && harBarnMellomSeksOgTolvMåneder(vilkår);
     const erOvergangsstønad = behandling.stønadstype === Stønadstype.OVERGANGSSTØNAD;
 
     const automatiskBrev: Set<AutomatiskBrevValg> = new Set();

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/utils.ts
@@ -208,6 +208,10 @@ export const utledAvslagValg = (vedtak?: IVedtak | undefined) => {
             !!vedtak &&
             vedtak._type === IVedtakType.Avslag &&
             vedtak.resultatType === EBehandlingResultat.AVSLÅ,
+        erInnvilgelseOvergangsstønad:
+            !!vedtak &&
+            vedtak._type === IVedtakType.InnvilgelseOvergangsstønad &&
+            vedtak.resultatType === EBehandlingResultat.INNVILGE,
     };
 };
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det skal være mulig å huke av for å sende varselbrev om aktivitetsplikt hvis søker har barn mellom 6 og 12 mnder. Det skal være valgt som default hvis mulig.

Dette løser utfordringen med at saksbehandler selv må huske å sende et manuelt brev etter at en behandling er fullført.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24483)
[Backend PR](https://github.com/navikt/familie-ef-sak/pull/2854)

Nytt valg på modal:
![image](https://github.com/user-attachments/assets/b0f49ebe-0249-475d-8193-ef15e505bccd)

Varselbrev blir sendt med:
![image](https://github.com/user-attachments/assets/b05e470c-8932-4eea-beda-6e34b7be81eb)
