### PR TITLE
Tydeliggjøre ikke oppfylt barn på aleneomsorg

### DIFF
--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/Aleneomsorg.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/Aleneomsorg/Aleneomsorg.tsx
@@ -3,7 +3,7 @@ import { vilkårStatusForBarn } from '../../Vurdering/VurderingUtil';
 import VisEllerEndreVurdering from '../../Vurdering/VisEllerEndreVurdering';
 import AleneomsorgInfo from './AleneomsorgInfo';
 import { VilkårPropsAleneomsorg } from '../vilkårprops';
-import { InngangsvilkårType } from '../vilkår';
+import { InngangsvilkårType, Vilkårsresultat } from '../vilkår';
 import { byggTomRessurs, Ressurs } from '../../../../App/typer/ressurs';
 import { Stønadstype } from '../../../../App/typer/behandlingstema';
 import { useApp } from '../../../../App/context/AppContext';
@@ -44,10 +44,23 @@ export const Aleneomsorg: React.FC<VilkårPropsAleneomsorg> = ({
         }
     }, [axiosRequest, behandling.stønadstype, behandling.id, settBarnMedLøpendeStønad]);
 
-    const vilkårsresultatAleneomsorg = vurderinger
-        .filter((vurdering) => vurdering.vilkårType === InngangsvilkårType.ALENEOMSORG)
-        .map((v) => v.resultat);
+    const inngangsvilkårAleneomsorg = vurderinger.filter(
+        (vurdering) => vurdering.vilkårType === InngangsvilkårType.ALENEOMSORG
+    );
+
+    const vilkårsresultatAleneomsorg = inngangsvilkårAleneomsorg.map((v) => v.resultat);
+
     const utleddResultat = vilkårStatusForBarn(vilkårsresultatAleneomsorg);
+
+    const oppfylteVilkår = inngangsvilkårAleneomsorg.filter(
+        (vurdering) => vurdering.resultat === Vilkårsresultat.OPPFYLT
+    );
+
+    const harFlereBarnAleneomsorg = inngangsvilkårAleneomsorg.length > 1;
+
+    const visAntallOppfylteVilkårHvisFlereBarn: string = harFlereBarnAleneomsorg
+        ? `(${oppfylteVilkår.length} av ${inngangsvilkårAleneomsorg.length} oppfylt)`
+        : '';
 
     return (
         <Vilkårpanel
@@ -55,6 +68,7 @@ export const Aleneomsorg: React.FC<VilkårPropsAleneomsorg> = ({
             tittel="Aleneomsorg"
             vilkårsresultat={utleddResultat}
             vilkår={InngangsvilkårType.ALENEOMSORG}
+            ekstraTekst={visAntallOppfylteVilkårHvisFlereBarn}
         >
             {grunnlag.barnMedSamvær.map((barn, indeks) => {
                 const vurdering = vurderinger.find(

--- a/src/frontend/Komponenter/Behandling/Vilkårpanel/Vilkårpanel.tsx
+++ b/src/frontend/Komponenter/Behandling/Vilkårpanel/Vilkårpanel.tsx
@@ -1,39 +1,13 @@
 import React, { FC, ReactNode } from 'react';
-import styled from 'styled-components';
 import { Vilkårsresultat, VilkårType } from '../Inngangsvilkår/vilkår';
-import { Button, Heading } from '@navikt/ds-react';
+import { Box, Button, Heading, HStack } from '@navikt/ds-react';
 import { ChevronUpIcon, ChevronDownIcon } from '@navikt/aksel-icons';
 import { VilkårsresultatIkon } from '../../../Felles/Ikoner/VilkårsresultatIkon';
 import { BodyShortSmall } from '../../../Felles/Visningskomponenter/Tekster';
-import { AGray50, ATextSubtle } from '@navikt/ds-tokens/dist/tokens';
 import {
     EkspandertTilstand,
     useEkspanderbareVilkårpanelContext,
 } from '../../../App/context/EkspanderbareVilkårpanelContext';
-
-const VilkårpanelBase = styled.div`
-    margin: 2rem;
-    background-color: ${AGray50};
-`;
-
-const VilkårpanelTittel = styled.div`
-    padding-left: 1rem;
-    display: flex;
-    justify-content: space-between;
-`;
-
-const VilkårsresultatContainer = styled.span`
-    display: flex;
-    align-items: center;
-
-    .tittel {
-        margin: 0 1rem 0 0.5rem;
-    }
-
-    .paragrafTittel {
-        color: ${ATextSubtle};
-    }
-`;
 
 interface Props {
     tittel: string;
@@ -41,6 +15,7 @@ interface Props {
     vilkårsresultat: Vilkårsresultat;
     children: ReactNode;
     vilkår: VilkårType;
+    ekstraTekst?: string;
 }
 
 export const Vilkårpanel: FC<Props> = ({
@@ -49,40 +24,40 @@ export const Vilkårpanel: FC<Props> = ({
     vilkårsresultat,
     children,
     vilkår,
+    ekstraTekst,
 }) => {
     const { ekspanderteVilkår, toggleEkspandertTilstand } = useEkspanderbareVilkårpanelContext();
 
     return (
-        <VilkårpanelBase>
-            <>
-                <VilkårpanelTittel>
-                    <VilkårsresultatContainer>
-                        <VilkårsresultatIkon vilkårsresultat={vilkårsresultat} />
-                        <Heading className={'tittel'} size="small" level="5">
-                            {tittel}
-                        </Heading>
-                        {paragrafTittel && (
-                            <BodyShortSmall className={'paragrafTittel'}>
-                                {paragrafTittel}
-                            </BodyShortSmall>
-                        )}
-                    </VilkårsresultatContainer>
-                    <Button
-                        size="medium"
-                        variant="tertiary"
-                        icon={
-                            ekspanderteVilkår[vilkår] === EkspandertTilstand.KOLLAPSET ? (
-                                <ChevronUpIcon />
-                            ) : (
-                                <ChevronDownIcon />
-                            )
-                        }
-                        onClick={() => toggleEkspandertTilstand(vilkår)}
-                        disabled={ekspanderteVilkår[vilkår] === EkspandertTilstand.KAN_IKKE_LUKKES}
-                    />
-                </VilkårpanelTittel>
-                {ekspanderteVilkår[vilkår] !== EkspandertTilstand.KOLLAPSET && children}
-            </>
-        </VilkårpanelBase>
+        <Box background="surface-subtle" style={{ margin: '0 2rem 2rem 2rem' }}>
+            <HStack justify="space-between">
+                <HStack gap="space-12" align={'center'} style={{ paddingLeft: '1rem' }}>
+                    <VilkårsresultatIkon vilkårsresultat={vilkårsresultat} />
+                    <Heading className={'tittel'} size="small" level="5">
+                        {tittel}
+                    </Heading>
+                    {paragrafTittel && (
+                        <BodyShortSmall className={'paragrafTittel'}>
+                            {paragrafTittel}
+                        </BodyShortSmall>
+                    )}
+                    {ekstraTekst && <BodyShortSmall>{ekstraTekst}</BodyShortSmall>}
+                </HStack>
+                <Button
+                    size="medium"
+                    variant="tertiary"
+                    icon={
+                        ekspanderteVilkår[vilkår] === EkspandertTilstand.KOLLAPSET ? (
+                            <ChevronUpIcon />
+                        ) : (
+                            <ChevronDownIcon />
+                        )
+                    }
+                    onClick={() => toggleEkspandertTilstand(vilkår)}
+                    disabled={ekspanderteVilkår[vilkår] === EkspandertTilstand.KAN_IKKE_LUKKES}
+                />
+            </HStack>
+            {ekspanderteVilkår[vilkår] !== EkspandertTilstand.KOLLAPSET && children}
+        </Box>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Vilkårpanel/VilkårpanelInnhold.tsx
+++ b/src/frontend/Komponenter/Behandling/Vilkårpanel/VilkårpanelInnhold.tsx
@@ -1,10 +1,10 @@
 import React, { FC, ReactNode } from 'react';
 import styled from 'styled-components';
 import { AGray300 } from '@navikt/ds-tokens/dist/tokens';
+import { Box } from '@navikt/ds-react';
 
 const Container = styled.div<{ $borderBottom: boolean }>`
     display: flex;
-    margin: 0 1rem;
     border-bottom: ${(props) => (props.$borderBottom ? `1px solid ${AGray300}` : 'none')};
 
     @media (max-width: 1600px) {
@@ -12,7 +12,6 @@ const Container = styled.div<{ $borderBottom: boolean }>`
     }
 
     .venstreKolonne {
-        padding: 1.5rem 0;
         width: 50%;
 
         @media (max-width: 1600px) {
@@ -20,7 +19,6 @@ const Container = styled.div<{ $borderBottom: boolean }>`
         }
     }
     .høyreKolonne {
-        padding: 1.5rem 0;
         width: 50%;
         max-width: 50rem;
         margin-left: auto;
@@ -44,9 +42,11 @@ export const VilkårpanelInnhold: FC<Props> = ({
     children: { venstre, høyre },
 }) => {
     return (
-        <Container $borderBottom={borderBottom}>
-            {venstre && <div className="venstreKolonne">{venstre}</div>}
-            <div className="høyreKolonne">{høyre}</div>
-        </Container>
+        <Box padding={'space-16'}>
+            <Container $borderBottom={borderBottom}>
+                {venstre && <div className="venstreKolonne">{venstre}</div>}
+                <div className="høyreKolonne">{høyre}</div>
+            </Container>
+        </Box>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Vurdering/LagTittel.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/LagTittel.tsx
@@ -1,0 +1,40 @@
+import { XMarkOctagonIcon } from '@navikt/aksel-icons';
+import { ARed500 } from '@navikt/ds-tokens/dist/tokens';
+import { Heading, HStack } from '@navikt/ds-react';
+import React, { FC } from 'react';
+import {
+    IVurdering,
+    InngangsvilkårType,
+    Vilkårsresultat,
+    resultatTilTekst,
+} from '../Inngangsvilkår/vilkår';
+
+export const LagTittel: FC<{
+    vurdering: IVurdering;
+    erAutomatiskVurdert: boolean;
+}> = ({ vurdering, erAutomatiskVurdert }) => {
+    const erAleneomsorg = vurdering.vilkårType === InngangsvilkårType.ALENEOMSORG;
+    const erVurderingOppfylt = vurdering.resultat === Vilkårsresultat.OPPFYLT;
+
+    const tittel = () => {
+        let tittel = '';
+
+        tittel = `Vilkår ${resultatTilTekst[vurdering.resultat]}`;
+
+        tittel += erAutomatiskVurdert ? ` (automatisk)` : ``;
+        return tittel;
+    };
+
+    const skalViseXIkon = erAleneomsorg && !erVurderingOppfylt;
+
+    return (
+        <HStack gap="1">
+            <Heading size={'small'} level={'3'}>
+                {tittel()}
+            </Heading>
+            {skalViseXIkon && (
+                <XMarkOctagonIcon title="a11y-title" fontSize="1.5rem" color={ARed500} />
+            )}
+        </HStack>
+    );
+};

--- a/src/frontend/Komponenter/Behandling/Vurdering/VisEllerEndreVurdering.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/VisEllerEndreVurdering.tsx
@@ -65,7 +65,6 @@ const VisEllerEndreVurdering: FC<Props> = ({
     feilmelding,
     venstreKnappetekst,
     høyreKnappetekst,
-    tittelTekstVisVurdering,
 }) => {
     const {
         behandlingErRedigerbar,
@@ -173,7 +172,6 @@ const VisEllerEndreVurdering: FC<Props> = ({
                     resetVurdering={resetVurdering}
                     feilmelding={feilmelding || resetFeilmelding}
                     behandlingErRedigerbar={behandlingErRedigerbar && erSaksbehandler}
-                    tittelTekst={tittelTekstVisVurdering}
                     gjenbrukVilkårsvurdering={gjenbrukVilkårsvurdering}
                     gjenbrukbareVilkårsvurderinger={gjenbrukbareVilkårsvurderinger}
                 />

--- a/src/frontend/Komponenter/Behandling/Vurdering/VisVurdering.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/VisVurdering.tsx
@@ -3,10 +3,10 @@ import { FC } from 'react';
 import styled from 'styled-components';
 import { delvilkårTypeTilTekst, svarTypeTilTekst } from './tekster';
 import { BrukerMedBlyantIkon, CogIkon } from '../../../Felles/Ikoner/DataGrunnlagIkoner';
-import { IVurdering, resultatTilTekst, Vilkårsresultat } from '../Inngangsvilkår/vilkår';
+import { IVurdering, Vilkårsresultat } from '../Inngangsvilkår/vilkår';
 import { BreakWordBodyLongSmall } from '../../../Felles/Visningskomponenter/BreakWordBodyLongSmall';
 import { formaterIsoDatoTidMedSekunder } from '../../../App/utils/formatter';
-import { Button, ErrorMessage, Heading } from '@navikt/ds-react';
+import { Button, ErrorMessage } from '@navikt/ds-react';
 import { TrashIcon, PencilIcon, RecycleIcon } from '@navikt/aksel-icons';
 
 import {
@@ -23,6 +23,7 @@ import {
 import { ATextSubtle } from '@navikt/ds-tokens/dist/tokens';
 import { utledSkalViseGjenbrukKnapp } from './utils';
 import { ModalGjenbrukVilkårsvurdering } from './ModalGjenbrukVilkårsvurdering';
+import { LagTittel } from './LagTittel';
 
 const StyledVilkår = styled.div`
     grid-column: 2/4;
@@ -44,15 +45,6 @@ const StyledFeilmelding = styled.div`
     max-width: 30rem;
 `;
 
-const StyledIkonOgTittel = styled.span`
-    margin-bottom: 0.5rem;
-    display: flex;
-
-    svg {
-        margin-right: 1rem;
-    }
-`;
-
 const SistOppdatertTekst = styled(DetailSmall)`
     color: ${ATextSubtle};
 `;
@@ -63,7 +55,6 @@ interface Props {
     feilmelding: string | undefined;
     startRedigering: () => void;
     behandlingErRedigerbar: boolean;
-    tittelTekst?: string;
     gjenbrukVilkårsvurdering: () => void;
     gjenbrukbareVilkårsvurderinger: string[];
 }
@@ -74,7 +65,6 @@ const VisVurdering: FC<Props> = ({
     resetVurdering,
     feilmelding,
     behandlingErRedigerbar,
-    tittelTekst,
     gjenbrukVilkårsvurdering,
     gjenbrukbareVilkårsvurderinger,
 }) => {
@@ -99,14 +89,7 @@ const VisVurdering: FC<Props> = ({
             {!erAutomatiskVurdert && <BrukerMedBlyantIkon />}
 
             <TittelOgKnappWrapper>
-                <StyledIkonOgTittel>
-                    <Heading size={'small'} level={'3'}>
-                        {tittelTekst
-                            ? tittelTekst
-                            : `Vilkår ${resultatTilTekst[vurdering.resultat]}`}
-                        {erAutomatiskVurdert ? ` (automatisk)` : ``}
-                    </Heading>
-                </StyledIkonOgTittel>
+                <LagTittel vurdering={vurdering} erAutomatiskVurdert={erAutomatiskVurdert} />
                 {behandlingErRedigerbar && (
                     <>
                         <div>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Skal tydeliggjøre hvilket barn som ikke har oppfylt aleneomsorg hvis det er flere barn.

* Laget en ny komponent for å lage tittel til en vilkår
* Refaktorert noe styling - ønsker å bruke komponenter fra aksel i stedet for styled components.

![image](https://github.com/user-attachments/assets/c6e93af4-1e8c-4a6c-8b09-b7de564dbb80)
![image](https://github.com/user-attachments/assets/bb72dec5-0516-42af-a32b-1581e9e5f238)

