### PR TITLE
Knapp havnet bak editor og ble derfor ikke mulig å trykke på

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
@@ -149,7 +149,7 @@ export const BrevMenyDelmal: React.FC<Props> = ({
                     </Button>
                 </HStack>
                 {ekspanderbartPanelÅpen && (
-                    <VStack gap={'2'} style={{ padding: '1rem' }}>
+                    <VStack gap={'4'} style={{ padding: '1rem' }}>
                         {erDelmalblokk &&
                             delmalValgfelt &&
                             delmalValgfelt.map((valgFelt, index) => (
@@ -203,7 +203,7 @@ export const BrevMenyDelmal: React.FC<Props> = ({
                                         oppdaterOverstyrtInnhold(delmal, nyttInnhold);
                                     }}
                                 />
-                                <div>
+                                <div style={{ marginTop: '2rem' }}>
                                     <Button
                                         onClick={() => overstyring.konverterTilDelmalblokk(delmal)}
                                         size={'small'}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Slik ser det ut når knappen ikke er mulig å trykke på
![Screenshot 2025-07-09 at 10 33 25](https://github.com/user-attachments/assets/30a6a611-42ac-43bd-ac54-86bf52f37208)

Med denne fixen legges knappen under editor, slik at editor ikke ligger over og gjør knappen uklikkbar:
![Screenshot 2025-07-09 at 10 38 31](https://github.com/user-attachments/assets/f5984387-58fd-4050-bc4a-f71733fa32f6)

I følge internett er dette typisk noe som skjer med Quill-editor som har absolutte posisjoneringer og høy z-indeks.

Gjerne gi beskjed eller forslag til forbedring, dersom det finnes penere måter å løse dette på. Fikk ikke til å løse problemet med å øke vstack-gap.