### PR TITLE
Brev style (mottakere og flettefelt) 

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevMenyDelmal.tsx
@@ -175,7 +175,6 @@ export const BrevMenyDelmal: React.FC<Props> = ({
                                 )
                                 .map((flettefelt) => (
                                     <Flettefelt
-                                        fetLabel={true}
                                         flettefelt={flettefelt}
                                         dokument={dokument}
                                         flettefelter={flettefelter}

--- a/src/frontend/Komponenter/Behandling/Brev/BrevMottakereListe.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevMottakereListe.tsx
@@ -1,26 +1,6 @@
 import React from 'react';
 import { EBrevmottakerRolle, IBrevmottakere } from '../Brevmottakere/typer';
-import { Alert, BodyShort, Button, Label, Tooltip } from '@navikt/ds-react';
-import styled from 'styled-components';
-
-const Grid = styled.div`
-    display: flex;
-    gap: 2rem;
-`;
-
-const InfoHeader = styled.div`
-    display: flex;
-    gap: 1rem;
-`;
-
-const KompaktButton = styled(Button)`
-    padding: 0;
-    justify-content: right;
-
-    .navds-button__inner {
-        margin: 0;
-    }
-`;
+import { Alert, BodyShort, Button, HStack, Label, Tooltip } from '@navikt/ds-react';
 
 const BrevMottakereListe: React.FC<{
     mottakere: IBrevmottakere;
@@ -46,19 +26,20 @@ const BrevMottakereListe: React.FC<{
 
     return flereBrevmottakereErValgt || !brukerErBrevmottaker ? (
         <Alert variant={'info'} size="small">
-            <InfoHeader>
-                <Label>Brevmottakere:</Label>
+            <HStack gap="4">
+                <Label>Brevmottakere: </Label>
                 {kanEndreBrevmottakere && (
                     <Tooltip content={'Legg til verge eller fullmektige brevmottakere'}>
-                        <KompaktButton
+                        <Button
                             variant={'tertiary'}
                             onClick={() => settVisBrevmottakereModal(true)}
+                            style={{ padding: 0 }}
                         >
                             Legg til/endre brevmottakere
-                        </KompaktButton>
+                        </Button>
                     </Tooltip>
                 )}
-            </InfoHeader>
+            </HStack>
             <ul>
                 {navn.map((navn, index) => (
                     <li key={navn + index}>
@@ -68,20 +49,21 @@ const BrevMottakereListe: React.FC<{
             </ul>
         </Alert>
     ) : (
-        <Grid>
-            <Label>Brevmottaker:</Label>
+        <HStack gap="4">
+            <Label>Brevmottaker: </Label>
             <BodyShort>{navn.map((navn) => navn)}</BodyShort>
             {kanEndreBrevmottakere && (
                 <Tooltip content={'Legg til verge eller fullmektige brevmottakere'}>
-                    <KompaktButton
+                    <Button
                         variant={'tertiary'}
                         onClick={() => settVisBrevmottakereModal(true)}
+                        style={{ padding: 0 }}
                     >
                         Legg til/endre brevmottakere
-                    </KompaktButton>
+                    </Button>
                 </Tooltip>
             )}
-        </Grid>
+        </HStack>
     );
 };
 

--- a/src/frontend/Komponenter/Behandling/Brev/Flettefelt.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Flettefelt.tsx
@@ -1,22 +1,9 @@
 import { erFlettefeltFritektsfelt, finnFlettefeltNavnOgBeskrivelseFraRef } from './BrevUtils';
 import React from 'react';
 import { BrevStruktur, FlettefeltMedVerdi, Flettefeltreferanse } from './BrevTyper';
-import styled from 'styled-components';
-import { BodyShort, HelpText, Label, Textarea, TextField } from '@navikt/ds-react';
-
-const StyledInput = styled(({ ...props }) => (
-    <TextField label={props.label} autoComplete="off" {...props} />
-))`
-    padding-top: 0.5rem;
-`;
-
-const TekstMedHjelpetekstWrapper = styled.div`
-    display: flex;
-    gap: 1rem;
-`;
+import { BodyShort, HelpText, HStack, Label, Textarea, TextField } from '@navikt/ds-react';
 
 interface Props {
-    fetLabel: boolean;
     flettefelt: Flettefeltreferanse;
     dokument: BrevStruktur;
     flettefelter: FlettefeltMedVerdi[];
@@ -28,7 +15,6 @@ interface Props {
 }
 
 export const Flettefelt: React.FC<Props> = ({
-    fetLabel,
     flettefelt,
     dokument,
     flettefelter,
@@ -53,14 +39,13 @@ export const Flettefelt: React.FC<Props> = ({
         return flettefeltMedVerdi?.automatiskUtfylt ? (
             <div>
                 <Label>{flettefeltNavn}</Label>
-                <TekstMedHjelpetekstWrapper>
+                <HStack>
                     <BodyShort>{flettefeltMedVerdi.verdi}</BodyShort>
                     {flettefeltBeskrivelse && <HelpText>{flettefeltBeskrivelse}</HelpText>}
-                </TekstMedHjelpetekstWrapper>
+                </HStack>
             </div>
         ) : (
-            <StyledInput
-                fetLabel={fetLabel}
+            <TextField
                 description={flettefeltBeskrivelse}
                 label={flettefeltNavn}
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/frontend/Komponenter/Behandling/Brev/ValgfeltSelect.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/ValgfeltSelect.tsx
@@ -123,7 +123,6 @@ export const ValgfeltSelect: React.FC<Props> = ({
 
                                 return (
                                     <Flettefelt
-                                        fetLabel={false}
                                         flettefelt={flettefelt}
                                         dokument={dokument}
                                         flettefelter={flettefelter}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Vil fjerne styled components:

**Nå:**
(endring - litt mindre mellomrom)
<img width="738" height="131" alt="Brevmottaker KRITISK KLEMME (bruker) Legg tilendre brevmottakere" src="https://github.com/user-attachments/assets/8aa7834d-f7cf-4eb4-b420-397e569f937c" />

￼
**Før:**
<img width="755" height="212" alt="Brevmottaker" src="https://github.com/user-attachments/assets/758c16d6-246a-4f89-95b5-fae0b4fcd694" />

**Nå/før - 🙂** 
<img width="915" height="367" alt="Pasted Graphic 19" src="https://github.com/user-attachments/assets/32e1d479-ede0-4d31-a0dd-9e40cf302307" />


**Eksempler på bruk (flettefelt )med og uten "fetLabel" - ingen forskjell**

**false**
<img width="724" height="704" alt="Hvis inntekten er endret" src="https://github.com/user-attachments/assets/e7ba8249-a0d0-4c55-82fc-1eee829bfd10" />

**true**
<img width="684" height="367" alt="Fritekst - Begrunnelse for beregning av inntekt (Se wordmal)" src="https://github.com/user-attachments/assets/07516da7-fe69-489a-8485-3b87f043eb6d" />


￼

￼


￼

￼







PREPROD (fetLabel = true)
￼
(fetLabel = false - ingen forskjell) 
￼

