### PR TITLE
Vil ta bort styled components på personopplysningssiden og bruke akse…

### DIFF
--- a/src/frontend/Felles/Personopplysninger/PersonopplysningPanel.module.css
+++ b/src/frontend/Felles/Personopplysninger/PersonopplysningPanel.module.css
@@ -1,5 +1,0 @@
-.panel {
-    border: 1px solid var(--a-gray-100);
-    background-color: var(--a-bg-subtle);
-    padding: 1rem;
-}

--- a/src/frontend/Felles/Personopplysninger/PersonopplysningPanel.module.css
+++ b/src/frontend/Felles/Personopplysninger/PersonopplysningPanel.module.css
@@ -1,5 +1,5 @@
 .panel {
-    border: 1px solid #efefef;
-    background-color: #f9f9f9;
+    border: 1px solid var(--a-gray-100);
+    background-color: var(--a-bg-subtle);
     padding: 1rem;
 }

--- a/src/frontend/Felles/Personopplysninger/PersonopplysningPanel.tsx
+++ b/src/frontend/Felles/Personopplysninger/PersonopplysningPanel.tsx
@@ -1,6 +1,5 @@
-import { BodyShort, Heading, HStack, ReadMore, VStack } from '@navikt/ds-react';
+import { BodyShort, Heading, HStack, ReadMore, VStack, Box } from '@navikt/ds-react';
 import React, { ReactNode } from 'react';
-import styles from './PersonopplysningPanel.module.css';
 
 const PersonopplysningerPanel: React.FC<{
     Ikon: React.FC;
@@ -9,7 +8,12 @@ const PersonopplysningerPanel: React.FC<{
     children?: ReactNode;
 }> = ({ Ikon, tittel, children, tittelBeskrivelse }) => {
     return (
-        <div className={styles.panel}>
+        <Box
+            padding={'space-16'}
+            borderColor={'border-on-inverted'}
+            background={'bg-subtle'}
+            borderWidth={'1'}
+        >
             <HStack gap="4" align="center">
                 <Ikon />
                 <Heading size="small" className="tittel">
@@ -31,7 +35,7 @@ const PersonopplysningerPanel: React.FC<{
                     {children}
                 </VStack>
             )}
-        </div>
+        </Box>
     );
 };
 

--- a/src/frontend/Felles/Personopplysninger/PersonopplysningPanel.tsx
+++ b/src/frontend/Felles/Personopplysninger/PersonopplysningPanel.tsx
@@ -1,29 +1,6 @@
-import { BodyShort, Heading, ReadMore } from '@navikt/ds-react';
+import { BodyShort, Heading, HStack, ReadMore, VStack } from '@navikt/ds-react';
 import React, { ReactNode } from 'react';
-import styled from 'styled-components';
 import styles from './PersonopplysningPanel.module.css';
-
-const TittelMedIkon = styled.div`
-    display: flex;
-    gap: 1rem;
-    align-items: center;
-`;
-
-const IkonWrapper = styled.div`
-    display: flex;
-    justify-content: center;
-`;
-
-const InnholdWrapper = styled.div`
-    padding-left: 1.75rem;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-`;
-
-const ReadMoreMedMarginLeft = styled(ReadMore)`
-    padding-left: 2.5rem;
-`;
 
 const PersonopplysningerPanel: React.FC<{
     Ikon: React.FC;
@@ -33,21 +10,27 @@ const PersonopplysningerPanel: React.FC<{
 }> = ({ Ikon, tittel, children, tittelBeskrivelse }) => {
     return (
         <div className={styles.panel}>
-            <TittelMedIkon className="ikon">
-                <IkonWrapper>
-                    <Ikon />
-                </IkonWrapper>
+            <HStack gap="4" align="center">
+                <Ikon />
                 <Heading size="small" className="tittel">
                     {tittel}
                 </Heading>
                 {!children && <BodyShort size="small">(Ingen data)</BodyShort>}
-            </TittelMedIkon>
+            </HStack>
             {tittelBeskrivelse && (
-                <ReadMoreMedMarginLeft size="small" header={tittelBeskrivelse.header}>
+                <ReadMore
+                    style={{ paddingLeft: '2.5rem' }}
+                    size="small"
+                    header={tittelBeskrivelse.header}
+                >
                     {tittelBeskrivelse.innhold}
-                </ReadMoreMedMarginLeft>
+                </ReadMore>
             )}
-            {children && <InnholdWrapper>{children}</InnholdWrapper>}
+            {children && (
+                <VStack style={{ paddingLeft: '1.75rem' }} gap="4">
+                    {children}
+                </VStack>
+            )}
         </div>
     );
 };


### PR DESCRIPTION
…l hvis mulig.

**Ting vi kan diskutere:* 

1.
Bildet under viser at bg i .panel har blitt litt mørkere. Hva tenker vi om det? 
Fortsette å hardkode: background-color: #f9f9f9? Kan være med på at det er litt penere. 

Men, jeg vil gjerne bruke akseldefinerte farger hvis mulig. Jeg finner ingen grå som er så lys i aksel her: https://aksel.nav.no/grunnleggende/styling/design-tokens#afff774dad80

2.
Kunne også byttet ut panel-div med <Box> fra aksel, men her fikk jeg noen warnings på "manglende fil" på background - fiks virket hacky: 

<Box
            padding="space-16"
            borderColor="border-on-inverted"
            background={'bg-subtle'}
            borderWidth="1"
        >

<img width="533" height="181" alt="image" src="https://github.com/user-attachments/assets/3a4bfe27-6b9b-435a-8cbc-c2dc73693598" />

3.
Har også lagt "one liners" inn som inline style, f.eks : style={{ paddingLeft: '2.5rem' }}.  

**Eksempler på fargeendring:**

<img width="1176" height="803" alt="image" src="https://github.com/user-attachments/assets/6441e6a9-c68f-4dae-8d29-15209f55d544" />

<img width="1409" height="677" alt="image" src="https://github.com/user-attachments/assets/7e56eb8b-1fa0-49d2-bfe5-3c16788d857e" />
