### PR TITLE
Brevbygger - wrapper HtmlEditor og fjerner margin top på div for knapp

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
@@ -196,14 +196,16 @@ export const BrevMenyDelmal: React.FC<Props> = ({
                             </div>
                         )}
                         {overstyring.overstyrtDelmal?.skalOverstyre && (
-                            <>
-                                <HtmlEditor
-                                    defaultValue={overstyring.overstyrtDelmal.htmlInnhold}
-                                    onTextChange={(nyttInnhold) => {
-                                        oppdaterOverstyrtInnhold(delmal, nyttInnhold);
-                                    }}
-                                />
-                                <div style={{ marginTop: '2rem' }}>
+                            <VStack gap={'2'}>
+                                <div>
+                                    <HtmlEditor
+                                        defaultValue={overstyring.overstyrtDelmal.htmlInnhold}
+                                        onTextChange={(nyttInnhold) => {
+                                            oppdaterOverstyrtInnhold(delmal, nyttInnhold);
+                                        }}
+                                    />
+                                </div>
+                                <div>
                                     <Button
                                         onClick={() => overstyring.konverterTilDelmalblokk(delmal)}
                                         size={'small'}
@@ -213,7 +215,7 @@ export const BrevMenyDelmal: React.FC<Props> = ({
                                         Gjør om til brevbygger
                                     </Button>
                                 </div>
-                            </>
+                            </VStack>
                         )}
                     </VStack>
                 )}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

- Legger til en VStack for å styre avstand mellom editor og knapp. 
- Wrapper HtmlEditor i en div - uten denne blir komponentene liggende nærme hverandre.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-25704)

<img width="1368" height="1204" alt="image" src="https://github.com/user-attachments/assets/ce48b025-4f9b-45de-9b5f-f9c6da65433f" />
