### PR TITLE
skal angi alle brevmottakere i toppen av brev for brev i behandling

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/BrevFane.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevFane.tsx
@@ -1,5 +1,11 @@
-import React, { useEffect, useState } from 'react';
-import { byggTomRessurs, Ressurs, RessursStatus } from '../../../App/typer/ressurs';
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+    byggTomRessurs,
+    Ressurs,
+    RessursFeilet,
+    RessursStatus,
+    RessursSuksess,
+} from '../../../App/typer/ressurs';
 import PdfVisning from '../../../Felles/Pdf/PdfVisning';
 import SendTilBeslutter from '../Totrinnskontroll/SendTilBeslutter';
 import { useBehandling } from '../../../App/context/BehandlingContext';
@@ -17,6 +23,8 @@ import { useHentOppfølgingsoppgave } from '../../../App/hooks/useHentOppfølgin
 import { AlertError } from '../../../Felles/Visningskomponenter/Alerts';
 import styled from 'styled-components';
 import { AutomatiskBrevSomSendes } from './AutomatiskBrevSomSendes';
+import { IBrevmottakere } from '../Brevmottakere/typer';
+import { AxiosRequestConfig } from 'axios';
 
 const StyledVStack = styled(VStack)`
     position: sticky;
@@ -59,6 +67,21 @@ export const BrevFane: React.FC<Props> = ({ behandling }) => {
         behandling.id
     );
     const [erDokumentInnlastet, settErDokumentInnlastet] = useState(false);
+    const [brevmottakere, settBrevmottakere] =
+        useState<Ressurs<IBrevmottakere | undefined>>(byggTomRessurs());
+
+    const hentBrevmottakere = useCallback(() => {
+        const behandlingConfig: AxiosRequestConfig = {
+            method: 'GET',
+            url: `familie-ef-sak/api/brevmottakere/${behandling.id}`,
+        };
+        return axiosRequest<IBrevmottakere | undefined, null>(behandlingConfig).then(
+            (res: RessursSuksess<IBrevmottakere | undefined> | RessursFeilet) => {
+                settBrevmottakere(res);
+                return res;
+            }
+        );
+    }, [axiosRequest, behandling.id]);
 
     const lagBeslutterBrev = () => {
         axiosRequest<string, null>({
@@ -100,15 +123,20 @@ export const BrevFane: React.FC<Props> = ({ behandling }) => {
         hentVilkår(behandling.id);
     }, [behandling.id, hentVilkår]);
 
+    useEffect(() => {
+        hentBrevmottakere();
+    }, [hentBrevmottakere]);
+
     return (
         <DataViewer
             response={{
                 personopplysningerResponse,
                 vedtak,
                 vilkår,
+                brevmottakere,
             }}
         >
-            {({ personopplysningerResponse, vedtak, vilkår }) => {
+            {({ personopplysningerResponse, vedtak, vilkår, brevmottakere }) => {
                 return (
                     <Container>
                         <LikDelContainer>
@@ -117,6 +145,8 @@ export const BrevFane: React.FC<Props> = ({ behandling }) => {
                                 <BrevmottakereForBehandling
                                     behandlingId={behandling.id}
                                     personopplysninger={personopplysningerResponse}
+                                    brevmottakere={brevmottakere}
+                                    settBrevMottakere={settBrevmottakere}
                                 />
                                 {!behandlingErRedigerbar && (
                                     <>
@@ -145,6 +175,7 @@ export const BrevFane: React.FC<Props> = ({ behandling }) => {
                                         settKanSendesTilBeslutter={settKanSendesTilBeslutter}
                                         behandling={behandling}
                                         vedtaksresultat={vedtak?.resultatType}
+                                        brevmottakere={brevmottakere}
                                     />
                                 )}
                             </VStack>

--- a/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Brevmeny.tsx
@@ -17,6 +17,7 @@ import { useVerdierForBrev } from '../../../App/hooks/useVerdierForBrev';
 import { utledHtmlFelterPåStønadstype } from './BrevUtils';
 import { useBehandling } from '../../../App/context/BehandlingContext';
 import { BrevvelgerContainer } from './BrevvelgerContainer';
+import { IBrevmottakere } from '../Brevmottakere/typer';
 
 export interface Props {
     oppdaterBrevRessurs: (brevRessurs: Ressurs<string>) => void;
@@ -24,6 +25,7 @@ export interface Props {
     settKanSendesTilBeslutter: (kanSendesTilBeslutter: boolean) => void;
     behandling: Behandling;
     vedtaksresultat?: EBehandlingResultat;
+    brevmottakere: IBrevmottakere | undefined;
 }
 
 const Brevmeny: React.FC<Props> = ({
@@ -32,6 +34,7 @@ const Brevmeny: React.FC<Props> = ({
     vedtaksresultat,
     personopplysninger,
     settKanSendesTilBeslutter,
+    brevmottakere,
 }) => {
     const { hentBeløpsperioder, beløpsperioder } = useHentBeløpsperioder(
         behandling.id,
@@ -88,6 +91,7 @@ const Brevmeny: React.FC<Props> = ({
                             )}
                             brevverdier={brevverdier}
                             settBrevOppdatert={settKanSendesTilBeslutter}
+                            brevmottakere={brevmottakere}
                         />
                     ) : null
                 }

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmenyVisning.tsx
@@ -62,7 +62,7 @@ export type BrevmenyVisningProps = {
     oppdaterBrevRessurs: (brevRessurs: Ressurs<string>) => void;
     htmlFelter?: { [htmlfeltNavn: string]: string } | undefined | null;
     brevverdier: Brevverdier;
-    brevmottakere?: IBrevmottakere | undefined;
+    brevmottakere: IBrevmottakere | undefined;
 } & ({ fagsakId: string; behandlingId?: never } | { behandlingId: string; fagsakId?: never });
 
 const BrevmenyVisning: React.FC<BrevmenyVisningProps> = ({

--- a/src/frontend/Komponenter/Behandling/Brevmottakere/BrevmottakereForBehandling.tsx
+++ b/src/frontend/Komponenter/Behandling/Brevmottakere/BrevmottakereForBehandling.tsx
@@ -1,16 +1,14 @@
-import React, { FC, useCallback, useEffect, useState } from 'react';
+import React, { Dispatch, FC, SetStateAction, useCallback, useEffect } from 'react';
 import { IPersonopplysninger } from '../../../App/typer/personopplysninger';
 import { useApp } from '../../../App/context/AppContext';
 import { IBrevmottakere } from './typer';
 import {
     byggSuksessRessurs,
-    byggTomRessurs,
     Ressurs,
     RessursFeilet,
     RessursStatus,
     RessursSuksess,
 } from '../../../App/typer/ressurs';
-import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { AxiosRequestConfig } from 'axios';
 import { useBehandling } from '../../../App/context/BehandlingContext';
 import { Brevmottakere } from './Brevmottakere';
@@ -19,22 +17,21 @@ import { ModalState } from '../Modal/NyEierModal';
 export const BrevmottakereForBehandling: FC<{
     behandlingId: string;
     personopplysninger: IPersonopplysninger;
-}> = ({ personopplysninger, behandlingId }) => {
+    brevmottakere: IBrevmottakere | undefined;
+    settBrevMottakere: Dispatch<SetStateAction<Ressurs<IBrevmottakere | undefined>>>;
+}> = ({ personopplysninger, behandlingId, brevmottakere, settBrevMottakere }) => {
     const { axiosRequest } = useApp();
     const { hentAnsvarligSaksbehandler, behandlingErRedigerbar, settNyEierModalState } =
         useBehandling();
 
-    const [mottakere, settMottakere] =
-        useState<Ressurs<IBrevmottakere | undefined>>(byggTomRessurs());
-
-    const settBrevmottakere = (brevmottakere: IBrevmottakere) =>
+    const oppdaterBrevmottakere = (brevmottakere: IBrevmottakere) =>
         axiosRequest<string, IBrevmottakere>({
             url: `familie-ef-sak/api/brevmottakere/${behandlingId}`,
             method: 'POST',
             data: brevmottakere,
         }).then((res: RessursSuksess<string> | RessursFeilet) => {
             if (res.status === RessursStatus.SUKSESS) {
-                settMottakere(byggSuksessRessurs(brevmottakere));
+                settBrevMottakere(byggSuksessRessurs(brevmottakere));
             } else {
                 settNyEierModalState(ModalState.LUKKET);
                 hentAnsvarligSaksbehandler.rerun();
@@ -49,26 +46,22 @@ export const BrevmottakereForBehandling: FC<{
         };
         return axiosRequest<IBrevmottakere | undefined, null>(behandlingConfig).then(
             (res: RessursSuksess<IBrevmottakere | undefined> | RessursFeilet) => {
-                settMottakere(res);
+                settBrevMottakere(res);
                 return res;
             }
         );
-    }, [axiosRequest, behandlingId]);
+    }, [axiosRequest, behandlingId, settBrevMottakere]);
 
     useEffect(() => {
         hentBrevmottakere();
     }, [hentBrevmottakere]);
 
     return (
-        <DataViewer response={{ mottakere }}>
-            {({ mottakere }) => (
-                <Brevmottakere
-                    personopplysninger={personopplysninger}
-                    mottakere={mottakere}
-                    kallSettBrevmottakere={settBrevmottakere}
-                    kanEndreBrevmottakere={behandlingErRedigerbar}
-                />
-            )}
-        </DataViewer>
+        <Brevmottakere
+            personopplysninger={personopplysninger}
+            mottakere={brevmottakere}
+            kallSettBrevmottakere={oppdaterBrevmottakere}
+            kanEndreBrevmottakere={behandlingErRedigerbar}
+        />
     );
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ref. demo. Dette er en fortsettelse av [denne PRen](https://github.com/navikt/familie-ef-sak-frontend/pull/3162) som oppdaterer brev med brevmottakere også for brev i behandling.

<table>
  <tr>
    <th style="text-align:center">Før</th>
    <th style="text-align:center">Etter</th>
  </tr>
  <tr>
    <td><img src="URL URL URL" alt="Før" width="400"/><img width="595" height="841" alt="localhost_8000_behandling_f014644c-9465-4842-adf7-2d5d42f45e5c_brev (2)" src="https://github.com/user-attachments/assets/e459569f-463f-499b-b4af-0eb4949f2493" /></td>
    <td><img src="URL URL URL" alt="Etter" width="400"/><img width="595" height="841" alt="localhost_8000_behandling_f014644c-9465-4842-adf7-2d5d42f45e5c_brev (1)" src="https://github.com/user-attachments/assets/5e72ff60-0aac-4b42-924d-767a1b8f43a6" /></td>
  </tr>
</table>

Man må ta stilling til om brevmottaker er verge eller fullmektig:
<img width="469" height="351" alt="localhost_8000_behandling_f014644c-9465-4842-adf7-2d5d42f45e5c_brev" src="https://github.com/user-attachments/assets/d34ad358-1153-43eb-88ba-bcb23ddebfeb" />


