### PR TITLE
Vil fjerne de siste styled-components under .../personopplysninger

### DIFF
--- a/src/frontend/Felles/Personopplysninger/Beboere.tsx
+++ b/src/frontend/Felles/Personopplysninger/Beboere.tsx
@@ -1,16 +1,12 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { IPersonFraSøk, ISøkeresultatPerson } from '../../App/typer/personopplysninger';
+import { ISøkeresultatPerson } from '../../App/typer/personopplysninger';
 import { useApp } from '../../App/context/AppContext';
 import { byggTomRessurs, Ressurs, RessursFeilet, RessursStatus } from '../../App/typer/ressurs';
 import DataViewer from '../DataViewer/DataViewer';
 import SystemetLaster from '../SystemetLaster/SystemetLaster';
-import { Table } from '@navikt/ds-react';
-import { styled } from 'styled-components';
-import { nullableDatoTilAlder } from '../../App/utils/dato';
+import { BodyShort, Table } from '@navikt/ds-react';
 
-const StyledDataCell = styled(Table.DataCell)<{ person: IPersonFraSøk }>`
-    font-weight: ${(props) => (props.person.erSøker || props.person.erBarn ? 'bold' : 'normal')};
-`;
+import { nullableDatoTilAlder } from '../../App/utils/dato';
 
 const Beboere: React.FC<{
     fagsakPersonId: string;
@@ -57,11 +53,19 @@ const Beboere: React.FC<{
                             </Table.Header>
                             <Table.Body>
                                 {søkResultat.personer.map((beboer) => {
+                                    const vektHvisBarnEllerSøker =
+                                        beboer.erSøker || beboer.erBarn ? 'semibold' : 'regular';
+
                                     return (
                                         <Table.Row key={beboer.personIdent}>
-                                            <StyledDataCell person={beboer} textSize={'small'}>
-                                                {`${beboer.visningsnavn} ${beboer.fødselsdato ? `(${nullableDatoTilAlder(beboer.fødselsdato)})` : ''}`}
-                                            </StyledDataCell>
+                                            <Table.DataCell textSize={'small'}>
+                                                <BodyShort
+                                                    weight={vektHvisBarnEllerSøker}
+                                                    size={'small'}
+                                                >
+                                                    {`${beboer.visningsnavn} ${beboer.fødselsdato ? `(${nullableDatoTilAlder(beboer.fødselsdato)})` : ''}`}
+                                                </BodyShort>
+                                            </Table.DataCell>
                                             <Table.DataCell textSize={'small'}>
                                                 {beboer.personIdent}
                                             </Table.DataCell>

--- a/src/frontend/Felles/Personopplysninger/InnflyttingUtflytting.tsx
+++ b/src/frontend/Felles/Personopplysninger/InnflyttingUtflytting.tsx
@@ -3,8 +3,7 @@ import { IInnflyttingTilNorge, IUtflyttingFraNorge } from '../../App/typer/perso
 import { KolonneTitler, SmallTable } from './TabellWrapper';
 import FlyMedSky from '../Ikoner/FlyMedSky';
 import { formaterNullableIsoDato, formaterNullableIsoÅr } from '../../App/utils/formatter';
-import styled from 'styled-components';
-import { HelpText, Label, Table } from '@navikt/ds-react';
+import { HelpText, HStack, Label, Table } from '@navikt/ds-react';
 import PersonopplysningerPanel from './PersonopplysningPanel';
 
 interface Props {
@@ -12,14 +11,8 @@ interface Props {
     utflyttinger: IUtflyttingFraNorge[];
 }
 
-const FlexBoxCenter = styled.div`
-    display: flex;
-    gap: 1rem;
-    align-items: center;
-`;
-
 export const headerForInnflyttingTabell: React.ReactNode = (
-    <FlexBoxCenter>
+    <HStack gap="4" align="center">
         <Label size="small">Innflyttet år</Label>
         <HelpText>
             Innflyttet år er basert på Folkeregisteret sitt gyldighetstidspunktet for innflytting.
@@ -27,7 +20,7 @@ export const headerForInnflyttingTabell: React.ReactNode = (
             virkeligheten. Dersom man skal finne ut når en innflytting gjelder fra må man se på
             andre opplysninger, f.eks. den norske bostedsadressens fra-dato.
         </HelpText>
-    </FlexBoxCenter>
+    </HStack>
 );
 
 const InnflyttingUtflytting: React.FC<Props> = ({ innflyttinger, utflyttinger }) => {
@@ -59,11 +52,14 @@ const InnflyttingUtflytting: React.FC<Props> = ({ innflyttinger, utflyttinger })
 const Innflytting: React.FC<{ innflyttinger: IInnflyttingTilNorge[] }> = ({ innflyttinger }) => {
     return (
         <SmallTable>
-            <KolonneTitler titler={['Innflyttet fra', headerForInnflyttingTabell, '', '']} />
+            <KolonneTitler
+                titler={['Innflyttet fra', headerForInnflyttingTabell]}
+                minimumbredde="12rem"
+            />
             <Table.Body>
                 {innflyttinger.map((innflytting, indeks) => {
                     return (
-                        <tr key={indeks}>
+                        <Table.Row key={indeks}>
                             <Table.DataCell>
                                 {innflytting.fraflyttingsland +
                                     (innflytting.fraflyttingssted
@@ -73,9 +69,7 @@ const Innflytting: React.FC<{ innflyttinger: IInnflyttingTilNorge[] }> = ({ innf
                             <Table.DataCell>
                                 {formaterNullableIsoÅr(innflytting.dato)}
                             </Table.DataCell>
-                            <Table.DataCell />
-                            <Table.DataCell />
-                        </tr>
+                        </Table.Row>
                     );
                 })}
             </Table.Body>
@@ -86,11 +80,11 @@ const Innflytting: React.FC<{ innflyttinger: IInnflyttingTilNorge[] }> = ({ innf
 const Utflytting: React.FC<{ utflyttinger: IUtflyttingFraNorge[] }> = ({ utflyttinger }) => {
     return (
         <SmallTable>
-            <KolonneTitler titler={['Utflyttet til', 'Utflyttingsdato', '', '']} />
+            <KolonneTitler titler={['Utflyttet til', 'Utflyttingsdato']} minimumbredde="12rem" />
             <Table.Body>
                 {utflyttinger.map((utflytting, indeks) => {
                     return (
-                        <tr key={indeks}>
+                        <Table.Row key={indeks}>
                             <Table.DataCell>
                                 {utflytting.tilflyttingsland +
                                     (utflytting.tilflyttingssted
@@ -100,9 +94,7 @@ const Utflytting: React.FC<{ utflyttinger: IUtflyttingFraNorge[] }> = ({ utflytt
                             <Table.DataCell>
                                 {formaterNullableIsoDato(utflytting.dato)}
                             </Table.DataCell>
-                            <Table.DataCell />
-                            <Table.DataCell />
-                        </tr>
+                        </Table.Row>
                     );
                 })}
             </Table.Body>

--- a/src/frontend/Felles/Personopplysninger/TabellWrapper.tsx
+++ b/src/frontend/Felles/Personopplysninger/TabellWrapper.tsx
@@ -13,9 +13,14 @@ type Kolonnetittel = string | React.ReactNode;
 export const KolonneTitler: React.FC<{
     titler: Kolonnetittel[];
     skalHaMinimumBreddePåKolonne?: boolean;
-}> = ({ titler, skalHaMinimumBreddePåKolonne = false }) => {
+    minimumbredde?: string;
+}> = ({ titler, skalHaMinimumBreddePåKolonne = false, minimumbredde = undefined }) => {
     const minimumBreddePåDatoStyle = (tittel: Kolonnetittel) => {
-        return tittel === 'Dato' && skalHaMinimumBreddePåKolonne ? { minWidth: '10rem' } : {};
+        if (minimumbredde !== undefined) {
+            return { minWidth: minimumbredde };
+        } else {
+            return tittel === 'Dato' && skalHaMinimumBreddePåKolonne ? { minWidth: '10rem' } : {};
+        }
     };
 
     return (


### PR DESCRIPTION
Før/nå helt like: 
<img width="717" height="231" alt="UTTRYKKSFULL SLEKTNING 25429436896" src="https://github.com/user-attachments/assets/d478d7b2-c9f4-4a2b-b5e1-2715ff278ea9" />
<img width="730" height="200" alt="Beboere" src="https://github.com/user-attachments/assets/d006e7ae-44b8-4f6e-8caf-874851d3ab8e" />

Nå La på minWidth på tabell, fjernet unødvendlige kolonner (?) og byttet ut FlexBoxCenter med HStack: 
<img width="575" height="255" alt="Innflyttet fra" src="https://github.com/user-attachments/assets/b59593d9-8cc9-403f-9c4c-9d1c42a1cff8" />
Før:
<img width="508" height="227" alt="Innflyttet fra" src="https://github.com/user-attachments/assets/87c97832-3e8d-4309-8849-79778427e625" />

