### PR TITLE
Vil fjerne styled-comp.

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/FrittståendeBrevMedVisning.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/FrittståendeBrevMedVisning.tsx
@@ -3,27 +3,7 @@ import { byggTomRessurs, Ressurs } from '../../../App/typer/ressurs';
 import PdfVisning from '../../../Felles/Pdf/PdfVisning';
 import { IPersonopplysninger } from '../../../App/typer/personopplysninger';
 import { FrittståendeSanitybrev } from './FrittståendeSanitybrev';
-import { styled } from 'styled-components';
-import { VStack } from '@navikt/ds-react';
-
-const StyledVStack = styled(VStack)`
-    position: sticky;
-    top: 100px;
-`;
-
-const Container = styled.div`
-    display: flex;
-    gap: 1rem;
-
-    @media (max-width: 1400px) {
-        flex-direction: column;
-        padding: 3rem;
-    }
-`;
-
-const LikDelContainer = styled.div`
-    flex: 1;
-`;
+import { HStack, VStack } from '@navikt/ds-react';
 
 type Props = {
     fagsakId: string;
@@ -43,24 +23,24 @@ export const FrittståendeBrevMedVisning: React.FC<Props> = ({
     };
 
     return (
-        <Container>
-            <LikDelContainer>
+        <HStack gap="4">
+            <div style={{ flex: 1 }}>
                 <FrittståendeSanitybrev
                     fagsakId={fagsakId}
                     personopplysninger={personopplysninger}
                     brevRessurs={brevRessurs}
                     oppdaterBrevRessurs={oppdaterBrevRessurs}
                 />
-            </LikDelContainer>
-            <LikDelContainer>
-                <StyledVStack gap="2" align="center">
+            </div>
+            <div style={{ flex: 1 }}>
+                <VStack gap="2" align="center">
                     <PdfVisning
                         pdfFilInnhold={brevRessurs}
                         erDokumentInnlastet={erDokumentInnlastet}
                         settErDokumentInnlastet={settErDokumentInnlastet}
                     />
-                </StyledVStack>
-            </LikDelContainer>
-        </Container>
+                </VStack>
+            </div>
+        </HStack>
     );
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Vil bruke Axelkomponenter i fritekstbrev (ikke under behandling).

Endret oppførsel: Knekker nå litt senere enn før. Tenker det er en fordel?  

Før
<img width="1406" height="1064" alt="ensligmorellerfar ansatt dev nav no_person_da974e0f-de6e-46b7-97e7-789009f9d944_frittstaaende-brev (1)" src="https://github.com/user-attachments/assets/9e785ae4-efe0-436c-8b8c-df6b1b6d6ba0" />


Denne: 
<img width="1406" height="1064" alt="localhost_8000_person_da974e0f-de6e-46b7-97e7-789009f9d944_frittstaaende-brev (1)" src="https://github.com/user-attachments/assets/7a7da907-4dd5-4cc6-ba94-a70bb08d9a51" />
