### PR TITLE
Fritekstbrev styling uten styled components

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/Fritekstområde.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Fritekstområde.tsx
@@ -13,30 +13,19 @@ import { ArrowDownIcon, ArrowUpIcon, PlusIcon, TrashIcon } from '@navikt/aksel-i
 import { FritekstAvsnitt, Fritekstområder } from './BrevTyper';
 
 const FritekstAvsnittContainer: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-    <Box padding="4" borderWidth="1" borderRadius="small" borderColor="border-subtle" width={'90%'}>
-        <VStack gap="1">
-            <Heading size="xsmall">Avsnitt</Heading>
+    <Box padding="4" borderWidth="1" borderRadius="small" borderColor="border-default">
+        <VStack gap="2" width="100%">
             {children}
         </VStack>
     </Box>
 );
 
 const FritekstområdePanel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-    <Box padding="4" width="90%">
-        <HStack gap="4">{children}</HStack>
+    <Box padding="4">
+        <VStack gap="4" width="100%">
+            {children}
+        </VStack>
     </Box>
-);
-
-const KnappeWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
-    <div
-        style={{
-            display: 'flex',
-            justifyContent: 'flex-end',
-            gap: '0.5rem',
-        }}
-    >
-        {children}
-    </div>
 );
 
 export const Fritekstområde: React.FC<{
@@ -126,7 +115,7 @@ export const Fritekstområde: React.FC<{
                                     })
                                 }
                             />
-                            <KnappeWrapper>
+                            <HStack gap="1" justify="end">
                                 <Tooltip content="Slett avsnitt">
                                     <Button
                                         icon={<TrashIcon />}
@@ -151,7 +140,7 @@ export const Fritekstområde: React.FC<{
                                         onClick={() => flyttAvsnittOpp(indeks)}
                                     />
                                 </Tooltip>
-                            </KnappeWrapper>
+                            </HStack>
                         </FritekstAvsnittContainer>
                     );
                 })}

--- a/src/frontend/Komponenter/Behandling/Brev/Fritekstområde.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/Fritekstområde.tsx
@@ -1,27 +1,43 @@
 import React, { SetStateAction } from 'react';
-import { Button, Heading, Panel, Textarea, TextField, Tooltip } from '@navikt/ds-react';
+import {
+    Box,
+    Button,
+    Heading,
+    HStack,
+    Textarea,
+    TextField,
+    Tooltip,
+    VStack,
+} from '@navikt/ds-react';
 import { ArrowDownIcon, ArrowUpIcon, PlusIcon, TrashIcon } from '@navikt/aksel-icons';
-import styled from 'styled-components';
 import { FritekstAvsnitt, Fritekstområder } from './BrevTyper';
 
-const FritekstAvsnittContainer = styled(Panel).attrs({ border: true })`
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-    width: 100%;
-`;
+const FritekstAvsnittContainer: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <Box padding="4" borderWidth="1" borderRadius="small" borderColor="border-subtle" width={'90%'}>
+        <VStack gap="1">
+            <Heading size="xsmall">Avsnitt</Heading>
+            {children}
+        </VStack>
+    </Box>
+);
 
-const FritekstområdePanel = styled(Panel)`
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-`;
+const FritekstområdePanel: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <Box padding="4" width="90%">
+        <HStack gap="4">{children}</HStack>
+    </Box>
+);
 
-const KnappeWrapper = styled.div`
-    display: flex;
-    justify-content: flex-end;
-    gap: 0.5rem;
-`;
+const KnappeWrapper: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+    <div
+        style={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            gap: '0.5rem',
+        }}
+    >
+        {children}
+    </div>
+);
 
 export const Fritekstområde: React.FC<{
     id: string;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Bildene er tatt rett før brekkpunkt hvis siden blir mindre -> brev flytter seg ned. Samme før/nå.  

Styled comp: 
Før: 
<img width="1481" height="1197" alt="image" src="https://github.com/user-attachments/assets/5e0470b2-b051-4d0e-ab74-033a38777e33" />

Nå
<img width="1482" height="1195" alt="image" src="https://github.com/user-attachments/assets/31ab5993-13ef-47dc-83b1-14a064b7c476" />

Bred (som før): 
<img width="2279" height="341" alt="image" src="https://github.com/user-attachments/assets/f09edc0b-a75a-423f-a748-0d7b4d226bc2" />

