### PR TITLE
Fikser sjekk for om barn er under 12 måneder, tidligere sjekket den o…

### DIFF
--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.test.ts
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.test.ts
@@ -52,7 +52,7 @@ describe('Har barn mellom seks og tolv måneder', () => {
         expect(harBarnMellomSeksOgTolvMåneder(vilkår as IVilkår)).toBe(false);
     });
 
-    it('skal returnere false når et barn er 12 måneder eller mer', () => {
+    it('skal returnere false når et barn er 12 måneder eller eldre', () => {
         const fødselsdato = new Date();
         fødselsdato.setMonth(fødselsdato.getMonth() - 12);
         const vilkår = lagVilkår(fødselsdato.toISOString());

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.test.ts
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.test.ts
@@ -52,9 +52,9 @@ describe('Har barn mellom seks og tolv måneder', () => {
         expect(harBarnMellomSeksOgTolvMåneder(vilkår as IVilkår)).toBe(false);
     });
 
-    it('skal returnere false når et barn er over 12 måneder', () => {
+    it('skal returnere false når et barn er 12 måneder eller mer', () => {
         const fødselsdato = new Date();
-        fødselsdato.setMonth(fødselsdato.getMonth() - 13);
+        fødselsdato.setMonth(fødselsdato.getMonth() - 12);
         const vilkår = lagVilkår(fødselsdato.toISOString());
 
         expect(harBarnMellomSeksOgTolvMåneder(vilkår as IVilkår)).toBe(false);

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.ts
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.ts
@@ -32,7 +32,7 @@ export const harBarnMellomSeksOgTolvMåneder = (vilkår: IVilkår) => {
 
         const alderMåneder = antallMånederSidenDato(fødselsdato);
 
-        return alderMåneder >= 6 && alderMåneder <= 12;
+        return alderMåneder >= 6 && alderMåneder <= 11;
     });
 };
 


### PR DESCRIPTION
…m barn var under 13 måneder (12 måneder og alle dager opp til neste måned).

### Hvorfor er denne endringen nødvendig? ✨
