### PR TITLE
Fix - styling knapper

### DIFF
--- a/src/frontend/Felles/Hamburgermeny/Hamburgermeny.tsx
+++ b/src/frontend/Felles/Hamburgermeny/Hamburgermeny.tsx
@@ -1,6 +1,7 @@
 import React, { FC, useEffect, useRef, useState } from 'react';
 import { MenuHamburgerIcon, MenuElipsisVerticalIcon } from '@navikt/aksel-icons';
 import styled from 'styled-components';
+import { Button } from '@navikt/ds-react';
 
 interface HamburgerMenyInnholdProps {
     $åpen: boolean;
@@ -56,19 +57,6 @@ const HamburgerMenyInnhold = styled.div<HamburgerMenyInnholdProps>`
 
         list-style-type: none;
     }
-
-    li:hover {
-        background-color: #0166c5;
-        color: white;
-        cursor: pointer;
-    }
-`;
-
-const Knapp = styled.button`
-    height: 100%;
-    width: 100%;
-
-    text-align: left;
 `;
 
 export interface MenyItem {
@@ -130,14 +118,16 @@ export const Hamburgermeny: FC<Props> = ({
                 <ul>
                     {items.map((p) => (
                         <li key={p.tekst}>
-                            <Knapp
+                            <Button
+                                variant="tertiary"
+                                size="xsmall"
                                 onClick={() => {
                                     settÅpenHamburgerMeny(false);
                                     p.onClick();
                                 }}
                             >
                                 {p.tekst}
-                            </Knapp>
+                            </Button>
                         </li>
                     ))}
                 </ul>

--- a/src/frontend/Komponenter/Behandling/BehandlingSide.module.css
+++ b/src/frontend/Komponenter/Behandling/BehandlingSide.module.css
@@ -29,6 +29,12 @@
     overflow-y: auto;
     width: 1.5rem;
     min-width: 1.5rem;
+
+    button {
+        border: none;
+        padding: 0;
+        cursor: pointer;
+    }
 }
 
 .hoyreMenyWrapperAapen {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Da jeg slettet less filene var det noen knapper som mistet styling. Disse endringene retter opp i dette.

Opsi:
![image](https://github.com/user-attachments/assets/4f22de06-e272-4fa5-b4bc-f8d4de0591e9)

![image](https://github.com/user-attachments/assets/6b680162-77c2-4744-b503-d8777fc30fa4)

![image](https://github.com/user-attachments/assets/30610617-af52-41c5-811e-a74d8d489264)

Fix:
![image](https://github.com/user-attachments/assets/b5f4cc8d-f40b-4bcf-ba04-602c08119d47)

![image](https://github.com/user-attachments/assets/5567a709-09fd-42b1-9b1f-e3c6d991742d)

![image](https://github.com/user-attachments/assets/1854d252-23b1-4885-918a-7655fe81ff61)
