### PR TITLE
Ny skolepengevisning

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgeVedtak/Skoleårsperioder.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgeVedtak/Skoleårsperioder.tsx
@@ -53,33 +53,37 @@ const Skoleårsperioder: React.FC<Props> = ({
 
     return (
         <>
-            {skoleårsperioder.value.map((skoleårsperiode, index) => {
-                return (
-                    <Skoleårsperiode
-                        låsteUtgiftIder={låsteUtgiftIder}
-                        customValidate={customValidate}
-                        fjernSkoleårsperiode={() => fjernSkoleårsperiode(index)}
-                        key={index}
-                        skoleårsperiode={skoleårsperiode}
-                        oppdaterSkoleårsperiode={(
-                            property: keyof ISkoleårsperiodeSkolepenger,
-                            value: ISkoleårsperiodeSkolepenger[keyof ISkoleårsperiodeSkolepenger]
-                        ) => oppdaterSkoleårsperiode(index, property, value)}
-                        oppdaterValideringsfeil={(
-                            property: keyof ISkoleårsperiodeSkolepenger,
-                            oppdaterteFeil
-                        ) =>
-                            oppdaterValideringsfeil(
-                                settValideringsFeil,
-                                index,
-                                property,
+            {skoleårsperioder.value
+                .map((skoleårsperiode) => skoleårsperiode)
+                .reverse()
+                .map((skoleårsperiode, index) => {
+                    const originalIndex = skoleårsperioder.value.length - index - 1;
+                    return (
+                        <Skoleårsperiode
+                            låsteUtgiftIder={låsteUtgiftIder}
+                            customValidate={customValidate}
+                            fjernSkoleårsperiode={() => fjernSkoleårsperiode(index)}
+                            key={originalIndex}
+                            skoleårsperiode={skoleårsperiode}
+                            oppdaterSkoleårsperiode={(
+                                property: keyof ISkoleårsperiodeSkolepenger,
+                                value: ISkoleårsperiodeSkolepenger[keyof ISkoleårsperiodeSkolepenger]
+                            ) => oppdaterSkoleårsperiode(originalIndex, property, value)}
+                            oppdaterValideringsfeil={(
+                                property: keyof ISkoleårsperiodeSkolepenger,
                                 oppdaterteFeil
-                            )
-                        }
-                        valideringsfeil={valideringsfeil && valideringsfeil[index]}
-                    />
-                );
-            })}
+                            ) =>
+                                oppdaterValideringsfeil(
+                                    settValideringsFeil,
+                                    originalIndex,
+                                    property,
+                                    oppdaterteFeil
+                                )
+                            }
+                            valideringsfeil={valideringsfeil && valideringsfeil[originalIndex]}
+                        />
+                    );
+                })}
             {behandlingErRedigerbar && (
                 <LeggTilKnapp
                     ikonPosisjon={'right'}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgeVedtak/Skoleårsperioder.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgeVedtak/Skoleårsperioder.tsx
@@ -58,6 +58,9 @@ const Skoleårsperioder: React.FC<Props> = ({
         (skoleårsperiode) => !skoleårsperiode.erHentetFraBackend
     ).length;
 
+    const harMinstToLagredeSkoleårsperioder =
+        skoleårsperioder.value.length - antallUlagredeSkoleårsperioder > 1;
+
     const skoleårsperioderReversert = skoleårsperioder.value.toReversed();
 
     return (
@@ -105,18 +108,20 @@ const Skoleårsperioder: React.FC<Props> = ({
                     />
                 ) : null;
             })}
-            <Knapp
-                icon={visTidligereSkoleår ? <ChevronUpIcon /> : <ChevronDownIcon />}
-                variant={'tertiary'}
-                size={'medium'}
-                iconPosition={'left'}
-                type={'button'}
-                onClick={() => {
-                    settVisTidligereSkoleår((prevState) => !prevState);
-                }}
-            >
-                {visTidligereSkoleår ? 'Skjul tidligere skoleår' : 'Vis tidligere skoleår'}
-            </Knapp>
+            {harMinstToLagredeSkoleårsperioder && (
+                <Knapp
+                    icon={visTidligereSkoleår ? <ChevronUpIcon /> : <ChevronDownIcon />}
+                    variant={'tertiary'}
+                    size={'medium'}
+                    iconPosition={'left'}
+                    type={'button'}
+                    onClick={() => {
+                        settVisTidligereSkoleår((prevState) => !prevState);
+                    }}
+                >
+                    {visTidligereSkoleår ? 'Skjul tidligere skoleår' : 'Vis tidligere skoleår'}
+                </Knapp>
+            )}
         </>
     );
 };

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgeVedtak/Skoleårsperioder.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Skolepenger/InnvilgeVedtak/Skoleårsperioder.tsx
@@ -1,5 +1,5 @@
 import { ISkoleårsperiodeSkolepenger } from '../../../../../App/typer/vedtak';
-import React, { Dispatch, SetStateAction } from 'react';
+import React, { Dispatch, SetStateAction, useState } from 'react';
 import { useBehandling } from '../../../../../App/context/BehandlingContext';
 import { ListState } from '../../../../../App/hooks/felles/useListState';
 import { FormErrors, Valideringsfunksjon } from '../../../../../App/hooks/felles/useFormState';
@@ -9,6 +9,8 @@ import { InnvilgeVedtakForm, tomSkoleårsperiodeSkolepenger } from '../Felles/ty
 import { oppdaterValideringsfeil } from '../Felles/utils';
 import LeggTilKnapp from '../../../../../Felles/Knapper/LeggTilKnapp';
 import Skoleårsperiode from './Skoleårsperiode';
+import { Knapp } from '../../../../../Felles/Knapper/HovedKnapp';
+import { ChevronDownIcon, ChevronUpIcon } from '@navikt/aksel-icons';
 
 interface Props {
     customValidate: (fn: Valideringsfunksjon<InnvilgeVedtakForm>) => boolean;
@@ -29,6 +31,7 @@ const Skoleårsperioder: React.FC<Props> = ({
 }) => {
     const { behandlingErRedigerbar } = useBehandling();
     const { settIkkePersistertKomponent } = useApp();
+    const [visTidligereSkoleår, settVisTidligereSkoleår] = useState<boolean>(false);
 
     const fjernSkoleårsperiode = (index: number) => {
         skoleårsperioder.remove(index);
@@ -51,39 +54,14 @@ const Skoleårsperioder: React.FC<Props> = ({
         oppdaterHarUtførtBeregning(false);
     };
 
+    const antallUlagredeSkoleårsperioder = skoleårsperioder.value.filter(
+        (skoleårsperiode) => !skoleårsperiode.erHentetFraBackend
+    ).length;
+
+    const skoleårsperioderReversert = skoleårsperioder.value.toReversed();
+
     return (
         <>
-            {skoleårsperioder.value
-                .map((skoleårsperiode) => skoleårsperiode)
-                .reverse()
-                .map((skoleårsperiode, index) => {
-                    const originalIndex = skoleårsperioder.value.length - index - 1;
-                    return (
-                        <Skoleårsperiode
-                            låsteUtgiftIder={låsteUtgiftIder}
-                            customValidate={customValidate}
-                            fjernSkoleårsperiode={() => fjernSkoleårsperiode(index)}
-                            key={originalIndex}
-                            skoleårsperiode={skoleårsperiode}
-                            oppdaterSkoleårsperiode={(
-                                property: keyof ISkoleårsperiodeSkolepenger,
-                                value: ISkoleårsperiodeSkolepenger[keyof ISkoleårsperiodeSkolepenger]
-                            ) => oppdaterSkoleårsperiode(originalIndex, property, value)}
-                            oppdaterValideringsfeil={(
-                                property: keyof ISkoleårsperiodeSkolepenger,
-                                oppdaterteFeil
-                            ) =>
-                                oppdaterValideringsfeil(
-                                    settValideringsFeil,
-                                    originalIndex,
-                                    property,
-                                    oppdaterteFeil
-                                )
-                            }
-                            valideringsfeil={valideringsfeil && valideringsfeil[originalIndex]}
-                        />
-                    );
-                })}
             {behandlingErRedigerbar && (
                 <LeggTilKnapp
                     ikonPosisjon={'right'}
@@ -92,6 +70,53 @@ const Skoleårsperioder: React.FC<Props> = ({
                     variant="tertiary"
                 />
             )}
+            {skoleårsperioderReversert.map((skoleårsperiode, indexReversertListe) => {
+                const indexOriginalListe = skoleårsperioder.value.length - indexReversertListe - 1;
+
+                const skalViseSkoleår =
+                    visTidligereSkoleår ||
+                    indexReversertListe === 0 ||
+                    !skoleårsperiode.erHentetFraBackend ||
+                    indexReversertListe === antallUlagredeSkoleårsperioder;
+
+                return skalViseSkoleår ? (
+                    <Skoleårsperiode
+                        låsteUtgiftIder={låsteUtgiftIder}
+                        customValidate={customValidate}
+                        fjernSkoleårsperiode={() => fjernSkoleårsperiode(indexOriginalListe)}
+                        key={indexOriginalListe}
+                        skoleårsperiode={skoleårsperiode}
+                        oppdaterSkoleårsperiode={(
+                            property: keyof ISkoleårsperiodeSkolepenger,
+                            value: ISkoleårsperiodeSkolepenger[keyof ISkoleårsperiodeSkolepenger]
+                        ) => oppdaterSkoleårsperiode(indexOriginalListe, property, value)}
+                        oppdaterValideringsfeil={(
+                            property: keyof ISkoleårsperiodeSkolepenger,
+                            oppdaterteFeil
+                        ) =>
+                            oppdaterValideringsfeil(
+                                settValideringsFeil,
+                                indexOriginalListe,
+                                property,
+                                oppdaterteFeil
+                            )
+                        }
+                        valideringsfeil={valideringsfeil && valideringsfeil[indexOriginalListe]}
+                    />
+                ) : null;
+            })}
+            <Knapp
+                icon={visTidligereSkoleår ? <ChevronUpIcon /> : <ChevronDownIcon />}
+                variant={'tertiary'}
+                size={'medium'}
+                iconPosition={'left'}
+                type={'button'}
+                onClick={() => {
+                    settVisTidligereSkoleår((prevState) => !prevState);
+                }}
+            >
+                {visTidligereSkoleår ? 'Skjul tidligere skoleår' : 'Vis tidligere skoleår'}
+            </Knapp>
         </>
     );
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Løser [dette favrokortet](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-24480)

Skal følge både design og logikk som forklart i Favro-kortet og Figma-skissene. Vi rydder opp i visningen av skoleårsperiodene ved å:
- Vise de fra nyeste til eldste
- Skjule de eldste periodene

De vi nå viser er:
- Nyeste periode
- Alle perioder som har blitt lagt til i frontend uten å ha blitt lagret
- Første lagrede periode som etterfølger en ulagret periode