### PR TITLE
Dokumentoversikt besøkte lenker

### DIFF
--- a/src/frontend/App/utils/localStorage.ts
+++ b/src/frontend/App/utils/localStorage.ts
@@ -23,3 +23,11 @@ export const hentFraLocalStorage = <T>(key: string, fallbackVerdi: T): T => {
         return fallbackVerdi;
     }
 };
+
+export const slettElementFraLocalStorage = (key: string) => {
+    try {
+        localStorage.removeItem(key);
+    } catch {
+        // Ingen skade skjedd
+    }
+};

--- a/src/frontend/App/utils/localStorage.ts
+++ b/src/frontend/App/utils/localStorage.ts
@@ -1,8 +1,11 @@
 export const oppgaveRequestKeyPrefix = 'oppgaveFiltreringRequest';
+export const dokumentOversiktKeyPrefix = 'dokumentOversiktRequest';
 
-export const oppgaveRequestKey = (innloggetIdent: string): string => {
-    return oppgaveRequestKeyPrefix + innloggetIdent;
-};
+export const oppgaveRequestKey = (innloggetIdent: string) =>
+    oppgaveRequestKeyPrefix + innloggetIdent;
+
+export const dokumentOversiktRequestKey = (fagsakPersonId: string) =>
+    dokumentOversiktKeyPrefix + fagsakPersonId;
 
 export const lagreTilLocalStorage = <T>(key: string, request: T): void => {
     try {

--- a/src/frontend/Komponenter/Journalføring/Admin/JournalføringAdmin.tsx
+++ b/src/frontend/Komponenter/Journalføring/Admin/JournalføringAdmin.tsx
@@ -13,7 +13,7 @@ import {
     hentFraLocalStorage,
     lagreTilLocalStorage,
     oppgaveRequestKey,
-} from '../../Oppgavebenk/oppgavefilterStorage';
+} from '../../../App/utils/localStorage';
 import { IJournalpostResponse, journalstatusTilTekst } from '../../../App/typer/journalføring';
 import { formaterIsoDatoTid } from '../../../App/utils/formatter';
 import { UtledEllerVelgFagsak } from '../Felles/UtledEllerVelgFagsak';

--- a/src/frontend/Komponenter/Journalføring/Standard/JournalføringSide.tsx
+++ b/src/frontend/Komponenter/Journalføring/Standard/JournalføringSide.tsx
@@ -12,7 +12,7 @@ import {
     hentFraLocalStorage,
     lagreTilLocalStorage,
     oppgaveRequestKey,
-} from '../../Oppgavebenk/oppgavefilterStorage';
+} from '../../../App/utils/localStorage';
 import { BodyShort, Heading, HStack } from '@navikt/ds-react';
 import JournalføringWrapper, {
     Høyrekolonne,

--- a/src/frontend/Komponenter/Oppgavebenk/OppgaveFiltrering.tsx
+++ b/src/frontend/Komponenter/Oppgavebenk/OppgaveFiltrering.tsx
@@ -12,7 +12,7 @@ import {
     hentFraLocalStorage,
     lagreTilLocalStorage,
     oppgaveRequestKey,
-} from './oppgavefilterStorage';
+} from '../../App/utils/localStorage';
 import MappeVelger from './MappeVelger';
 import { IMappe } from './typer/mappe';
 import { harEgenAnsattRolle, harStrengtFortroligRolle } from '../../App/utils/roller';

--- a/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
@@ -19,10 +19,9 @@ import { KolonneTitler } from '../../Felles/Personopplysninger/TabellWrapper';
 import { EndreDokumenttittelModal } from './Dokumentoversikt/EndreDokumenttittelModal';
 import { useHentDokumenter } from '../../App/hooks/useHentDokumenter';
 import {
-    dokumentOversiktRequestKey,
-    hentFraLocalStorage,
-    lagreTilLocalStorage,
-} from '../../App/utils/localStorage';
+    hentBesøkteLenkerFraLocalStorage,
+    lagreBesøkteLenkerTilLocalStorage,
+} from './Dokumentoversikt/utils';
 
 const FiltreringGrid = styled.div`
     display: grid;
@@ -74,14 +73,9 @@ export const Dokumenter: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonI
     });
     const { dokumenter, hentDokumenterCallback } = useHentDokumenter();
     const [valgtDokumentId, settValgtDokumentId] = useState<string>('');
-    const [besøkteDokumentLenker, settBesøkteDokumentLenker] = useState<string[]>(
-        hentFraLocalStorage<{ besøkteDokumentLenker: string[] }>(
-            dokumentOversiktRequestKey(fagsakPersonId),
-            { besøkteDokumentLenker: [] }
-        ).besøkteDokumentLenker
+    const [besøkteDokumentLenker, settbesøkteDokumentLenker] = useState<string[]>(
+        hentBesøkteLenkerFraLocalStorage(fagsakPersonId)
     );
-
-    console.log('besøkte lenker', besøkteDokumentLenker);
 
     useEffect(() => {
         hentDokumenterCallback(vedleggRequest);
@@ -92,20 +86,11 @@ export const Dokumenter: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonI
             return;
         }
 
-        console.log('lagrer til local storage', journalpostId);
-
-        lagreTilLocalStorage<{ besøkteDokumentLenker: string[] }>(
-            dokumentOversiktRequestKey(fagsakPersonId),
-            {
-                besøkteDokumentLenker: [...besøkteDokumentLenker, journalpostId],
-            }
-        );
-        settBesøkteDokumentLenker(
-            hentFraLocalStorage<{ besøkteDokumentLenker: string[] }>(
-                dokumentOversiktRequestKey(fagsakPersonId),
-                { besøkteDokumentLenker: [] }
-            ).besøkteDokumentLenker
-        );
+        lagreBesøkteLenkerTilLocalStorage(fagsakPersonId, [
+            ...besøkteDokumentLenker,
+            journalpostId,
+        ]);
+        settbesøkteDokumentLenker(hentBesøkteLenkerFraLocalStorage(fagsakPersonId));
     };
 
     const settVedlegg = (key: keyof VedleggRequest) => {

--- a/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
@@ -18,6 +18,11 @@ import { Tabellrad } from './Dokumentoversikt/Tabellrad';
 import { KolonneTitler } from '../../Felles/Personopplysninger/TabellWrapper';
 import { EndreDokumenttittelModal } from './Dokumentoversikt/EndreDokumenttittelModal';
 import { useHentDokumenter } from '../../App/hooks/useHentDokumenter';
+import {
+    dokumentOversiktRequestKey,
+    hentFraLocalStorage,
+    lagreTilLocalStorage,
+} from '../../App/utils/localStorage';
 
 const FiltreringGrid = styled.div`
     display: grid;
@@ -69,10 +74,39 @@ export const Dokumenter: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonI
     });
     const { dokumenter, hentDokumenterCallback } = useHentDokumenter();
     const [valgtDokumentId, settValgtDokumentId] = useState<string>('');
+    const [besøkteDokumentLenker, settBesøkteDokumentLenker] = useState<string[]>(
+        hentFraLocalStorage<{ besøkteDokumentLenker: string[] }>(
+            dokumentOversiktRequestKey(fagsakPersonId),
+            { besøkteDokumentLenker: [] }
+        ).besøkteDokumentLenker
+    );
+
+    console.log('besøkte lenker', besøkteDokumentLenker);
 
     useEffect(() => {
         hentDokumenterCallback(vedleggRequest);
     }, [hentDokumenterCallback, vedleggRequest]);
+
+    const oppdaterBesøkteDokumentLenker = (journalpostId: string) => {
+        if (besøkteDokumentLenker.includes(journalpostId)) {
+            return;
+        }
+
+        console.log('lagrer til local storage', journalpostId);
+
+        lagreTilLocalStorage<{ besøkteDokumentLenker: string[] }>(
+            dokumentOversiktRequestKey(fagsakPersonId),
+            {
+                besøkteDokumentLenker: [...besøkteDokumentLenker, journalpostId],
+            }
+        );
+        settBesøkteDokumentLenker(
+            hentFraLocalStorage<{ besøkteDokumentLenker: string[] }>(
+                dokumentOversiktRequestKey(fagsakPersonId),
+                { besøkteDokumentLenker: [] }
+            ).besøkteDokumentLenker
+        );
+    };
 
     const settVedlegg = (key: keyof VedleggRequest) => {
         return (val?: string | number) =>
@@ -213,23 +247,44 @@ export const Dokumenter: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonI
                                         .map((journalpostId: string) => {
                                             return grupperteDokumenter[journalpostId].map(
                                                 (dokument: Dokumentinfo, indeks: number) => {
+                                                    const dokumentHarBlittBesøkt =
+                                                        besøkteDokumentLenker.includes(
+                                                            dokument.dokumentinfoId
+                                                        );
+
                                                     if (indeks === 0) {
                                                         return (
                                                             <HovedTabellrad
-                                                                key={`${journalpostId}-${indeks}`}
+                                                                key={`${journalpostId}-${dokument.dokumentinfoId}`}
                                                                 dokument={dokument}
                                                                 settValgtDokumentId={
                                                                     settValgtDokumentId
+                                                                }
+                                                                dokumentHarBlittBesøkt={
+                                                                    dokumentHarBlittBesøkt
+                                                                }
+                                                                oppdaterBesøkteDokumentLenker={() =>
+                                                                    oppdaterBesøkteDokumentLenker(
+                                                                        dokument.dokumentinfoId
+                                                                    )
                                                                 }
                                                             />
                                                         );
                                                     } else
                                                         return (
                                                             <Tabellrad
-                                                                key={`${journalpostId}-${indeks}`}
+                                                                key={`${journalpostId}-${dokument.dokumentinfoId}`}
                                                                 dokument={dokument}
                                                                 settValgtDokumentId={
                                                                     settValgtDokumentId
+                                                                }
+                                                                dokumentHarBlittBesøkt={
+                                                                    dokumentHarBlittBesøkt
+                                                                }
+                                                                oppdaterBesøkteDokumentLenker={() =>
+                                                                    oppdaterBesøkteDokumentLenker(
+                                                                        dokument.dokumentinfoId
+                                                                    )
                                                                 }
                                                             />
                                                         );

--- a/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
@@ -21,6 +21,7 @@ import { useHentDokumenter } from '../../App/hooks/useHentDokumenter';
 import {
     hentBesøkteLenkerFraLocalStorage,
     lagreBesøkteLenkerTilLocalStorage,
+    slettForeldedeInnslagFraLocalStorage,
 } from './Dokumentoversikt/utils';
 
 const FiltreringGrid = styled.div`
@@ -78,6 +79,7 @@ export const Dokumenter: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonI
     );
 
     useEffect(() => {
+        slettForeldedeInnslagFraLocalStorage();
         hentDokumenterCallback(vedleggRequest);
     }, [hentDokumenterCallback, vedleggRequest]);
 

--- a/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Dokumenttittel.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Dokumenttittel.tsx
@@ -10,8 +10,9 @@ const Div = styled.div<{ $erHovedDokument: boolean }>`
     margin-left: ${(props) => (props.$erHovedDokument ? '0rem' : '2rem')};
 `;
 
+// Standard farger for ikke besøkte og besøkte lenker
 const Tittel = styled.a<{ $harBlittBesøkt: boolean }>`
-    color: ${(props) => (props.$harBlittBesøkt ? 'purple' : '#0067c5')};
+    color: ${(props) => (props.$harBlittBesøkt ? '#800080' : '#0067c5')};
 `;
 
 const IkonKnapp = styled(Button)`

--- a/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Dokumenttittel.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Dokumenttittel.tsx
@@ -34,27 +34,24 @@ export const Dokumenttittel: React.FC<Props> = ({
     erHovedDokument,
     dokumentHarBlittBesøkt,
     oppdaterBesøkteDokumentLenker,
-}) => {
-    console.log('harBlittBesøkt', dokumentHarBlittBesøkt, dokument.dokumentinfoId);
-    return (
-        <HStack gap="2">
-            <IkonKnapp
-                icon={<NotePencilIcon title="Rediger" />}
-                variant="tertiary"
-                onClick={() => settValgtDokumentId(dokument.dokumentinfoId)}
-            />
-            <Div $erHovedDokument={erHovedDokument}>
-                <Tittel
-                    $harBlittBesøkt={dokumentHarBlittBesøkt}
-                    href={`/dokument/journalpost/${dokument.journalpostId}/dokument-pdf/${dokument.dokumentinfoId}/${tittelMedUrlGodkjenteTegn(dokument.tittel)}`}
-                    target={'_blank'}
-                    rel={'noreferrer'}
-                    onClick={oppdaterBesøkteDokumentLenker}
-                >
-                    {dokument.tittel}
-                </Tittel>
-                <LogiskeVedlegg logiskeVedlegg={dokument.logiskeVedlegg} />
-            </Div>
-        </HStack>
-    );
-};
+}) => (
+    <HStack gap="2">
+        <IkonKnapp
+            icon={<NotePencilIcon title="Rediger" />}
+            variant="tertiary"
+            onClick={() => settValgtDokumentId(dokument.dokumentinfoId)}
+        />
+        <Div $erHovedDokument={erHovedDokument}>
+            <Tittel
+                $harBlittBesøkt={dokumentHarBlittBesøkt}
+                href={`/dokument/journalpost/${dokument.journalpostId}/dokument-pdf/${dokument.dokumentinfoId}/${tittelMedUrlGodkjenteTegn(dokument.tittel)}`}
+                target={'_blank'}
+                rel={'noreferrer'}
+                onClick={oppdaterBesøkteDokumentLenker}
+            >
+                {dokument.tittel}
+            </Tittel>
+            <LogiskeVedlegg logiskeVedlegg={dokument.logiskeVedlegg} />
+        </Div>
+    </HStack>
+);

--- a/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Dokumenttittel.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Dokumenttittel.tsx
@@ -5,14 +5,18 @@ import { NotePencilIcon } from '@navikt/aksel-icons';
 import { LogiskeVedlegg } from './LogiskeVedlegg';
 import styled from 'styled-components';
 import { Dokumentinfo } from '../../../App/typer/dokumentliste';
+import { ABlue500, ATextVisited } from '@navikt/ds-tokens/dist/tokens';
 
 const Div = styled.div<{ $erHovedDokument: boolean }>`
     margin-left: ${(props) => (props.$erHovedDokument ? '0rem' : '2rem')};
 `;
 
-// Standard farger for ikke besøkte og besøkte lenker
+const standardFargeIkkeBesøktLenke = ABlue500;
+const standardFargeBesøktLenke = ATextVisited;
+
 const Tittel = styled.a<{ $harBlittBesøkt: boolean }>`
-    color: ${(props) => (props.$harBlittBesøkt ? '#800080' : '#0067c5')};
+    color: ${(props) =>
+        props.$harBlittBesøkt ? standardFargeBesøktLenke : standardFargeIkkeBesøktLenke};
 `;
 
 const IkonKnapp = styled(Button)`

--- a/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Dokumenttittel.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Dokumenttittel.tsx
@@ -10,10 +10,8 @@ const Div = styled.div<{ $erHovedDokument: boolean }>`
     margin-left: ${(props) => (props.$erHovedDokument ? '0rem' : '2rem')};
 `;
 
-const Tittel = styled.a`
-    &:visited {
-        color: purple;
-    }
+const Tittel = styled.a<{ $harBlittBesøkt: boolean }>`
+    color: ${(props) => (props.$harBlittBesøkt ? 'purple' : '#0067c5')};
 `;
 
 const IkonKnapp = styled(Button)`
@@ -26,13 +24,18 @@ interface Props {
     dokument: Dokumentinfo;
     settValgtDokumentId: Dispatch<SetStateAction<string>>;
     erHovedDokument: boolean;
+    dokumentHarBlittBesøkt: boolean;
+    oppdaterBesøkteDokumentLenker: () => void;
 }
 
 export const Dokumenttittel: React.FC<Props> = ({
     dokument,
     settValgtDokumentId,
     erHovedDokument,
+    dokumentHarBlittBesøkt,
+    oppdaterBesøkteDokumentLenker,
 }) => {
+    console.log('harBlittBesøkt', dokumentHarBlittBesøkt, dokument.dokumentinfoId);
     return (
         <HStack gap="2">
             <IkonKnapp
@@ -42,9 +45,11 @@ export const Dokumenttittel: React.FC<Props> = ({
             />
             <Div $erHovedDokument={erHovedDokument}>
                 <Tittel
+                    $harBlittBesøkt={dokumentHarBlittBesøkt}
                     href={`/dokument/journalpost/${dokument.journalpostId}/dokument-pdf/${dokument.dokumentinfoId}/${tittelMedUrlGodkjenteTegn(dokument.tittel)}`}
                     target={'_blank'}
                     rel={'noreferrer'}
+                    onClick={oppdaterBesøkteDokumentLenker}
                 >
                     {dokument.tittel}
                 </Tittel>

--- a/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Hovedtabellrad.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Hovedtabellrad.tsx
@@ -23,9 +23,16 @@ export const IkkeTilgang = styled.div`
 interface Props {
     dokument: Dokumentinfo;
     settValgtDokumentId: Dispatch<SetStateAction<string>>;
+    dokumentHarBlittBesøkt: boolean;
+    oppdaterBesøkteDokumentLenker: () => void;
 }
 
-export const HovedTabellrad: React.FC<Props> = ({ dokument, settValgtDokumentId }) => {
+export const HovedTabellrad: React.FC<Props> = ({
+    dokument,
+    settValgtDokumentId,
+    dokumentHarBlittBesøkt,
+    oppdaterBesøkteDokumentLenker,
+}) => {
     return (
         <Table.Row>
             <Table.DataCell>{formaterNullableIsoDatoTid(dokument.dato)}</Table.DataCell>
@@ -41,6 +48,8 @@ export const HovedTabellrad: React.FC<Props> = ({ dokument, settValgtDokumentId 
                         dokument={dokument}
                         settValgtDokumentId={settValgtDokumentId}
                         erHovedDokument={true}
+                        dokumentHarBlittBesøkt={dokumentHarBlittBesøkt}
+                        oppdaterBesøkteDokumentLenker={oppdaterBesøkteDokumentLenker}
                     />
                 ) : (
                     <>

--- a/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Hovedtabellrad.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Hovedtabellrad.tsx
@@ -7,18 +7,11 @@ import {
     avsenderMottakerIdTypeTilTekst,
     journalstatusTilTekst,
 } from '../../../App/typer/journalføring';
-import styled from 'styled-components';
 import { skalViseLenke } from '../utils';
 import { PadlockLockedIcon } from '@navikt/aksel-icons';
 import { Table } from '@navikt/ds-react';
 import { JournalpostTag } from '../../Behandling/Høyremeny/Dokumentliste';
 import { Dokumenttittel } from './Dokumenttittel';
-
-export const IkkeTilgang = styled.div`
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-`;
 
 interface Props {
     dokument: Dokumentinfo;

--- a/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Tabellrad.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Tabellrad.tsx
@@ -1,10 +1,10 @@
 import React, { Dispatch, SetStateAction } from 'react';
 import { Dokumentinfo } from '../../../App/typer/dokumentliste';
 import { skalViseLenke } from '../utils';
-import { IkkeTilgang } from './Hovedtabellrad';
 import { PadlockLockedIcon } from '@navikt/aksel-icons';
 import { Table } from '@navikt/ds-react';
 import { Dokumenttittel } from './Dokumenttittel';
+import styled from 'styled-components';
 
 interface Props {
     dokument: Dokumentinfo;
@@ -12,6 +12,12 @@ interface Props {
     dokumentHarBlittBesøkt: boolean;
     oppdaterBesøkteDokumentLenker: () => void;
 }
+
+const IkkeTilgang = styled.div`
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+`;
 
 export const Tabellrad: React.FC<Props> = ({
     dokument,

--- a/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Tabellrad.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Tabellrad.tsx
@@ -9,9 +9,16 @@ import { Dokumenttittel } from './Dokumenttittel';
 interface Props {
     dokument: Dokumentinfo;
     settValgtDokumentId: Dispatch<SetStateAction<string>>;
+    dokumentHarBlittBesøkt: boolean;
+    oppdaterBesøkteDokumentLenker: () => void;
 }
 
-export const Tabellrad: React.FC<Props> = ({ dokument, settValgtDokumentId }) => {
+export const Tabellrad: React.FC<Props> = ({
+    dokument,
+    settValgtDokumentId,
+    dokumentHarBlittBesøkt,
+    oppdaterBesøkteDokumentLenker,
+}) => {
     return (
         <Table.Row>
             <Table.DataCell></Table.DataCell>
@@ -24,6 +31,8 @@ export const Tabellrad: React.FC<Props> = ({ dokument, settValgtDokumentId }) =>
                         dokument={dokument}
                         settValgtDokumentId={settValgtDokumentId}
                         erHovedDokument={false}
+                        dokumentHarBlittBesøkt={dokumentHarBlittBesøkt}
+                        oppdaterBesøkteDokumentLenker={oppdaterBesøkteDokumentLenker}
                     />
                 ) : (
                     <IkkeTilgang>

--- a/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/utils.ts
+++ b/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/utils.ts
@@ -1,0 +1,22 @@
+import {
+    dokumentOversiktRequestKey,
+    hentFraLocalStorage,
+    lagreTilLocalStorage,
+} from '../../../App/utils/localStorage';
+
+export const hentBesøkteLenkerFraLocalStorage = (fagsakPersonId: string) =>
+    hentFraLocalStorage<{ besøkteDokumentLenker: string[] }>(
+        dokumentOversiktRequestKey(fagsakPersonId),
+        { besøkteDokumentLenker: [] }
+    ).besøkteDokumentLenker;
+
+export const lagreBesøkteLenkerTilLocalStorage = (
+    fagsakPersonId: string,
+    dokumentLenker: string[]
+) =>
+    lagreTilLocalStorage<{ besøkteDokumentLenker: string[] }>(
+        dokumentOversiktRequestKey(fagsakPersonId),
+        {
+            besøkteDokumentLenker: dokumentLenker,
+        }
+    );

--- a/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/utils.ts
+++ b/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/utils.ts
@@ -33,14 +33,14 @@ export const lagreBesøkteLenkerTilLocalStorage = (
 
 export const slettForeldedeInnslagFraLocalStorage = () => {
     const nåværendeTidspunkt = Date.now();
-    const utløpstidspunkt = 14 * 24 * 60 * 60 * 1000; // 14 dager
+    const utløpstidspunktFjortenDager = 14 * 24 * 60 * 60 * 1000;
 
     for (const key of Object.keys(localStorage)) {
         if (key.startsWith(dokumentOversiktKeyPrefix)) {
             const besøkteDokumenter = hentFraLocalStorage<BesøkteDokumenter>(key, fallbackVerdi);
             const endretTidspunkt = new Date(besøkteDokumenter.endretTidspunkt).getTime();
 
-            if (nåværendeTidspunkt - endretTidspunkt > utløpstidspunkt) {
+            if (nåværendeTidspunkt - endretTidspunkt > utløpstidspunktFjortenDager) {
                 slettElementFraLocalStorage(key);
             }
         }

--- a/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/utils.ts
+++ b/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/utils.ts
@@ -1,22 +1,48 @@
 import {
+    dokumentOversiktKeyPrefix,
     dokumentOversiktRequestKey,
     hentFraLocalStorage,
     lagreTilLocalStorage,
+    slettElementFraLocalStorage,
 } from '../../../App/utils/localStorage';
 
+interface BesøkteDokumenter {
+    besøkteDokumentLenker: string[];
+    endretTidspunkt: string;
+}
+
+const fallbackVerdi: BesøkteDokumenter = {
+    besøkteDokumentLenker: [],
+    endretTidspunkt: new Date().toISOString(),
+};
+
 export const hentBesøkteLenkerFraLocalStorage = (fagsakPersonId: string) =>
-    hentFraLocalStorage<{ besøkteDokumentLenker: string[] }>(
+    hentFraLocalStorage<BesøkteDokumenter>(
         dokumentOversiktRequestKey(fagsakPersonId),
-        { besøkteDokumentLenker: [] }
+        fallbackVerdi
     ).besøkteDokumentLenker;
 
 export const lagreBesøkteLenkerTilLocalStorage = (
     fagsakPersonId: string,
     dokumentLenker: string[]
 ) =>
-    lagreTilLocalStorage<{ besøkteDokumentLenker: string[] }>(
-        dokumentOversiktRequestKey(fagsakPersonId),
-        {
-            besøkteDokumentLenker: dokumentLenker,
+    lagreTilLocalStorage<BesøkteDokumenter>(dokumentOversiktRequestKey(fagsakPersonId), {
+        besøkteDokumentLenker: dokumentLenker,
+        endretTidspunkt: new Date().toISOString(),
+    });
+
+export const slettForeldedeInnslagFraLocalStorage = () => {
+    const nåværendeTidspunkt = Date.now();
+    const utløpstidspunkt = 14 * 24 * 60 * 60 * 1000; // 14 dager
+
+    for (const key of Object.keys(localStorage)) {
+        if (key.startsWith(dokumentOversiktKeyPrefix)) {
+            const besøkteDokumenter = hentFraLocalStorage<BesøkteDokumenter>(key, fallbackVerdi);
+            const endretTidspunkt = new Date(besøkteDokumenter.endretTidspunkt).getTime();
+
+            if (nåværendeTidspunkt - endretTidspunkt > utløpstidspunkt) {
+                slettElementFraLocalStorage(key);
+            }
         }
-    );
+    }
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Fra Teams:
<img width="994" alt="Skjermbilde 2025-05-07 kl  10 46 21" src="https://github.com/user-attachments/assets/ce09310c-9106-4808-ba45-0a568e8d7766" />

Chrome har av en eller annen grunn sluttet å støtte visning av lenker som har blitt besøkt fra dokumentoversikten vår. Dette er til stor bry for saksbehandlere. Har laget en løsning som benytter seg av LocalStorage for å sjekke om vi har besøkt en lenke tidligere eller ikke. Innslag i localStorage invalideres etter to uker for å unngå overforbruk av LocalStorage-minne.
