### PR TITLE
Refaktorert Sticky komponent - Faner skal også være sticky

### DIFF
--- a/src/frontend/Felles/PersonHeader/PersonHeader.tsx
+++ b/src/frontend/Felles/PersonHeader/PersonHeader.tsx
@@ -2,7 +2,6 @@ import React, { FC } from 'react';
 import { IPersonopplysninger } from '../../App/typer/personopplysninger';
 import styled from 'styled-components';
 import { Behandling, Fagsak, FagsakPerson } from '../../App/typer/fagsak';
-import { Sticky } from '../Visningskomponenter/Sticky';
 import { nullableDatoTilAlder } from '../../App/utils/dato';
 import { useApp } from '../../App/context/AppContext';
 import { AksjonsknapperPersonHeader } from './AksjonsknapperPersonHeader';
@@ -10,23 +9,6 @@ import { ABorderStrong } from '@navikt/ds-tokens/dist/tokens';
 import Visittkort from './Visittkort';
 import PersonTags from './PersonTags';
 import BehandlingTags from './BehandlingTags';
-
-export const Container = styled(Sticky)`
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 1rem;
-
-    padding: 0 1rem 0 1rem;
-
-    border-bottom: 1px solid ${ABorderStrong};
-    z-index: 23;
-    top: 48px; // Høyden på headeren
-
-    .visittkort {
-        border-bottom: none;
-    }
-`;
 
 const FlexContainer = styled.div`
     display: flex;
@@ -74,7 +56,12 @@ export const PersonHeader: FC<Props> = (props) => {
     const fagsakPersonId = harBehandling ? props.fagsak.fagsakPersonId : props.fagsakPerson.id;
 
     return (
-        <Container>
+        <div
+            style={{
+                padding: '0 1rem 0 1rem',
+                borderBottom: `1px solid ${ABorderStrong}`,
+            }}
+        >
             <FlexContainer>
                 <Visittkort
                     fagsakPersonId={fagsakPersonId}
@@ -103,6 +90,6 @@ export const PersonHeader: FC<Props> = (props) => {
                     />
                 </FlexContainer>
             )}
-        </Container>
+        </div>
     );
 };

--- a/src/frontend/Felles/Visningskomponenter/Sticky.module.css
+++ b/src/frontend/Felles/Visningskomponenter/Sticky.module.css
@@ -1,0 +1,7 @@
+.sticky {
+    position: sticky;
+    position: -webkit-sticky;
+    top: 0;
+    z-index: 24;
+    background-color: white;
+}

--- a/src/frontend/Felles/Visningskomponenter/Sticky.tsx
+++ b/src/frontend/Felles/Visningskomponenter/Sticky.tsx
@@ -1,9 +1,13 @@
-import styled from 'styled-components';
+import React from 'react';
+import styles from './Sticky.module.css';
 
-export const Sticky = styled.div`
-    position: sticky;
-    position: -webkit-sticky;
-    top: 0;
-    z-index: 24;
-    background-color: white;
-`;
+export const Sticky: React.FC<{ children: React.ReactNode; style?: React.CSSProperties }> = ({
+    children,
+    style,
+}) => {
+    return (
+        <div className={styles.sticky} style={style}>
+            {children}
+        </div>
+    );
+};

--- a/src/frontend/Komponenter/Personoversikt/PersonOversiktSide.tsx
+++ b/src/frontend/Komponenter/Personoversikt/PersonOversiktSide.tsx
@@ -9,7 +9,7 @@ import { useApp } from '../../App/context/AppContext';
 import { useSetValgtFagsakPersonId } from '../../App/hooks/useSetValgtFagsakPersonId';
 import { useSetPersonIdent } from '../../App/hooks/useSetPersonIdent';
 import { useHentFagsakPerson } from '../../App/hooks/useHentFagsakPerson';
-import { Tabs } from '@navikt/ds-react';
+import { Tabs, VStack } from '@navikt/ds-react';
 import { InntektForPerson } from './InntektForPerson';
 import { PersonHeader } from '../../Felles/PersonHeader/PersonHeader';
 import { Personopplysninger } from './Personopplysninger';
@@ -19,6 +19,7 @@ import { FrittståendeBrevMedVisning } from '../Behandling/Brev/FrittståendeBre
 import { Dokumenter } from './Dokumenter';
 import { OpprettFagsak } from '../Behandling/Førstegangsbehandling/OpprettFagsak';
 import { Side } from './Side';
+import { Sticky } from '../../Felles/Visningskomponenter/Sticky';
 
 interface FaneProps {
     label: string;
@@ -161,20 +162,33 @@ const PersonOversikt: React.FC<Props> = ({
 
     return (
         <>
-            <PersonHeader fagsakPerson={fagsakPerson} personopplysninger={personopplysninger} />
-
-            <Tabs
-                value={path}
-                onChange={(fane) => {
-                    navigate(`/person/${fagsakPersonId}/${fane}`);
+            <Sticky
+                style={{
+                    zIndex: 23,
+                    top: '48px', // Høyden på headeren
                 }}
             >
-                <Tabs.List>
-                    {faner.map((fane) => (
-                        <Tabs.Tab key={fane.path} value={fane.path} label={fane.label} />
-                    ))}
-                </Tabs.List>
-            </Tabs>
+                <VStack>
+                    <PersonHeader
+                        fagsakPerson={fagsakPerson}
+                        personopplysninger={personopplysninger}
+                    />
+
+                    <Tabs
+                        value={path}
+                        onChange={(fane) => {
+                            navigate(`/person/${fagsakPersonId}/${fane}`);
+                        }}
+                    >
+                        <Tabs.List>
+                            {faner.map((fane) => (
+                                <Tabs.Tab key={fane.path} value={fane.path} label={fane.label} />
+                            ))}
+                        </Tabs.List>
+                    </Tabs>
+                </VStack>
+            </Sticky>
+
             <Side skalHaBakgrunnsfarge={skalHaBakgrunnsfarge}>
                 <Routes>
                     {faner.map((fane) => (


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

- Skrevet om komponenten Sticky til å bruke css moduler.
- Bruker komponenten i PersonOversiktSide og wrapper PersonHeader og faner i denne slik at faner også følger med når man scroller.

Før:
<img width="3456" height="898" alt="image" src="https://github.com/user-attachments/assets/56283f9b-fd68-4516-9327-48e441ca3c36" />


Etter:
<img width="3456" height="870" alt="image" src="https://github.com/user-attachments/assets/a5d41493-59c9-4e05-8c1b-eb0df1774ab9" />
