### PR TITLE
Styled components aktivitet/annet

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Frontend app for enslig forsørger saksbehandling (overgangsstønad)
 
 # Kom i gang med utvikling
 
--   Installere avhengigheter `yarn`
--   Starte dev-server `yarn start:dev`
--   Starte mock-server `yarn start:mock`
--   Åpne `http://localhost:8000` i nettleseren din
+- Installere avhengigheter `yarn`
+- Starte dev-server `yarn start:dev`
+- Starte mock-server `yarn start:mock`
+- Åpne `http://localhost:8000` i nettleseren din
 
 For å kunne installere avhengigheter fra navikt registry må man være logget inn i github packages. Kjør kommando:
 `npm login --scope=@navikt --registry=https://npm.pkg.github.com`
@@ -35,7 +35,8 @@ Appen krever en del environment variabler og legges til i .env fila i root på p
     AZURE_APP_WELL_KNOWN_URL='<AZURE_APP_WELL_KNOWN_URL fra secret>'
 ```
 
-Secrets kan bli lagt inn automatisk dersom man kjører `sh hent-og-lagre-miljøvariabler.sh`. Scriptet krever at du har `jq`, er pålogget naisdevice og er logget inn på google `gcloud auth login`)
+Secrets kan bli lagt inn automatisk dersom man kjører `sh hent-og-lagre-miljøvariabler.sh`. Scriptet krever at du har
+`jq`, er pålogget naisdevice og er logget inn på google `gcloud auth login`)
 
 Secrets kan også hentes selv fra cluster med
 `kubectl -n teamfamilie get secret azuread-familie-ef-sak-frontend-lokal -o json | jq '.data | map_values(@base64d)'`
@@ -55,30 +56,37 @@ ENV=lokalt-mot-preprod
 EF_SAK_SCOPE=api://dev-gcp.teamfamilie.familie-ef-sak/.default
 ```
 
-For å bygge prodversjon kjør `yarn build`. Prodversjonen vil ikke kjøre lokalt med mindre det gjøres en del endringer i forbindelse med uthenting av environment variabler og URLer for uthenting av informasjon.
+For å bygge prodversjon kjør `yarn build`. Prodversjonen vil ikke kjøre lokalt med mindre det gjøres en del endringer i
+forbindelse med uthenting av environment variabler og URLer for uthenting av informasjon.
 
 ## Installere @navikt-pakker lokalt
 
 For å installere @navikt-scopede pakker må du autentisere deg med et PAT.
 
-1. Opprett et Personal Access Token. Token genererer du under developer settings på Github. Den trenger kun read:packages. Husk å enable SSO for navikt-orgen.
-2. Skriv `npm login --scope=@navikt --registry=https://npm.pkg.github.com` i terminalen (obs, windows-syntaksen er litt annerledes - mellomrom heller enn =)
+1. Opprett et Personal Access Token. Token genererer du under developer settings på Github. Den trenger kun read:
+   packages. Husk å enable SSO for navikt-orgen.
+2. Skriv `npm login --scope=@navikt --registry=https://npm.pkg.github.com` i terminalen (obs, windows-syntaksen er litt
+   annerledes - mellomrom heller enn =)
 3. Skriv inn eposten din og brukernavnet ditt. Passordet er tokenet fra github
 
 ## Testing
 
 Appen benytter [vitest](https://vitest.dev/) til enhetstesting. Legg gjerne til nye tester etter oppdateringer av appen.
-For å kjøre opp tester lokalt kan man kjøre `yarn test`. For å kjøre opp testene i interaktiv modus kan man kjøre `vitest`.
+For å kjøre opp tester lokalt kan man kjøre `yarn test`. For å kjøre opp testene i interaktiv modus kan man kjøre
+`vitest`.
 
 # Mens du koder
 
-I Team Familie har vi et internt [felles frontend-bibliotek](https://github.com/navikt/familie-felles-frontend) for komponenter som kan brukes på tvers av appene våre. Lager man noe som kan senere gjenbrukes, er det fint om disse trekkes ut hit.
+I Team Familie har vi et internt [felles frontend-bibliotek](https://github.com/navikt/familie-felles-frontend) for
+komponenter som kan brukes på tvers av appene våre. Lager man noe som kan senere gjenbrukes, er det fint om disse
+trekkes ut hit.
 
-Ta gjerne en titt på Team Familie sin [readme](https://github.com/navikt/familie) med best practices når det kommer til frontendutvikling, uu og bruken av styled-components!
+Ta gjerne en titt på Team Familie sin [readme](https://github.com/navikt/familie) med best practices når det kommer til
+frontendutvikling, uu og bruken av styled-components!
 
 # Bygg og deploy
 
-Appen bygges på github actions, og gir beskjed til nais deploy om å deployere appen i fss området. Alle pull requester går til dev miljøet og main går til produksjon og dev-miljøet.
+Appen bygges på github actions, og deployes til gcp. Merge til main vil deploye app til produksjon og dev.
 
 # Henvendelser
 

--- a/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/Aktivitet.module.css
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/Aktivitet.module.css
@@ -1,0 +1,4 @@
+.annetListe {
+    margin: 0;
+    padding-left: 1rem;
+}

--- a/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/Annet.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/Annet.tsx
@@ -1,27 +1,21 @@
 import React, { FC } from 'react';
 import { ISærligeTilsynsbehov } from '../../../../App/typer/aktivitetstyper';
-import styled from 'styled-components';
 import { Søknadsgrunnlag } from '../../../../Felles/Ikoner/DataGrunnlagIkoner';
 import { DinSituasjonTilTekst, EDinSituasjon } from './typer';
 import { formaterNullableIsoDato } from '../../../../App/utils/formatter';
-import { BodyLong, HelpText } from '@navikt/ds-react';
+import { BodyLong, HelpText, HStack } from '@navikt/ds-react';
 import { BodyShortSmall } from '../../../../Felles/Visningskomponenter/Tekster';
 import { InfoSeksjonWrapper } from '../../Vilkårpanel/VilkårInformasjonKomponenter';
 import Informasjonsrad from '../../Vilkårpanel/Informasjonsrad';
 import { FlexColumnContainer } from '../../Vilkårpanel/StyledVilkårInnhold';
-
-const StyledList = styled.ul`
-    list-style-type: square;
-    margin: 0;
-    padding-left: 1rem;
-`;
+import styles from './Aktivitet.module.css';
 
 const hjelpetekst = (
     <ul>
         <BodyLong>
             Mulig alternativer i søknadsdialog:
             <li>Jeg er syk</li>
-            <li>Barnet mitt er sykt </li>
+            <li>Barnet mitt er sykt</li>
             <li>Jeg har søkt om barnepass, men ikke fått plass enda</li>
             <li>
                 Jeg har barn som trenger særlig tilsyn på grunn av fysiske, psykiske eller store
@@ -31,11 +25,6 @@ const hjelpetekst = (
         </BodyLong>
     </ul>
 );
-
-const TittelHjelpetekstWrapper = styled.div`
-    display: flex;
-    gap: 1rem;
-`;
 
 interface Props {
     dinSituasjon: EDinSituasjon[];
@@ -48,17 +37,17 @@ const Annet: FC<Props> = ({ dinSituasjon, særligTilsynsbehov }) => {
             <InfoSeksjonWrapper
                 ikon={<Søknadsgrunnlag />}
                 undertittel={
-                    <TittelHjelpetekstWrapper className={'førsteDataKolonne'}>
+                    <HStack gap="4" className={'førsteDataKolonne'}>
                         Annet
                         <HelpText placement={'top-start'}>{hjelpetekst}</HelpText>
-                    </TittelHjelpetekstWrapper>
+                    </HStack>
                 }
             >
                 <Informasjonsrad
                     label="Mer om søkers situasjon"
                     verdiSomString={false}
                     verdi={
-                        <StyledList>
+                        <ul className={styles.annetListe}>
                             {dinSituasjon.map((svarsalternativ) => (
                                 <li key={svarsalternativ}>
                                     <BodyShortSmall>
@@ -66,7 +55,7 @@ const Annet: FC<Props> = ({ dinSituasjon, særligTilsynsbehov }) => {
                                     </BodyShortSmall>
                                 </li>
                             ))}
-                        </StyledList>
+                        </ul>
                     }
                 />
                 <FlexColumnContainer $gap={1}>

--- a/src/frontend/Komponenter/Behandling/Aktivitet/AktivitetsvilkårHeader.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/AktivitetsvilkårHeader.tsx
@@ -1,26 +1,20 @@
 import React from 'react';
-import styled from 'styled-components';
 import {
     EVilkårstyper,
     useEkspanderbareVilkårpanelContext,
 } from '../../../App/context/EkspanderbareVilkårpanelContext';
 import { ÅpneOgLukkePanelKnapper } from '../Inngangsvilkår/ÅpneOgLukkePanelKnapper';
-
-const Container = styled.div`
-    margin: 2rem;
-    display: flex;
-    align-items: flex-end;
-`;
+import { HStack } from '@navikt/ds-react';
 
 export const AktivitetsvilkårHeader: React.FC = () => {
     const { lukkAlle, åpneAlle } = useEkspanderbareVilkårpanelContext();
 
     return (
-        <Container>
+        <HStack justify="end" style={{ margin: '2rem' }}>
             <ÅpneOgLukkePanelKnapper
                 lukkAlle={() => lukkAlle(EVilkårstyper.AKTIVITETSVILKÅR)}
                 åpneAlle={() => åpneAlle(EVilkårstyper.AKTIVITETSVILKÅR)}
             />
-        </Container>
+        </HStack>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/ÅpneOgLukkePanelKnapper.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/ÅpneOgLukkePanelKnapper.tsx
@@ -1,27 +1,21 @@
 import React from 'react';
 import { ChevronUpIcon, ChevronDownIcon } from '@navikt/aksel-icons';
 import { Button } from '@navikt/ds-react';
-import styled from 'styled-components';
-
-const KnappeWrapper = styled.div`
-    display: flex;
-    gap: 1rem;
-    margin-left: auto;
-`;
 
 interface Props {
     lukkAlle: () => void;
     åpneAlle: () => void;
 }
+
 export const ÅpneOgLukkePanelKnapper: React.FC<Props> = ({ lukkAlle, åpneAlle }) => {
     return (
-        <KnappeWrapper>
+        <>
             <Button variant="tertiary" icon={<ChevronUpIcon />} size="small" onClick={lukkAlle}>
                 Lukk alle
             </Button>
             <Button variant="tertiary" icon={<ChevronDownIcon />} size="small" onClick={åpneAlle}>
                 Åpne alle
             </Button>
-        </KnappeWrapper>
+        </>
     );
 };


### PR DESCRIPTION
Vil fjerne styled components under aktivitet(Annet)

Denne fikser "Annet" <ul> nå default (runde), ikke list-style-type: square; (kan enkelt endres tilbake) 
+ Annet Hjelpetekst - ikon 

**Før:**
<img width="1013" height="225" alt="Pasted Graphic 10" src="https://github.com/user-attachments/assets/cd996d6d-1f75-44d9-b68f-307edffdb1b9" />

**Nå:**
<img width="968" height="220" alt="Pasted Graphic 11" src="https://github.com/user-attachments/assets/4d993e35-b823-49e8-97bb-7052909976d2" />

<img width="1633" height="565" alt="Pasted Graphic 12" src="https://github.com/user-attachments/assets/38b1f7b3-1636-4828-97fe-425bb54691a4" />


Fjerner også styled comp. for åpne/lukke knappene øverst til høyre (forenklet disse litt + litt mindre mellomrom) 

**Miniendring i README (fss + deploy)  (+ linting)** 
>Appen bygges på github actions, og deployes til **gcp**. Merge til main vil deploye app til produksjon og dev.


**Ny versjon av åpne/lukke:** 
<img width="893" height="455" alt="Begrunnelse" src="https://github.com/user-attachments/assets/a18dec9b-4104-431d-b102-69c9e41bbe35" />

