### PR TITLE
Konsekvent styling - refaktorert styling

### DIFF
--- a/src/frontend/Felles/Personopplysninger/NavKontor.tsx
+++ b/src/frontend/Felles/Personopplysninger/NavKontor.tsx
@@ -1,27 +1,16 @@
 import React from 'react';
 import { INavKontor } from '../../App/typer/personopplysninger';
-import styled from 'styled-components';
 import { Detail } from '@navikt/ds-react';
 import { Buildings3Icon } from '@navikt/aksel-icons';
+import PersonopplysningerPanel from './PersonopplysningPanel';
 
-const NavKontorContainer = styled.div`
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-    gap: 0.5rem;
-`;
-
-const OfficeIkon = styled(Buildings3Icon)`
-    width: 1rem;
-    height: 1rem;
-`;
+const OfficeIkon: React.FC = () => <Buildings3Icon width={24} height={24} />;
 
 const NavKontor: React.FC<{ navKontor?: INavKontor }> = ({ navKontor }) => {
     return (
-        <NavKontorContainer>
-            <OfficeIkon />
+        <PersonopplysningerPanel Ikon={OfficeIkon} tittel="NAV-kontor">
             <Detail>{navKontor ? `${navKontor.enhetNr} - ${navKontor.navn}` : 'Ingen data'}</Detail>
-        </NavKontorContainer>
+        </PersonopplysningerPanel>
     );
 };
 

--- a/src/frontend/Felles/Personopplysninger/PersonopplysningPanel.module.css
+++ b/src/frontend/Felles/Personopplysninger/PersonopplysningPanel.module.css
@@ -1,0 +1,5 @@
+.panel {
+    border: 1px solid #efefef;
+    background-color: #f9f9f9;
+    padding: 1rem;
+}

--- a/src/frontend/Felles/Personopplysninger/PersonopplysningPanel.tsx
+++ b/src/frontend/Felles/Personopplysninger/PersonopplysningPanel.tsx
@@ -1,12 +1,7 @@
 import { BodyShort, Heading, ReadMore } from '@navikt/ds-react';
-import { AGray50 } from '@navikt/ds-tokens/dist/tokens';
 import React, { ReactNode } from 'react';
 import styled from 'styled-components';
-
-const Panel = styled.div`
-    background-color: ${AGray50};
-    padding: 1rem;
-`;
+import styles from './PersonopplysningPanel.module.css';
 
 const TittelMedIkon = styled.div`
     display: flex;
@@ -15,8 +10,6 @@ const TittelMedIkon = styled.div`
 `;
 
 const IkonWrapper = styled.div`
-    width: 24px;
-    height: 24px;
     display: flex;
     justify-content: center;
 `;
@@ -39,7 +32,7 @@ const PersonopplysningerPanel: React.FC<{
     children?: ReactNode;
 }> = ({ Ikon, tittel, children, tittelBeskrivelse }) => {
     return (
-        <Panel>
+        <div className={styles.panel}>
             <TittelMedIkon className="ikon">
                 <IkonWrapper>
                     <Ikon />
@@ -55,7 +48,7 @@ const PersonopplysningerPanel: React.FC<{
                 </ReadMoreMedMarginLeft>
             )}
             {children && <InnholdWrapper>{children}</InnholdWrapper>}
-        </Panel>
+        </div>
     );
 };
 

--- a/src/frontend/Felles/Personopplysninger/PersonopplysningerMedNavKontor.tsx
+++ b/src/frontend/Felles/Personopplysninger/PersonopplysningerMedNavKontor.tsx
@@ -11,15 +11,8 @@ import NavKontor from './NavKontor';
 import { INavKontor, IPersonopplysninger } from '../../App/typer/personopplysninger';
 import { Ressurs } from '../../App/typer/ressurs';
 import Vergemål from './Vergemål';
-import styled from 'styled-components';
 import { FagsakPerson } from '../../App/typer/fagsak';
-
-const Container = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    margin: 1rem 2rem;
-`;
+import { VStack } from '@navikt/ds-react';
 
 export const PersonopplysningerMedNavKontor: React.FC<{
     personopplysninger: IPersonopplysninger;
@@ -44,12 +37,13 @@ export const PersonopplysningerMedNavKontor: React.FC<{
         fagsakPerson.overgangsstønad
     );
     return (
-        <Container>
+        <VStack gap="space-8">
             <DataViewer response={{ navKontor }}>
                 {({ navKontor }) => {
                     return <NavKontor navKontor={navKontor} />;
                 }}
             </DataViewer>
+
             <Adressehistorikk adresser={adresse} fagsakPersonId={fagsakPerson.id} />
             <Sivilstatus sivilstander={sivilstand} harFagsak={harFagsak} />
             <Barn barn={barn} harFagsak={harFagsak} />
@@ -64,6 +58,6 @@ export const PersonopplysningerMedNavKontor: React.FC<{
             />
             <Vergemål vergemål={vergemål} />
             <Fullmakter fullmakter={fullmakt} />
-        </Container>
+        </VStack>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
@@ -12,7 +12,7 @@ import { ValgfeltSelect } from './ValgfeltSelect';
 import { Flettefelt } from './Flettefelt';
 import styled from 'styled-components';
 import { Accordion, Button, Checkbox } from '@navikt/ds-react';
-import { ABorderRadiusMedium, ABorderStrong } from '@navikt/ds-tokens/dist/tokens';
+import { ABorderDefault, ABorderRadiusMedium } from '@navikt/ds-tokens/dist/tokens';
 import { HtmlEditor } from '../../../Felles/HtmlEditor/HtmlEditor';
 import { ArrowsSquarepathIcon } from '@navikt/aksel-icons';
 import { finnFlettefeltRefFraFlettefeltApiNavn } from './BrevUtils';
@@ -136,16 +136,12 @@ export const BrevMenyDelmal: React.FC<Props> = ({
                 size="small"
                 style={{
                     width: '100%',
-                    border: `1px solid ${ABorderStrong}`,
+                    border: `1px solid ${ABorderDefault}`,
                     borderRadius: `${ABorderRadiusMedium}`,
                 }}
             >
                 <Accordion.Item open={ekspanderbartPanelÅpen}>
                     <Accordion.Header
-                        style={{
-                            borderRadius: `${ABorderRadiusMedium}`,
-                            border: 'none',
-                        }}
                         onClick={() => settEkspanderbartPanelÅpen(!ekspanderbartPanelÅpen)}
                     >
                         {delmal?.delmalNavn}

--- a/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
@@ -11,10 +11,10 @@ import React, { Dispatch, SetStateAction, useState } from 'react';
 import { ValgfeltSelect } from './ValgfeltSelect';
 import { Flettefelt } from './Flettefelt';
 import styled from 'styled-components';
-import { Accordion, Button, Checkbox } from '@navikt/ds-react';
+import { Button, Checkbox, HStack, VStack } from '@navikt/ds-react';
 import { ABorderDefault, ABorderRadiusMedium } from '@navikt/ds-tokens/dist/tokens';
 import { HtmlEditor } from '../../../Felles/HtmlEditor/HtmlEditor';
-import { ArrowsSquarepathIcon } from '@navikt/aksel-icons';
+import { ArrowsSquarepathIcon, ChevronDownIcon, ChevronUpIcon } from '@navikt/aksel-icons';
 import { finnFlettefeltRefFraFlettefeltApiNavn } from './BrevUtils';
 import { formaterTallMedTusenSkille } from '../../../App/utils/formatter';
 
@@ -23,14 +23,6 @@ const DelmalValg = styled.div`
     flex-direction: row;
     justify-content: flex-start;
     gap: 0.5rem;
-`;
-
-const AccordionInnhold = styled(Accordion.Content)`
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    border: none;
-    padding: 1rem;
 `;
 
 interface Props {
@@ -126,99 +118,106 @@ export const BrevMenyDelmal: React.FC<Props> = ({
 
     const erDelmalblokk = overstyring.overstyrtDelmal?.skalOverstyre !== true;
 
+    const ikon = !ekspanderbartPanelÅpen ? (
+        <ChevronDownIcon title="a11y-title" fontSize="1.5rem" />
+    ) : (
+        <ChevronUpIcon title="a11y-title" fontSize="1.5rem" />
+    );
+
     return (
         <DelmalValg>
             <Checkbox hideLabel onChange={håndterToggleDelmal} checked={valgt} size="small">
                 Velg delmal
             </Checkbox>
-            <Accordion
-                headingSize="xsmall"
-                size="small"
+            <VStack
+                justify={'start'}
                 style={{
                     width: '100%',
                     border: `1px solid ${ABorderDefault}`,
                     borderRadius: `${ABorderRadiusMedium}`,
                 }}
             >
-                <Accordion.Item open={ekspanderbartPanelÅpen}>
-                    <Accordion.Header
+                <HStack>
+                    <Button
+                        variant="tertiary-neutral"
+                        size="xsmall"
+                        icon={ikon}
                         onClick={() => settEkspanderbartPanelÅpen(!ekspanderbartPanelÅpen)}
+                        style={{ width: '100%', justifyContent: 'flex-start' }}
                     >
                         {delmal?.delmalNavn}
-                    </Accordion.Header>
-                    {ekspanderbartPanelÅpen && (
-                        <AccordionInnhold>
-                            {erDelmalblokk &&
-                                delmalValgfelt &&
-                                delmalValgfelt.map((valgFelt, index) => (
-                                    <ValgfeltSelect
-                                        valgFelt={valgFelt}
+                    </Button>
+                </HStack>
+                {ekspanderbartPanelÅpen && (
+                    <VStack gap={'2'} style={{ padding: '1rem' }}>
+                        {erDelmalblokk &&
+                            delmalValgfelt &&
+                            delmalValgfelt.map((valgFelt, index) => (
+                                <ValgfeltSelect
+                                    valgFelt={valgFelt}
+                                    dokument={dokument}
+                                    valgteFelt={valgteFelt}
+                                    settValgteFelt={settValgteFelt}
+                                    flettefelter={flettefelter}
+                                    settFlettefelter={settFlettefelter}
+                                    handleFlettefeltInput={handleFlettefeltInput}
+                                    delmal={delmal}
+                                    key={`${valgteFelt.valgFeltKategori}${index}`}
+                                    settKanSendeTilBeslutter={settBrevOppdatert}
+                                />
+                            ))}
+                        {erDelmalblokk &&
+                            delmalFlettefelter
+                                .flatMap((f) => f.flettefelt)
+                                .filter(
+                                    (felt, index, self) =>
+                                        self.findIndex((t) => t._ref === felt._ref) === index
+                                )
+                                .map((flettefelt) => (
+                                    <Flettefelt
+                                        fetLabel={true}
+                                        flettefelt={flettefelt}
                                         dokument={dokument}
-                                        valgteFelt={valgteFelt}
-                                        settValgteFelt={settValgteFelt}
                                         flettefelter={flettefelter}
-                                        settFlettefelter={settFlettefelter}
                                         handleFlettefeltInput={handleFlettefeltInput}
-                                        delmal={delmal}
-                                        key={`${valgteFelt.valgFeltKategori}${index}`}
-                                        settKanSendeTilBeslutter={settBrevOppdatert}
+                                        key={flettefelt._ref}
                                     />
                                 ))}
-                            {erDelmalblokk &&
-                                delmalFlettefelter
-                                    .flatMap((f) => f.flettefelt)
-                                    .filter(
-                                        (felt, index, self) =>
-                                            self.findIndex((t) => t._ref === felt._ref) === index
-                                    )
-                                    .map((flettefelt) => (
-                                        <Flettefelt
-                                            fetLabel={true}
-                                            flettefelt={flettefelt}
-                                            dokument={dokument}
-                                            flettefelter={flettefelter}
-                                            handleFlettefeltInput={handleFlettefeltInput}
-                                            key={flettefelt._ref}
-                                        />
-                                    ))}
-                            {erDelmalblokk && (
+                        {erDelmalblokk && (
+                            <div>
+                                <Button
+                                    onClick={() => overstyring.konverterTilHtml(delmal)}
+                                    size={'small'}
+                                    variant={'secondary'}
+                                    icon={<ArrowsSquarepathIcon />}
+                                >
+                                    Gjør om til tekstfelt
+                                </Button>
+                            </div>
+                        )}
+                        {overstyring.overstyrtDelmal?.skalOverstyre && (
+                            <>
+                                <HtmlEditor
+                                    defaultValue={overstyring.overstyrtDelmal.htmlInnhold}
+                                    onTextChange={(nyttInnhold) => {
+                                        oppdaterOverstyrtInnhold(delmal, nyttInnhold);
+                                    }}
+                                />
                                 <div>
                                     <Button
-                                        onClick={() => overstyring.konverterTilHtml(delmal)}
+                                        onClick={() => overstyring.konverterTilDelmalblokk(delmal)}
                                         size={'small'}
                                         variant={'secondary'}
                                         icon={<ArrowsSquarepathIcon />}
                                     >
-                                        Gjør om til tekstfelt
+                                        Gjør om til brevbygger
                                     </Button>
                                 </div>
-                            )}
-                            {overstyring.overstyrtDelmal?.skalOverstyre && (
-                                <>
-                                    <HtmlEditor
-                                        defaultValue={overstyring.overstyrtDelmal.htmlInnhold}
-                                        onTextChange={(nyttInnhold) => {
-                                            oppdaterOverstyrtInnhold(delmal, nyttInnhold);
-                                        }}
-                                    />
-                                    <div>
-                                        <Button
-                                            onClick={() =>
-                                                overstyring.konverterTilDelmalblokk(delmal)
-                                            }
-                                            size={'small'}
-                                            variant={'secondary'}
-                                            icon={<ArrowsSquarepathIcon />}
-                                        >
-                                            Gjør om til brevbygger
-                                        </Button>
-                                    </div>
-                                </>
-                            )}
-                        </AccordionInnhold>
-                    )}
-                </Accordion.Item>
-            </Accordion>
+                            </>
+                        )}
+                    </VStack>
+                )}
+            </VStack>
         </DelmalValg>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
@@ -16,7 +16,7 @@ import { useHentBrevmaler } from '../../../App/hooks/useHentBrevmaler';
 import { useVerdierForBrev } from '../../../App/hooks/useVerdierForBrev';
 import { utledHtmlFelterPåStønadstype } from './BrevUtils';
 import { useBehandling } from '../../../App/context/BehandlingContext';
-import { VStack } from '@navikt/ds-react';
+import { BrevvelgerContainer } from './BrevVelgerContainer';
 
 export interface Props {
     oppdaterBrevRessurs: (brevRessurs: Ressurs<string>) => void;
@@ -57,15 +57,7 @@ const Brevmeny: React.FC<Props> = ({
     const brevverdier = useVerdierForBrev(beløpsperioder, behandling, vedtak);
 
     return (
-        <VStack
-            gap="4"
-            style={{
-                backgroundColor: 'white',
-                padding: '1rem',
-                borderRadius: '0.5rem',
-                boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
-            }}
-        >
+        <BrevvelgerContainer>
             <BrevmalSelect
                 brevmal={brevMal}
                 settBrevmal={settBrevmal}
@@ -100,7 +92,7 @@ const Brevmeny: React.FC<Props> = ({
                     ) : null
                 }
             </DataViewer>
-        </VStack>
+        </BrevvelgerContainer>
     );
 };
 

--- a/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import { Ressurs, RessursStatus } from '../../../App/typer/ressurs';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import BrevmenyVisning from './BrevmenyVisning';
-import styled from 'styled-components';
 import {
     IMellomlagretBrevResponse,
     useMellomlagringBrev,
@@ -17,6 +16,7 @@ import { useHentBrevmaler } from '../../../App/hooks/useHentBrevmaler';
 import { useVerdierForBrev } from '../../../App/hooks/useVerdierForBrev';
 import { utledHtmlFelterPåStønadstype } from './BrevUtils';
 import { useBehandling } from '../../../App/context/BehandlingContext';
+import { VStack } from '@navikt/ds-react';
 
 export interface Props {
     oppdaterBrevRessurs: (brevRessurs: Ressurs<string>) => void;
@@ -25,12 +25,6 @@ export interface Props {
     behandling: Behandling;
     vedtaksresultat?: EBehandlingResultat;
 }
-
-const StyledBrevMeny = styled.div`
-    display: flex;
-    flex-direction: column;
-    min-width: 450px;
-`;
 
 const Brevmeny: React.FC<Props> = ({
     oppdaterBrevRessurs,
@@ -63,7 +57,15 @@ const Brevmeny: React.FC<Props> = ({
     const brevverdier = useVerdierForBrev(beløpsperioder, behandling, vedtak);
 
     return (
-        <StyledBrevMeny>
+        <VStack
+            gap="4"
+            style={{
+                backgroundColor: 'white',
+                padding: '1rem',
+                borderRadius: '0.5rem',
+                boxShadow: '0 1px 3px rgba(0, 0, 0, 0.1)',
+            }}
+        >
             <BrevmalSelect
                 brevmal={brevMal}
                 settBrevmal={settBrevmal}
@@ -98,7 +100,7 @@ const Brevmeny: React.FC<Props> = ({
                     ) : null
                 }
             </DataViewer>
-        </StyledBrevMeny>
+        </VStack>
     );
 };
 

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
@@ -31,7 +31,7 @@ import styled from 'styled-components';
 import { apiLoggFeil } from '../../../App/api/axios';
 import { IBrevverdier, MellomlagreSanitybrev } from '../../../App/hooks/useMellomlagringBrev';
 import { useDebouncedCallback } from 'use-debounce';
-import { Alert, Heading, Panel } from '@navikt/ds-react';
+import { Alert, Box, Heading } from '@navikt/ds-react';
 import { Brevverdier } from '../../../App/hooks/useVerdierForBrev';
 import { Fritekstområde } from './Fritekstområde';
 import { IPersonopplysninger } from '../../../App/typer/personopplysninger';
@@ -40,7 +40,6 @@ const BrevFelter = styled.div`
     display: flex;
     flex-direction: column;
     gap: 1rem;
-    padding: 1rem 0;
     min-width: 450px;
 `;
 
@@ -293,10 +292,10 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
                 if (erDelmalGruppe(gruppe)) {
                     if (skalSkjuleAlleDelmaler(gruppe, delmalStore)) return null;
                     return (
-                        <Panel key={`${gruppe.gruppeVisningsnavn}_${indeks}`}>
+                        <Box key={`${gruppe.gruppeVisningsnavn}_${indeks}`}>
                             {gruppe.gruppeVisningsnavn !== 'undefined' && (
                                 <BrevMenyTittel>
-                                    <Heading size="small" level={'5'}>
+                                    <Heading size="xsmall" level={'5'}>
                                         {gruppe.gruppeVisningsnavn}
                                     </Heading>
                                 </BrevMenyTittel>
@@ -328,7 +327,7 @@ const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({
                                     />
                                 </BrevMenyDelmalWrapper>
                             ))}
-                        </Panel>
+                        </Box>
                     );
                 } else {
                     return (

--- a/src/frontend/Komponenter/Behandling/Brev/BrevvelgerContainer.module.css
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevvelgerContainer.module.css
@@ -1,0 +1,6 @@
+.container {
+    background-color: 'white';
+    padding: '1rem';
+    border-radius: '0.5rem';
+    box-shadow: '0 1px 3px rgba(0, 0, 0, 0.1)';
+}

--- a/src/frontend/Komponenter/Behandling/Brev/BrevvelgerContainer.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevvelgerContainer.tsx
@@ -1,0 +1,9 @@
+import React, { FC } from 'react';
+import { VStack } from '@navikt/ds-react';
+import styles from './BrevvelgerContainer.module.css';
+
+export const BrevvelgerContainer: FC<{
+    children?: React.ReactNode;
+}> = ({ children }) => {
+    return <VStack className={styles.container}>{children}</VStack>;
+};

--- a/src/frontend/Komponenter/Behandling/Brev/FrittståendeBrevMedVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/FrittståendeBrevMedVisning.tsx
@@ -14,8 +14,6 @@ const StyledVStack = styled(VStack)`
 const Container = styled.div`
     display: flex;
     gap: 1rem;
-    padding: 1rem;
-    background-color: #f2f2f2;
 
     @media (max-width: 1400px) {
         flex-direction: column;

--- a/src/frontend/Komponenter/Behandling/Brev/FrittståendeSanitybrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/FrittståendeSanitybrev.tsx
@@ -25,6 +25,7 @@ import { Knapp } from '../../../Felles/Knapper/HovedKnapp';
 import { Alert, VStack } from '@navikt/ds-react';
 import { finnDokumenttittelForBrevmal } from './BrevUtils';
 import { BrevmottakereFrittståendeBrev } from '../Brevmottakere/BrevmottakereFrittståendeBrev';
+import { BrevvelgerContainer } from './BrevVelgerContainer';
 
 type Props = {
     fagsakId: string;
@@ -107,43 +108,45 @@ export const FrittståendeSanitybrev: React.FC<Props> = ({
                 mottakere={brevmottakere}
                 settMottakere={settBrevmottakere}
             />
-            <BrevmalSelect
-                dokumentnavn={brevmaler}
-                settBrevmal={settBrevmal}
-                brevmal={brevMal}
-                frittstående={true}
-            />
-            {brevMal && (
-                <DataViewer response={{ brevStruktur, mellomlagretBrev }}>
-                    {({ brevStruktur, mellomlagretBrev }) => (
-                        <>
-                            <BrevmenyVisning
-                                fagsakId={fagsakId}
-                                brevMal={brevMal}
-                                oppdaterBrevRessurs={oppdaterBrevRessurs}
-                                brevStruktur={brevStruktur}
-                                mellomlagreSanityBrev={mellomlagreSanitybrev}
-                                mellomlagretBrevVerdier={
-                                    (mellomlagretBrev as IMellomlagretBrevResponse)?.brevverdier
-                                }
-                                personopplysninger={personopplysninger}
-                                settBrevOppdatert={(laster) => settLaster(!laster)}
-                                brevverdier={brevverdier}
-                            />
-                            <Knapp
-                                disabled={
-                                    brevRessurs.status !== RessursStatus.SUKSESS ||
-                                    !brevmottakereValgt(brevmottakere)
-                                }
-                                onClick={() => settVisModal(true)}
-                                type={'button'}
-                            >
-                                Send brev
-                            </Knapp>
-                        </>
-                    )}
-                </DataViewer>
-            )}
+            <BrevvelgerContainer>
+                <BrevmalSelect
+                    dokumentnavn={brevmaler}
+                    settBrevmal={settBrevmal}
+                    brevmal={brevMal}
+                    frittstående={true}
+                />
+                {brevMal && (
+                    <DataViewer response={{ brevStruktur, mellomlagretBrev }}>
+                        {({ brevStruktur, mellomlagretBrev }) => (
+                            <>
+                                <BrevmenyVisning
+                                    fagsakId={fagsakId}
+                                    brevMal={brevMal}
+                                    oppdaterBrevRessurs={oppdaterBrevRessurs}
+                                    brevStruktur={brevStruktur}
+                                    mellomlagreSanityBrev={mellomlagreSanitybrev}
+                                    mellomlagretBrevVerdier={
+                                        (mellomlagretBrev as IMellomlagretBrevResponse)?.brevverdier
+                                    }
+                                    personopplysninger={personopplysninger}
+                                    settBrevOppdatert={(laster) => settLaster(!laster)}
+                                    brevverdier={brevverdier}
+                                />
+                                <Knapp
+                                    disabled={
+                                        brevRessurs.status !== RessursStatus.SUKSESS ||
+                                        !brevmottakereValgt(brevmottakere)
+                                    }
+                                    onClick={() => settVisModal(true)}
+                                    type={'button'}
+                                >
+                                    Send brev
+                                </Knapp>
+                            </>
+                        )}
+                    </DataViewer>
+                )}
+            </BrevvelgerContainer>
             <ModalWrapper
                 tittel={'Bekreft utsending av brev'}
                 visModal={visModal}

--- a/src/frontend/Komponenter/Behandling/Førstegangsbehandling/OpprettFagsak.tsx
+++ b/src/frontend/Komponenter/Behandling/Førstegangsbehandling/OpprettFagsak.tsx
@@ -14,7 +14,6 @@ const AlertInfoPreWrap = styled(AlertInfo)`
 `;
 
 const Container = styled.div`
-    margin: 1rem;
     max-width: 45rem;
 
     display: flex;

--- a/src/frontend/Komponenter/Migrering/InfotrygdSaker.tsx
+++ b/src/frontend/Komponenter/Migrering/InfotrygdSaker.tsx
@@ -12,7 +12,7 @@ import { useDataHenter } from '../../App/hooks/felles/useDataHenter';
 import DataViewer from '../../Felles/DataViewer/DataViewer';
 import { stønadstypeTilTekst } from '../../App/typer/behandlingstema';
 import { tekstMapping } from '../../App/utils/tekstmapping';
-import { Table } from '@navikt/ds-react';
+import { Heading, Table } from '@navikt/ds-react';
 import {
     TableDataCellSmall,
     TableHeaderCellSmall,
@@ -89,10 +89,10 @@ const InfotrygdSaker: FC<{ personIdent: string }> = ({ personIdent }) => {
     return (
         <DataViewer response={{ infotrygdSaker }}>
             {({ infotrygdSaker }) => (
-                <>
-                    <h2>Saker</h2>
+                <div>
+                    <Heading size={'medium'}>Saker</Heading>
                     <InfotrygdSakerTabell saker={infotrygdSaker.saker} />
-                </>
+                </div>
             )}
         </DataViewer>
     );

--- a/src/frontend/Komponenter/Migrering/MigrerBarnetilsyn.tsx
+++ b/src/frontend/Komponenter/Migrering/MigrerBarnetilsyn.tsx
@@ -3,13 +3,8 @@ import { useApp } from '../../App/context/AppContext';
 import { byggHenterRessurs, byggTomRessurs, Ressurs, RessursStatus } from '../../App/typer/ressurs';
 import { useToggles } from '../../App/context/TogglesContext';
 import { ToggleName } from '../../App/context/toggles';
-import styled from 'styled-components';
-import { Button } from '@navikt/ds-react';
+import { Button, Heading } from '@navikt/ds-react';
 import { visMigrertStatus } from './MigrerFagsak';
-
-const StyledKnapp = styled(Button)`
-    margin: 0.25rem;
-`;
 
 const MigrerBarnetilsyn: React.FC<{
     fagsakPersonId: string;
@@ -37,11 +32,11 @@ const MigrerBarnetilsyn: React.FC<{
     };
 
     return (
-        <div style={{ marginTop: '1rem' }}>
-            <h1>Migrering - Barnetilsyn</h1>
+        <>
+            <Heading size={'medium'}>Migrering - Barnetilsyn</Heading>
             <div>
                 {visMigrertStatus(migrertStatus, settIgnorerFeilISimulering)}
-                <StyledKnapp
+                <Button
                     onClick={migrerFagsak}
                     disabled={
                         migrertStatus.status === RessursStatus.HENTER ||
@@ -49,9 +44,9 @@ const MigrerBarnetilsyn: React.FC<{
                     }
                 >
                     Migrer Barnetilsyn
-                </StyledKnapp>
+                </Button>
             </div>
-        </div>
+        </>
     );
 };
 

--- a/src/frontend/Komponenter/Migrering/MigrerFagsak.tsx
+++ b/src/frontend/Komponenter/Migrering/MigrerFagsak.tsx
@@ -18,12 +18,8 @@ import {
 } from '../../App/utils/formatter';
 import Utregningstabell from '../Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/Utregningstabell';
 import styled from 'styled-components';
-import { Button, Checkbox, CheckboxGroup } from '@navikt/ds-react';
+import { Button, Checkbox, CheckboxGroup, Heading } from '@navikt/ds-react';
 import { AlertWarning } from '../../Felles/Visningskomponenter/Alerts';
-
-const StyledKnapp = styled(Button)`
-    margin: 0.25rem;
-`;
 
 const GodkjennSimuleringsfeil = styled(AlertWarning)`
     margin-top: 1rem;
@@ -133,11 +129,11 @@ const MigrerFagsak: React.FC<{
     };
 
     return (
-        <div style={{ marginTop: '1rem' }}>
-            <h1>Migrering - Overgangsstønad</h1>
-            <StyledKnapp variant={'secondary'} onClick={hentMigreringInfo}>
+        <div>
+            <Heading size={'medium'}>Migrering - Overgangsstønad</Heading>
+            <Button variant={'secondary'} onClick={hentMigreringInfo}>
                 Hent migreringinfo
-            </StyledKnapp>
+            </Button>
             <DataViewer response={{ migreringInfo }}>
                 {({ migreringInfo }) => {
                     return (
@@ -147,7 +143,7 @@ const MigrerFagsak: React.FC<{
 
                             {migreringInfo.kanMigreres && (
                                 <div>
-                                    <StyledKnapp
+                                    <Button
                                         onClick={migrerFagsak}
                                         disabled={
                                             migrertStatus.status === RessursStatus.HENTER ||
@@ -155,7 +151,7 @@ const MigrerFagsak: React.FC<{
                                         }
                                     >
                                         Migrer fagsak
-                                    </StyledKnapp>
+                                    </Button>
                                 </div>
                             )}
                         </>

--- a/src/frontend/Komponenter/Personoversikt/Behandlingsoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Behandlingsoversikt.tsx
@@ -7,7 +7,7 @@ import { useHentUtestengelser } from '../../App/hooks/useHentUtestengelser';
 import { InfostripeUtestengelse } from './InfostripeUtestengelse';
 import { ÅpneKlager } from './Klage/ÅpneKlager';
 import { FagsakPerson } from '../../App/typer/fagsak';
-import { Heading } from '@navikt/ds-react';
+import { Heading, VStack } from '@navikt/ds-react';
 import styled from 'styled-components';
 
 export enum BehandlingApplikasjon {
@@ -46,7 +46,7 @@ export const Behandlingsoversikt: React.FC<{
     return (
         <DataViewer response={{ klagebehandlinger }}>
             {({ klagebehandlinger }) => (
-                <>
+                <VStack gap={'space-16'}>
                     <InfostripeUtestengelse utestengelser={utestengelser} />
                     <ÅpneKlager fagsakPersonId={fagsakPerson.id} />
                     {fagsakPerson.overgangsstønad && (
@@ -82,7 +82,7 @@ export const Behandlingsoversikt: React.FC<{
                             hentUtestengelser={hentUtestengelser}
                         />
                     )}
-                </>
+                </VStack>
             )}
         </DataViewer>
     );

--- a/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Dokumenter.tsx
@@ -49,7 +49,6 @@ const ArkivtemaVelger = styled(FamilieReactSelect)`
 `;
 
 const Container = styled.div`
-    margin: 1rem;
     gap: 1rem;
     display: flex;
     flex-direction: column;

--- a/src/frontend/Komponenter/Personoversikt/FagsakOversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/FagsakOversikt.tsx
@@ -4,19 +4,12 @@ import { byggTomRessurs, Ressurs } from '../../App/typer/ressurs';
 import { Fagsak } from '../../App/typer/fagsak';
 import { TilbakekrevingBehandling } from '../../App/typer/tilbakekreving';
 import { useApp } from '../../App/context/AppContext';
-import styled from 'styled-components';
 import DataViewer from '../../Felles/DataViewer/DataViewer';
 import { BehandlingsoversiktTabell } from './BehandlingsoversiktTabell';
 import { FagsakTittelLinje } from './FagsakTittelLinje';
 import { KlageBehandling } from '../../App/typer/klage';
-import { Button } from '@navikt/ds-react';
+import { Button, VStack } from '@navikt/ds-react';
 import { harÅpenKlage } from '../../App/utils/klage';
-
-const Knapp = styled(Button)`
-    padding-left: 1.25rem;
-    padding-right: 1.25rem;
-    margin-top: 0.5rem;
-`;
 
 interface Props {
     fagsak: Fagsak;
@@ -49,7 +42,7 @@ export const FagsakOversikt: React.FC<Props> = ({
     return (
         <DataViewer response={{ tilbakekrevingBehandlinger }}>
             {({ tilbakekrevingBehandlinger }) => (
-                <>
+                <VStack gap={'space-8'}>
                     <FagsakTittelLinje fagsak={fagsak} />
                     <BehandlingsoversiktTabell
                         behandlinger={fagsak.behandlinger}
@@ -68,16 +61,18 @@ export const FagsakOversikt: React.FC<Props> = ({
                                 harÅpenKlage={harÅpenKlage(klageBehandlinger)}
                             />
 
-                            <Knapp
-                                onClick={() => settVisLagBehandlingModal(true)}
-                                variant={'secondary'}
-                                type={'button'}
-                            >
-                                Opprett ny behandling
-                            </Knapp>
+                            <div>
+                                <Button
+                                    onClick={() => settVisLagBehandlingModal(true)}
+                                    variant={'secondary'}
+                                    type={'button'}
+                                >
+                                    Opprett ny behandling
+                                </Button>
+                            </div>
                         </>
                     )}
-                </>
+                </VStack>
             )}
         </DataViewer>
     );

--- a/src/frontend/Komponenter/Personoversikt/FagsakTittelLinje.tsx
+++ b/src/frontend/Komponenter/Personoversikt/FagsakTittelLinje.tsx
@@ -1,36 +1,21 @@
-import styled from 'styled-components';
 import React from 'react';
 import { Fagsak } from '../../App/typer/fagsak';
 import { formatterEnumVerdi } from '../../App/utils/utils';
-import { Heading, Tag } from '@navikt/ds-react';
+import { Heading, HStack, Tag } from '@navikt/ds-react';
 import { BodyShortSmall } from '../../Felles/Visningskomponenter/Tekster';
-
-const StyledTag = styled(Tag)`
-    margin-left: 1rem;
-`;
-const TittelLinje = styled.div`
-    margin-top: 1.5rem;
-    display: flex;
-    align-items: flex-start;
-`;
-
-const TekstMedMargin = styled(BodyShortSmall)`
-    margin-top: 0.3rem;
-    margin-left: 0.3rem;
-`;
 
 export const FagsakTittelLinje: React.FC<{
     fagsak: Fagsak;
 }> = ({ fagsak }) => (
-    <TittelLinje>
+    <HStack align={'center'} gap={'space-8'}>
         <Heading size={'small'} level="3">
             Fagsak: {formatterEnumVerdi(fagsak.stønadstype)}
         </Heading>
-        <TekstMedMargin>({fagsak.eksternId})</TekstMedMargin>
+        <BodyShortSmall>({fagsak.eksternId})</BodyShortSmall>
         {fagsak.erLøpende && (
-            <StyledTag variant={'info'} size={'small'}>
+            <Tag variant={'info'} size={'small'}>
                 Løpende
-            </StyledTag>
+            </Tag>
         )}
-    </TittelLinje>
+    </HStack>
 );

--- a/src/frontend/Komponenter/Personoversikt/Infotrygdperioderoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Infotrygdperioderoversikt.tsx
@@ -11,23 +11,8 @@ import SummertePerioder from '../Migrering/SummertePerioder';
 import InfotrygdPerioder from '../Migrering/InfotrygdPerioder';
 import MigrerBarnetilsyn from '../Migrering/MigrerBarnetilsyn';
 import { AlertInfo } from '../../Felles/Visningskomponenter/Alerts';
-import { BodyShort, Checkbox } from '@navikt/ds-react';
+import { BodyShort, Checkbox, Heading, HStack, VStack } from '@navikt/ds-react';
 import Historiskpensjon from './Historiskpensjon/Historiskpensjon';
-
-const FlexBox = styled.div`
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    gap: 1rem;
-    align-items: flex-start;
-`;
-const StyledAlertStripe = styled(AlertInfo)`
-    width: 40rem;
-`;
-
-const InfotrygdperioderoversiktContainer = styled.div`
-    padding: 0.25rem;
-`;
 
 const CheckboxContainer = styled.div`
     display: flex;
@@ -56,14 +41,14 @@ const InfotrygdEllerSummertePerioder: React.FC<{
 
     return (
         <>
-            <FlexBox>
-                <StyledAlertStripe>
+            <HStack gap="space-16">
+                <AlertInfo>
                     <BodyShort>
                         Denne siden viser vedtaksperioder fra og med desember 2008
                     </BodyShort>
-                </StyledAlertStripe>
+                </AlertInfo>
                 <Historiskpensjon fagsakPersonId={fagsakPersonId} />
-            </FlexBox>
+            </HStack>
             <CheckboxContainer>
                 {skalViseCheckbox && (
                     <Checkbox
@@ -76,14 +61,30 @@ const InfotrygdEllerSummertePerioder: React.FC<{
                     </Checkbox>
                 )}
             </CheckboxContainer>
-            <h2>Overgangsstønad</h2>
-            {visPerioder(Stønadstype.OVERGANGSSTØNAD, visSummert, perioder.overgangsstønad)}
 
-            <h2>Barnetilsyn</h2>
-            {visPerioder(Stønadstype.BARNETILSYN, visSummert, perioder.barnetilsyn)}
+            <TittelOgPerioder
+                tittel="Overgangsstønad"
+                visPerioder={visPerioder}
+                stønadstype={Stønadstype.OVERGANGSSTØNAD}
+                visSummert={visSummert}
+                perioder={perioder.overgangsstønad}
+            />
 
-            <h2>Skolepenger</h2>
-            {visPerioder(Stønadstype.SKOLEPENGER, visSummert, perioder.skolepenger)}
+            <TittelOgPerioder
+                tittel="Barnetilsyn"
+                visPerioder={visPerioder}
+                stønadstype={Stønadstype.BARNETILSYN}
+                visSummert={visSummert}
+                perioder={perioder.barnetilsyn}
+            />
+
+            <TittelOgPerioder
+                tittel="Skolepenger"
+                visPerioder={visPerioder}
+                stønadstype={Stønadstype.SKOLEPENGER}
+                visSummert={visSummert}
+                perioder={perioder.skolepenger}
+            />
         </>
     );
 };
@@ -109,16 +110,37 @@ export const Infotrygdperioderoversikt: React.FC<{
     return (
         <DataViewer response={{ infotrygdPerioder }}>
             {({ infotrygdPerioder }) => (
-                <InfotrygdperioderoversiktContainer>
-                    <InfotrygdEllerSummertePerioder
-                        perioder={infotrygdPerioder}
-                        fagsakPersonId={fagsakPersonId}
-                    />
-                    <InfotrygdSaker personIdent={personIdent} />
-                    <MigrerFagsak fagsakPersonId={fagsakPersonId} />
-                    <MigrerBarnetilsyn fagsakPersonId={fagsakPersonId} />
-                </InfotrygdperioderoversiktContainer>
+                <div>
+                    <VStack gap="space-16">
+                        <InfotrygdEllerSummertePerioder
+                            perioder={infotrygdPerioder}
+                            fagsakPersonId={fagsakPersonId}
+                        />
+                        <InfotrygdSaker personIdent={personIdent} />
+                        <MigrerFagsak fagsakPersonId={fagsakPersonId} />
+                        <MigrerBarnetilsyn fagsakPersonId={fagsakPersonId} />
+                    </VStack>
+                </div>
             )}
         </DataViewer>
+    );
+};
+
+const TittelOgPerioder: React.FC<{
+    tittel: string;
+    visPerioder: (
+        stønadstype: Stønadstype,
+        visSummert: boolean,
+        perioder: Perioder
+    ) => React.JSX.Element;
+    stønadstype: Stønadstype;
+    visSummert: boolean;
+    perioder: Perioder;
+}> = ({ tittel, visPerioder, stønadstype, visSummert, perioder }) => {
+    return (
+        <div>
+            <Heading size={'medium'}>{tittel}</Heading>
+            {visPerioder(stønadstype, visSummert, perioder)}
+        </div>
     );
 };

--- a/src/frontend/Komponenter/Personoversikt/Infotrygdperioderoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Infotrygdperioderoversikt.tsx
@@ -26,14 +26,6 @@ const InfotrygdEllerSummertePerioder: React.FC<{
 }> = ({ perioder, fagsakPersonId }) => {
     const [visSummert, settVisSummert] = useState<boolean>(false);
 
-    const visPerioder = (stønadstype: Stønadstype, visSummert: boolean, perioder: Perioder) => {
-        return visSummert ? (
-            <SummertePerioder stønadstype={stønadstype} perioder={perioder.summert} />
-        ) : (
-            <InfotrygdPerioder stønadstype={stønadstype} perioder={perioder.perioder} />
-        );
-    };
-
     const skalViseCheckbox =
         perioder.overgangsstønad.perioder.length > 0 ||
         perioder.barnetilsyn.perioder.length > 0 ||
@@ -64,7 +56,6 @@ const InfotrygdEllerSummertePerioder: React.FC<{
 
             <TittelOgPerioder
                 tittel="Overgangsstønad"
-                visPerioder={visPerioder}
                 stønadstype={Stønadstype.OVERGANGSSTØNAD}
                 visSummert={visSummert}
                 perioder={perioder.overgangsstønad}
@@ -72,7 +63,6 @@ const InfotrygdEllerSummertePerioder: React.FC<{
 
             <TittelOgPerioder
                 tittel="Barnetilsyn"
-                visPerioder={visPerioder}
                 stønadstype={Stønadstype.BARNETILSYN}
                 visSummert={visSummert}
                 perioder={perioder.barnetilsyn}
@@ -80,7 +70,6 @@ const InfotrygdEllerSummertePerioder: React.FC<{
 
             <TittelOgPerioder
                 tittel="Skolepenger"
-                visPerioder={visPerioder}
                 stønadstype={Stønadstype.SKOLEPENGER}
                 visSummert={visSummert}
                 perioder={perioder.skolepenger}
@@ -128,15 +117,18 @@ export const Infotrygdperioderoversikt: React.FC<{
 
 const TittelOgPerioder: React.FC<{
     tittel: string;
-    visPerioder: (
-        stønadstype: Stønadstype,
-        visSummert: boolean,
-        perioder: Perioder
-    ) => React.JSX.Element;
     stønadstype: Stønadstype;
     visSummert: boolean;
     perioder: Perioder;
-}> = ({ tittel, visPerioder, stønadstype, visSummert, perioder }) => {
+}> = ({ tittel, stønadstype, visSummert, perioder }) => {
+    const visPerioder = (stønadstype: Stønadstype, visSummert: boolean, perioder: Perioder) => {
+        return visSummert ? (
+            <SummertePerioder stønadstype={stønadstype} perioder={perioder.summert} />
+        ) : (
+            <InfotrygdPerioder stønadstype={stønadstype} perioder={perioder.perioder} />
+        );
+    };
+
     return (
         <div>
             <Heading size={'medium'}>{tittel}</Heading>

--- a/src/frontend/Komponenter/Personoversikt/InntektForPerson.tsx
+++ b/src/frontend/Komponenter/Personoversikt/InntektForPerson.tsx
@@ -8,12 +8,6 @@ import styled from 'styled-components';
 import { formaterTallMedTusenSkille } from '../../App/utils/formatter';
 import { BodyShortSmall } from '../../Felles/Visningskomponenter/Tekster';
 
-const Container = styled.div`
-    width: max-content;
-    text-align: end;
-    padding: 2rem 0 0 3rem;
-`;
-
 const HøyrestiltDataCell = styled(Table.DataCell)`
     text-align: end;
 `;
@@ -48,9 +42,9 @@ const PensjonsgivendeInntektTabell: React.FC<{
 }> = ({ pensjonsgivendeInntekter }) => {
     if (pensjonsgivendeInntekter.length < 1) {
         return (
-            <Container>
+            <div>
                 <BodyShortSmall>Ingen registrert inntekt…</BodyShortSmall>
-            </Container>
+            </div>
         );
     }
 
@@ -59,7 +53,7 @@ const PensjonsgivendeInntektTabell: React.FC<{
     );
 
     return (
-        <Container>
+        <div>
             <Table size="small">
                 <Table.Header>
                     <Table.Row>
@@ -117,6 +111,6 @@ const PensjonsgivendeInntektTabell: React.FC<{
                     })}
                 </Table.Body>
             </Table>
-        </Container>
+        </div>
     );
 };

--- a/src/frontend/Komponenter/Personoversikt/PersonOversiktSide.tsx
+++ b/src/frontend/Komponenter/Personoversikt/PersonOversiktSide.tsx
@@ -13,7 +13,6 @@ import { useHentFagsakPerson } from '../../App/hooks/useHentFagsakPerson';
 import { Tabs } from '@navikt/ds-react';
 import { InntektForPerson } from './InntektForPerson';
 import { loggNavigereTabEvent } from '../../App/utils/amplitude/amplitudeLoggEvents';
-import { styled } from 'styled-components';
 import { PersonHeader } from '../../Felles/PersonHeader/PersonHeader';
 import { Personopplysninger } from './Personopplysninger';
 import { Vedtaksperioderoversikt } from './Vedtaksperioderoversikt';
@@ -21,10 +20,7 @@ import { Behandlingsoversikt } from './Behandlingsoversikt';
 import { FrittståendeBrevMedVisning } from '../Behandling/Brev/FrittståendeBrevMedVisning';
 import { Dokumenter } from './Dokumenter';
 import { OpprettFagsak } from '../Behandling/Førstegangsbehandling/OpprettFagsak';
-
-const StyledSide = styled.div`
-    padding: 0 1rem;
-`;
+import { Side } from './Side';
 
 interface FaneProps {
     label: string;
@@ -189,7 +185,7 @@ const PersonOversikt: React.FC<Props> = ({
                     ))}
                 </Tabs.List>
             </Tabs>
-            <StyledSide>
+            <Side>
                 <Routes>
                     {faner.map((fane) => (
                         <Route
@@ -213,7 +209,7 @@ const PersonOversikt: React.FC<Props> = ({
                         }
                     />
                 </Routes>
-            </StyledSide>
+            </Side>
         </>
     );
 };

--- a/src/frontend/Komponenter/Personoversikt/PersonOversiktSide.tsx
+++ b/src/frontend/Komponenter/Personoversikt/PersonOversiktSide.tsx
@@ -164,6 +164,8 @@ const PersonOversikt: React.FC<Props> = ({
     const path = paths.length ? paths[paths.length - 1] : '';
     useSetPersonIdent(personopplysninger.personIdent);
 
+    const skalHaBakgrunnsfarge = path === 'frittstaaende-brev';
+
     return (
         <>
             <PersonHeader fagsakPerson={fagsakPerson} personopplysninger={personopplysninger} />
@@ -185,7 +187,7 @@ const PersonOversikt: React.FC<Props> = ({
                     ))}
                 </Tabs.List>
             </Tabs>
-            <Side>
+            <Side skalHaBakgrunnsfarge={skalHaBakgrunnsfarge}>
                 <Routes>
                     {faner.map((fane) => (
                         <Route

--- a/src/frontend/Komponenter/Personoversikt/Side.module.css
+++ b/src/frontend/Komponenter/Personoversikt/Side.module.css
@@ -1,0 +1,5 @@
+.sideContainer {
+    margin: 0;
+    padding: 1rem;
+    /* background-color: var(--a-gray-50); */
+}

--- a/src/frontend/Komponenter/Personoversikt/Side.module.css
+++ b/src/frontend/Komponenter/Personoversikt/Side.module.css
@@ -1,5 +1,8 @@
 .sideContainer {
     margin: 0;
     padding: 1rem;
-    /* background-color: var(--a-gray-50); */
+}
+
+.bakgrunnsfarge {
+    background-color: #fafafa;
 }

--- a/src/frontend/Komponenter/Personoversikt/Side.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Side.tsx
@@ -3,6 +3,15 @@ import styles from './Side.module.css';
 
 export const Side: FC<{
     children?: React.ReactNode;
-}> = ({ children }) => {
-    return <div className={styles.sideContainer}>{children}</div>;
+    skalHaBakgrunnsfarge?: boolean;
+}> = ({ children, skalHaBakgrunnsfarge }) => {
+    return (
+        <div
+            className={
+                styles.sideContainer + (skalHaBakgrunnsfarge ? ` ${styles.bakgrunnsfarge}` : '')
+            }
+        >
+            {children}
+        </div>
+    );
 };

--- a/src/frontend/Komponenter/Personoversikt/Side.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Side.tsx
@@ -1,0 +1,8 @@
+import React, { FC } from 'react';
+import styles from './Side.module.css';
+
+export const Side: FC<{
+    children?: React.ReactNode;
+}> = ({ children }) => {
+    return <div className={styles.sideContainer}>{children}</div>;
+};

--- a/src/frontend/Komponenter/Personoversikt/Utestengelse/Utestengelse.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Utestengelse/Utestengelse.tsx
@@ -1,7 +1,6 @@
 import React, { FC, useState } from 'react';
 import { Button, Heading, Table } from '@navikt/ds-react';
 import { formaterIsoDato, formaterIsoSisteDagIMåneden } from '../../../App/utils/formatter';
-import styled from 'styled-components';
 import { useApp } from '../../../App/context/AppContext';
 import { UtestengelseModal } from './UtestengelseModal';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
@@ -9,19 +8,6 @@ import { IUtestengelse } from '../../../App/typer/utestengelse';
 import { Ressurs } from '../../../App/typer/ressurs';
 import { Hamburgermeny } from '../../../Felles/Hamburgermeny/Hamburgermeny';
 import { SlettUtestengelseModal } from './SlettUtestengelseModal';
-
-const StyledTable = styled(Table)`
-    width: 18rem;
-    margin-left: 1rem;
-`;
-
-const UtestengelseContainer = styled.div`
-    margin-top: 4rem;
-`;
-
-const Knapp = styled(Button)`
-    margin-top: 0.5rem;
-`;
 
 const UtestengelseTabell: FC<{
     utestengelser: Ressurs<IUtestengelse[]>;
@@ -35,7 +21,7 @@ const UtestengelseTabell: FC<{
                     return null;
                 }
                 return (
-                    <StyledTable size={'small'}>
+                    <Table size={'small'} style={{ width: 'fit-content' }}>
                         <Table.Header>
                             <Table.Row>
                                 <Table.ColumnHeader>Fra</Table.ColumnHeader>
@@ -74,7 +60,7 @@ const UtestengelseTabell: FC<{
                                 );
                             })}
                         </Table.Body>
-                    </StyledTable>
+                    </Table>
                 );
             }}
         </DataViewer>
@@ -91,8 +77,8 @@ const Utestengelse: FC<{
     const [utestengelseTilSletting, settUtestengelseTilSletting] = useState<IUtestengelse>();
 
     return (
-        <UtestengelseContainer>
-            <Heading level="3" size="medium">
+        <>
+            <Heading size={'small'} level="3">
                 Utestengelser
             </Heading>
             <UtestengelseTabell
@@ -102,13 +88,15 @@ const Utestengelse: FC<{
             />
 
             {erSaksbehandler && (
-                <Knapp
-                    variant={'secondary'}
-                    onClick={() => settVisUtestengModal(true)}
-                    type={'button'}
-                >
-                    Legg til utestengelse
-                </Knapp>
+                <div>
+                    <Button
+                        variant={'secondary'}
+                        onClick={() => settVisUtestengModal(true)}
+                        type={'button'}
+                    >
+                        Legg til utestengelse
+                    </Button>
+                </div>
             )}
             <UtestengelseModal
                 fagsakPersonId={fagsakPersonId}
@@ -120,7 +108,7 @@ const Utestengelse: FC<{
                 fjernUtestengelseTilSletting={() => settUtestengelseTilSletting(undefined)}
                 hentUtestengelser={hentUtestengelser}
             />
-        </UtestengelseContainer>
+        </>
     );
 };
 

--- a/src/frontend/Komponenter/Personoversikt/Vedtaksperioder/ValgteStønaderCheckbox.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Vedtaksperioder/ValgteStønaderCheckbox.tsx
@@ -20,6 +20,7 @@ const ValgteStønaderCheckbox: FC<{
     return (
         <HStack gap={'4'}>
             <CheckboxGroup
+                size="small"
                 legend=""
                 hideLegend
                 disabled={!harBehandling(stønaderMedBehandling, ValgtStønad.OVERGANGSSTØNAD)}
@@ -29,6 +30,7 @@ const ValgteStønaderCheckbox: FC<{
                 <Checkbox value="overgangsstønad">Overgangsstønad</Checkbox>
             </CheckboxGroup>
             <CheckboxGroup
+                size="small"
                 legend=""
                 hideLegend
                 disabled={!harBehandling(stønaderMedBehandling, ValgtStønad.BARNETILSYN)}
@@ -38,6 +40,7 @@ const ValgteStønaderCheckbox: FC<{
                 <Checkbox value="barnetilsyn">Barnetilsyn</Checkbox>
             </CheckboxGroup>
             <CheckboxGroup
+                size="small"
                 legend=""
                 hideLegend
                 disabled={!harBehandling(stønaderMedBehandling, ValgtStønad.SKOLEPENGER)}

--- a/src/frontend/Komponenter/Personoversikt/Vedtaksperioder/VedtaksperioderOSBT.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Vedtaksperioder/VedtaksperioderOSBT.tsx
@@ -17,7 +17,7 @@ export const Container = styled(VStack)`
     border: 1px solid #efefef;
     background-color: #f9f9f9;
     width: 100%;
-    padding: 0.5rem;
+    padding: 1rem;
 `;
 
 interface VedtaksperioderProps {

--- a/src/frontend/Komponenter/Personoversikt/Vedtaksperioderoversikt.tsx
+++ b/src/frontend/Komponenter/Personoversikt/Vedtaksperioderoversikt.tsx
@@ -13,7 +13,7 @@ export const Vedtaksperioderoversikt: React.FC<{ fagsakPerson: FagsakPerson }> =
     const [valgteStønader, settValgteStønader] = useState<ValgtStønad[]>(defaultValgteStønader);
 
     return (
-        <HStack gap="8">
+        <HStack gap="space-4">
             <ValgteStønaderCheckbox
                 valgteStønader={valgteStønader}
                 settValgteStønader={settValgteStønader}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Ønsker at side på ef-sak skal ha mer konsekvent styling. Har derfor laget en komponent som "Side" som skal brukes for å wrapper sider slik at det blir mer likt med padding/margin.

- Fjernet styled components underveis.
- Refaktorert BrevMenyDelmal slik at styling ble enklere.
- Lagt til optional farge på Side. Før var det elementer lenger ned som satte farge, men da kunne margin/padding påvirke dette.
- Styled brevbygger litt mer moderne.


Før:
![image](https://github.com/user-attachments/assets/1df85f3e-c070-4f80-85d2-13465700b304)
Etter:
![image](https://github.com/user-attachments/assets/079251d6-60b6-4f52-8f95-990a7b7db4b1)

Før:
![image](https://github.com/user-attachments/assets/2c229f14-5f1b-4855-ae9e-8353d1294bda)
Etter:
![image](https://github.com/user-attachments/assets/f3864ef4-0229-4791-8695-2a38cd0ba3a9)
