### PR TITLE
Vil fjerne styled components

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/AutomatiskBrevSomSendes.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/AutomatiskBrevSomSendes.tsx
@@ -1,13 +1,6 @@
-import { Checkbox, CheckboxGroup } from '@navikt/ds-react';
-import { ALimegreen100 } from '@navikt/ds-tokens/dist/tokens';
+import { Box, Checkbox, CheckboxGroup } from '@navikt/ds-react';
 import React, { FC } from 'react';
-import styled from 'styled-components';
 import { AutomatiskBrevValg, automatiskBrevValgTekst } from '../Totrinnskontroll/AutomatiskBrev';
-
-const Container = styled.div`
-    background: ${ALimegreen100};
-    padding: 0.5rem;
-`;
 
 export const AutomatiskBrevSomSendes: FC<{
     automatiskBrev?: AutomatiskBrevValg[];
@@ -17,7 +10,7 @@ export const AutomatiskBrevSomSendes: FC<{
     }
 
     return (
-        <Container>
+        <Box background={'surface-alt-2-subtle'} padding="space-8">
             <CheckboxGroup
                 legend="Send brev automatisk når vedtaket er godkjent:"
                 value={automatiskBrev}
@@ -30,6 +23,6 @@ export const AutomatiskBrevSomSendes: FC<{
                         </Checkbox>
                     ))}
             </CheckboxGroup>
-        </Container>
+        </Box>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Brev/FremleggoppgaverSomOpprettes.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/FremleggoppgaverSomOpprettes.tsx
@@ -1,16 +1,9 @@
-import { CheckboxGroup, Checkbox } from '@navikt/ds-react';
+import { CheckboxGroup, Checkbox, Box } from '@navikt/ds-react';
 import React, { FC } from 'react';
 import {
     oppgaveSomSkalOpprettesTilTekst,
     OppgaveTypeForOpprettelse,
 } from '../Totrinnskontroll/oppgaveForOpprettelseTyper';
-import { styled } from 'styled-components';
-import { ALimegreen100 } from '@navikt/ds-tokens/dist/tokens';
-
-const Container = styled.div`
-    background: ${ALimegreen100};
-    padding: 0.5rem;
-`;
 
 export const FremleggoppgaverSomOpprettes: FC<{
     oppgavetyperSomSkalOpprettes: OppgaveTypeForOpprettelse[];
@@ -20,7 +13,7 @@ export const FremleggoppgaverSomOpprettes: FC<{
     }
 
     return (
-        <Container>
+        <Box background={'surface-alt-2-subtle'} padding="space-8">
             <CheckboxGroup
                 legend="Følgende oppgave skal opprettes automatisk når vedtaket er godkjent:"
                 value={oppgavetyperSomSkalOpprettes}
@@ -32,6 +25,6 @@ export const FremleggoppgaverSomOpprettes: FC<{
                     </Checkbox>
                 ))}
             </CheckboxGroup>
-        </Container>
+        </Box>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/OppgaverForFerdigstilling.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/OppgaverForFerdigstilling.tsx
@@ -1,27 +1,12 @@
-import { Heading, Table, Checkbox, BodyLong } from '@navikt/ds-react';
+import { Heading, Table, Checkbox, BodyLong, Box } from '@navikt/ds-react';
 import React, { FC, useEffect } from 'react';
 import { behandlingstemaTilTekst } from '../../../App/typer/behandlingstema';
 import { formaterIsoDato } from '../../../App/utils/formatter';
 import { oppgaveTypeTilTekst } from '../../Oppgavebenk/typer/oppgavetype';
-import styled from 'styled-components';
-import { ALimegreen100 } from '@navikt/ds-tokens/dist/tokens';
 import { useHentOppgaverForFerdigstilling } from '../../../App/hooks/useHentOppgaverForFerdigstilling';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { Ressurs } from '../../../App/typer/ressurs';
 import { IOppgaverResponse } from '../../../App/hooks/useHentOppgaver';
-
-const StyledTableDataCell = styled(Table.DataCell)`
-    padding: 12px 8px 12px 0;
-`;
-
-const StyledBodyLong = styled(BodyLong)`
-    white-space: break-spaces;
-`;
-
-const TableContainer = styled.div`
-    padding: 0.5rem;
-    background-color: ${ALimegreen100};
-`;
 
 export const OppgaverForFerdigstilling: FC<{
     behandlingId: string;
@@ -33,7 +18,7 @@ export const OppgaverForFerdigstilling: FC<{
         hentOppgaverForFerdigstilling(behandlingId);
     }, [behandlingId, hentOppgaverForFerdigstilling]);
 
-    if (skalViseOppgaverForFerdigstilling(oppgaverForFerdigstilling)) {
+    if (skalIkkeViseOppgaverForFerdigstilling(oppgaverForFerdigstilling)) {
         return;
     }
 
@@ -45,7 +30,7 @@ export const OppgaverForFerdigstilling: FC<{
                         <Heading size="small">
                             Følgende oppgaver blir ferdigstilt når vedtaket er godkjent:
                         </Heading>
-                        <TableContainer>
+                        <Box background={'surface-alt-2-subtle'} padding="space-8">
                             <Table>
                                 <Table.Header>
                                     <Table.Row>
@@ -79,14 +64,18 @@ export const OppgaverForFerdigstilling: FC<{
                                                 <Table.ExpandableRow
                                                     key={i}
                                                     content={
-                                                        <StyledBodyLong>
+                                                        <BodyLong
+                                                            style={{ whiteSpace: 'break-spaces' }}
+                                                        >
                                                             {beskrivelse}
-                                                        </StyledBodyLong>
+                                                        </BodyLong>
                                                     }
                                                     togglePlacement="right"
                                                     expandOnRowClick
                                                 >
-                                                    <StyledTableDataCell>
+                                                    <Table.DataCell
+                                                        style={{ padding: '12px 8px 12px 0' }}
+                                                    >
                                                         <Checkbox
                                                             hideLabel
                                                             checked
@@ -95,7 +84,7 @@ export const OppgaverForFerdigstilling: FC<{
                                                         >
                                                             {' '}
                                                         </Checkbox>
-                                                    </StyledTableDataCell>
+                                                    </Table.DataCell>
                                                     <Table.DataCell scope="row">
                                                         {oppgavetype &&
                                                             oppgaveTypeTilTekst[oppgavetype]}
@@ -121,7 +110,7 @@ export const OppgaverForFerdigstilling: FC<{
                                     )}
                                 </Table.Body>
                             </Table>
-                        </TableContainer>
+                        </Box>
                     </>
                 );
             }}
@@ -129,7 +118,7 @@ export const OppgaverForFerdigstilling: FC<{
     );
 };
 
-const skalViseOppgaverForFerdigstilling = (
+const skalIkkeViseOppgaverForFerdigstilling = (
     oppgaverForFerdigstilling: Ressurs<IOppgaverResponse>
 ) => {
     return !(


### PR DESCRIPTION
 For: oppgaver og automatisk aktivitetsbrev (…under brevfanen). 

Vil bytte ut Container (ALimegreen100) med Box "surface-alt-2-subtle" (samme farge som ALimegreen100)

### Hvorfor er denne endringen nødvendig? ✨
Etter endring: 
<img width="728" height="682" alt="Felgende oppgaver blir ferdigstilt när vedtaket er godkjent" src="https://github.com/user-attachments/assets/0db618ec-313d-4c4a-acf1-b9bd929ce4c1" />

Før:
<img width="723" height="742" alt="8 Felgende oppgave skal opprettes automatisk nãr vedtaket er godkjent" src="https://github.com/user-attachments/assets/1e69aec2-f0b6-4d9b-bf80-26d818cc3ea8" />
