### PR TITLE
skal vise en tydeligere farge på besøkte lenker i dokumentoversikten

### DIFF
--- a/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Dokumenttittel.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumentoversikt/Dokumenttittel.tsx
@@ -5,14 +5,14 @@ import { NotePencilIcon } from '@navikt/aksel-icons';
 import { LogiskeVedlegg } from './LogiskeVedlegg';
 import styled from 'styled-components';
 import { Dokumentinfo } from '../../../App/typer/dokumentliste';
-import { ABlue500, ATextVisited } from '@navikt/ds-tokens/dist/tokens';
+import { ABlue500 } from '@navikt/ds-tokens/dist/tokens';
 
 const Div = styled.div<{ $erHovedDokument: boolean }>`
     margin-left: ${(props) => (props.$erHovedDokument ? '0rem' : '2rem')};
 `;
 
 const standardFargeIkkeBesøktLenke = ABlue500;
-const standardFargeBesøktLenke = ATextVisited;
+const standardFargeBesøktLenke = 'purple';
 
 const Tittel = styled.a<{ $harBlittBesøkt: boolean }>`
     color: ${(props) =>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Fikk tilbakemelding på at Axel sin besøkt-lenkefarge er litt for svak.