### PR TITLE
Vise antall mnd innvilget vedtakside barnetilsyn

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/UtgiftsperiodeValg.tsx
@@ -43,7 +43,7 @@ const Grid = styled.div<{ $lesevisning?: boolean }>`
     display: grid;
     grid-template-columns: ${(props) =>
         props.$lesevisning
-            ? 'repeat(7, max-content)'
+            ? 'repeat(8, max-content)'
             : '9rem 9rem repeat(2, max-content) 20rem 2rem 4rem repeat(2, max-content)'};
     grid-gap: 0.5rem 1rem;
     margin-bottom: 0.5rem;

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/UtgiftsperiodeValg.tsx
@@ -58,7 +58,6 @@ const SentrertBodySort = styled(BodyShortSmall)`
     display: flex;
     justify-content: center;
     align-items: center;
-    margin-top: 0.75rem;
 `;
 
 const BarnVelger = styled(FamilieReactSelect)`

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/UtgiftsperiodeValg.tsx
@@ -197,7 +197,6 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
                     <Label>Aktivitet</Label>
                     <Label>Periode fra og med</Label>
                     <Label>Periode til og med</Label>
-                    <Label> </Label>
                     <Label>Velg barn</Label>
                     <Label>Ant.</Label>
                     <Label>Utgifter</Label>

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/UtgiftsperiodeValg.tsx
@@ -17,7 +17,7 @@ import { FamilieReactSelect, ISelectOption } from '@navikt/familie-form-elements
 import { harTallverdi, tilHeltall, tilTallverdi } from '../../../../../App/utils/utils';
 import InputMedTusenSkille from '../../../../../Felles/Visningskomponenter/InputMedTusenskille';
 import { IBarnMedSamvær } from '../../../Inngangsvilkår/Aleneomsorg/typer';
-import { datoTilAlder } from '../../../../../App/utils/dato';
+import { datoTilAlder, kalkulerAntallMåneder } from '../../../../../App/utils/dato';
 import { Heading, Label, Tooltip } from '@navikt/ds-react';
 import FjernKnapp from '../../../../../Felles/Knapper/FjernKnapp';
 import { BodyShortSmall } from '../../../../../Felles/Visningskomponenter/Tekster';
@@ -212,6 +212,7 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
                         const antallBarn = utgiftsperioderState.value[index].barn
                             ? utgiftsperioderState.value[index].barn?.length
                             : 0;
+                        const antallMåneder = kalkulerAntallMåneder(årMånedFra, årMånedTil);
                         return (
                             <React.Fragment key={utgiftsperiode.endretKey}>
                                 <PeriodetypeSelect
@@ -259,6 +260,11 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
                                     }
                                     disabledFra={index === 0 && låsFraDatoFørsteRad}
                                 />
+                                <Label
+                                    style={{ marginTop: behandlingErRedigerbar ? '0.65rem' : 0 }}
+                                >
+                                    {antallMåneder && `${antallMåneder} mnd`}
+                                </Label>
                                 {behandlingErRedigerbar && !opphørEllerSanksjon ? (
                                     <BarnVelger
                                         placeholder={'Velg barn'}

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/UtgiftsperiodeValg.tsx
@@ -197,7 +197,7 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
                     <Label>Aktivitet</Label>
                     <Label>Periode fra og med</Label>
                     <Label>Periode til og med</Label>
-                    <Label>Antall måneder </Label>
+                    <Label> </Label>
                     <Label>Velg barn</Label>
                     <Label>Ant.</Label>
                     <Label>Utgifter</Label>

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/UtgiftsperiodeValg.tsx
@@ -54,10 +54,11 @@ const Grid = styled.div<{ $lesevisning?: boolean }>`
     }
 `;
 
-const SentrertBodySort = styled(BodyShortSmall)`
+const SentrertBodySort = styled(BodyShortSmall)<{ $lesevisning?: boolean }>`
     display: flex;
     justify-content: center;
     align-items: center;
+    margin-top: ${(props) => (props.$lesevisning ? '' : '0.75rem')};
 `;
 
 const BarnVelger = styled(FamilieReactSelect)`
@@ -310,7 +311,9 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
                                 {opphørEllerSanksjon ? (
                                     <div />
                                 ) : (
-                                    <SentrertBodySort>{antallBarn}</SentrertBodySort>
+                                    <SentrertBodySort $lesevisning={!behandlingErRedigerbar}>
+                                        {antallBarn}
+                                    </SentrertBodySort>
                                 )}
                                 {opphørEllerSanksjon ? (
                                     <div />

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/UtgiftsperiodeValg.tsx
@@ -197,6 +197,7 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
                     <Label>Aktivitet</Label>
                     <Label>Periode fra og med</Label>
                     <Label>Periode til og med</Label>
+                    <Label> </Label>
                     <Label>Velg barn</Label>
                     <Label>Ant.</Label>
                     <Label>Utgifter</Label>

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/UtgiftsperiodeValg.tsx
@@ -44,7 +44,7 @@ const Grid = styled.div<{ $lesevisning?: boolean }>`
     grid-template-columns: ${(props) =>
         props.$lesevisning
             ? 'repeat(8, max-content)'
-            : '9rem 9rem repeat(2, max-content) 20rem 2rem 4rem repeat(2, max-content)'};
+            : '9rem 9rem repeat(3, max-content) 20rem 2rem 4rem repeat(2, max-content)'};
     grid-gap: 0.5rem 1rem;
     margin-bottom: 0.5rem;
     align-items: start;
@@ -197,7 +197,7 @@ const UtgiftsperiodeValg: React.FC<Props> = ({
                     <Label>Aktivitet</Label>
                     <Label>Periode fra og med</Label>
                     <Label>Periode til og med</Label>
-                    <Label> </Label>
+                    <Label>Antall måneder </Label>
                     <Label>Velg barn</Label>
                     <Label>Ant.</Label>
                     <Label>Utgifter</Label>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Legger til antall måneder saksbehandler har lagt inn på vedtakssiden, ref [denne](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-25981) favro-oppgaven.

Redigeringsmodus:
<img width="1245" height="305" alt="image" src="https://github.com/user-attachments/assets/f93a238a-0d72-4c54-81ab-c09e5d785d98" />

Lesevisning:
<img width="888" height="246" alt="image" src="https://github.com/user-attachments/assets/e0f19e1f-0237-43a8-8dd1-18d13373356d" />
