### PR TITLE
Legger tilbake "FULLMAKT" i EBrevmottakerRolle

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brevmottakere/brevmottakerUtils.ts
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/brevmottakerUtils.ts
@@ -10,7 +10,7 @@ export const vergemålTilBrevmottaker = (vergemål: IVergemål): IBrevmottaker =
 export const fullmaktTilBrevMottaker = (fullmakt: IFullmakt): IBrevmottaker => ({
     navn: fullmakt.navn || '',
     personIdent: fullmakt.motpartsPersonident,
-    mottakerRolle: EBrevmottakerRolle.FULLMEKTIG,
+    mottakerRolle: EBrevmottakerRolle.FULLMEKTIG || EBrevmottakerRolle.FULLMAKT,
 });
 
 export const mottakereEllerBruker = (

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/typer.ts
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/typer.ts
@@ -19,4 +19,5 @@ export enum EBrevmottakerRolle {
     BRUKER = 'BRUKER',
     VERGE = 'VERGE',
     FULLMEKTIG = 'FULLMEKTIG',
+    FULLMAKT = 'FULLMAKT',
 }


### PR DESCRIPTION
# Legger tilbake "FULLMAKT" i EBrevmottakerRolle

### Hvorfor er denne endringen nødvendig? ✨ 

Loggene viser at en saksbehandler har sendt en sak til beslutter, der vi nå fikk en feil. Det virker som at enkelte behandlinger fortsatt har den tidligere tiltenkt ubrukte verdien "FULLMAKT".

Eksempel:

`Caused by: com.fasterxml.jackson.databind.exc.InvalidFormatException: Cannot deserialize value of type `no.nav.familie.ef.sak.brev.domain.MottakerRolle` from String "FULLMAKT": not one of the values accepted for Enum class: [VERGE, BRUKER, FULLMEKTIG]`

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-25725).

Det var tidligere gjort i denne [PRen](https://github.com/navikt/familie-ef-sak-frontend/pull/3123).

Denne PRen er en del av en bredre oppgave og depender på denne → [PRen](https://github.com/navikt/familie-ef-sak/pull/2954).

### Verdt å nevne

Har ikke testet noe spesielt, men har snakket med fagressurs som har vært i dialog med saksbehandler og håpet er at saksbehandler kan prøve på nytt med behandlingen. 