### PR TITLE
Inntektskalkulator - fra og med monthpicker

### DIFF
--- a/src/frontend/App/hooks/useVerdierForBrev.ts
+++ b/src/frontend/App/hooks/useVerdierForBrev.ts
@@ -168,11 +168,14 @@ export const beregnTiProsentØkningIMånedsinntekt = (årsinntekt: number) =>
 export const beregnTiProsentReduksjonIMånedsinntekt = (årsinntekt: number) =>
     formaterTallMedTusenSkille(Math.floor((årsinntekt / 12) * 0.9));
 
-export const genererBeregnetInntektTekst = (årsinntekt: number): string => {
+export const genererBeregnetInntektTekst = (årsinntekt: number, fraOgMed?: Date): string => {
     const minusTi = beregnTiProsentReduksjonIMånedsinntekt(årsinntekt);
     const plusTi = beregnTiProsentØkningIMånedsinntekt(årsinntekt);
+    const dato = fraOgMed
+        ? fraOgMed.toLocaleDateString('nb-NO', { year: 'numeric', month: 'long' })
+        : '[DATO]';
 
-    return `\nForventet årsinntekt fra [DATO]: ${formaterTallMedTusenSkille(årsinntekt)} kroner.
+    return `\nForventet årsinntekt fra ${dato}: ${formaterTallMedTusenSkille(årsinntekt)} kroner.
     - 10 % opp: ${plusTi} kroner per måned.
     - 10 % ned: ${minusTi} kroner per måned.`;
 };

--- a/src/frontend/Felles/Kalkulator/Inntektskalkulator.tsx
+++ b/src/frontend/Felles/Kalkulator/Inntektskalkulator.tsx
@@ -1,4 +1,4 @@
-import { Button, HStack, VStack } from '@navikt/ds-react';
+import { Button, HStack, MonthPicker, useMonthpicker, VStack } from '@navikt/ds-react';
 import React, { FC, useRef, useState } from 'react';
 import { BodyShortSmall } from '../Visningskomponenter/Tekster';
 import ForwardedTextField from '../../Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/ForwardedTextField';
@@ -7,12 +7,19 @@ import { EnsligErrorMessage } from '../ErrorMessage/EnsligErrorMessage';
 const TASTATURTAST_ENTER = 'Enter';
 
 const Inntektskalkulator: FC<{
-    leggTilBeregnetInntektTekstIBegrunnelse: (årsinntekt: number) => void;
+    leggTilBeregnetInntektTekstIBegrunnelse: (årsinntekt: number, fraOgMed?: Date) => void;
     nullstillBegrunnelse?: () => void;
 }> = ({ leggTilBeregnetInntektTekstIBegrunnelse, nullstillBegrunnelse }) => {
     const [årsinntekt, settÅrsinntekt] = useState<string>('');
     const textFieldRef = useRef<HTMLInputElement>(null);
     const [feilmedling, settFeilmedling] = useState<string>('');
+    const [fraOgMed, settFraOgMed] = useState<Date | undefined>(undefined);
+
+    const { monthpickerProps, inputProps, reset } = useMonthpicker({
+        onMonthChange: (month) => {
+            settFraOgMed(month);
+        },
+    });
 
     const oppdaterÅrsinntekt = () => {
         settFeilmedling('');
@@ -23,8 +30,10 @@ const Inntektskalkulator: FC<{
             return;
         }
 
-        leggTilBeregnetInntektTekstIBegrunnelse(årsinntektTall);
+        leggTilBeregnetInntektTekstIBegrunnelse(årsinntektTall, fraOgMed);
         settÅrsinntekt('');
+        settFraOgMed(undefined);
+        reset();
     };
 
     const handleRegnUtOgLeggTilTekst = (event: React.KeyboardEvent<HTMLInputElement>) => {
@@ -51,39 +60,54 @@ const Inntektskalkulator: FC<{
     };
 
     return (
-        <VStack gap="3">
-            <BodyShortSmall>Legg inn årsinntekt for å regne ut +/- 10 prosent.</BodyShortSmall>
+        <VStack gap="space-16">
+            <BodyShortSmall>
+                Legg inn årsinntekt og fra-dato for å regne ut +/- prosent.
+            </BodyShortSmall>
+
             <HStack gap="4" justify={nullstillBegrunnelse ? 'start' : 'space-between'}>
                 <ForwardedTextField
                     ref={textFieldRef}
-                    placeholder="Årsinntekt"
+                    placeholder=""
                     type="number"
                     inputMode="numeric"
-                    label=""
+                    label="Årsinntekt"
                     size="small"
                     value={årsinntekt}
                     onChange={handleTextFieldOnChange}
                     onKeyDown={handleRegnUtOgLeggTilTekst}
                 />
 
-                <Button
-                    type="button"
-                    variant="secondary"
-                    size="xsmall"
-                    onClick={oppdaterÅrsinntekt}
-                >
-                    Beregn
-                </Button>
-                {nullstillBegrunnelse !== undefined && (
-                    <Button
-                        type="button"
-                        variant="tertiary"
-                        size="xsmall"
-                        onClick={nullstillKalkulator}
-                    >
-                        Nullstill
-                    </Button>
-                )}
+                <MonthPicker {...monthpickerProps}>
+                    <MonthPicker.Input {...inputProps} label="Fra og med" size="small" />
+                </MonthPicker>
+
+                <HStack gap="2" align={'end'}>
+                    <div>
+                        <Button
+                            type="button"
+                            variant="secondary"
+                            size="xsmall"
+                            onClick={oppdaterÅrsinntekt}
+                        >
+                            Beregn
+                        </Button>
+                    </div>
+
+                    <div>
+                        {nullstillBegrunnelse !== undefined && (
+                            <Button
+                                type="button"
+                                variant="tertiary"
+                                size="xsmall"
+                                onClick={nullstillKalkulator}
+                            >
+                                Nullstill
+                            </Button>
+                        )}
+                    </div>
+                </HStack>
+
                 <EnsligErrorMessage>{feilmedling}</EnsligErrorMessage>
             </HStack>
         </VStack>

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/BeregnetInntektKalkulator.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/BeregnetInntektKalkulator.tsx
@@ -1,17 +1,12 @@
 import { CalculatorIcon } from '@navikt/aksel-icons';
 import { Dropdown, Button, Tooltip } from '@navikt/ds-react';
 import React, { FC, useEffect, useRef, useState } from 'react';
-import styled from 'styled-components';
 import Inntektskalkulator from '../../../../../Felles/Kalkulator/Inntektskalkulator';
-
-const StyledDropdownMenu = styled(Dropdown.Menu)`
-    width: 23rem;
-`;
 
 const TASTATURTAST_K = 'k';
 
 const BeregnetInntektKalkulator: FC<{
-    leggTilBeregnetInntektTekstIBegrunnelse: (årsinntekt: number) => void;
+    leggTilBeregnetInntektTekstIBegrunnelse: (årsinntekt: number, fraOgMed?: Date) => void;
 }> = ({ leggTilBeregnetInntektTekstIBegrunnelse }) => {
     const textFieldRef = useRef<HTMLInputElement>(null);
     const [erDropdownÅpen, settErDropdownÅpen] = useState<boolean>(false);
@@ -55,13 +50,18 @@ const BeregnetInntektKalkulator: FC<{
                     <CalculatorIcon aria-hidden fontSize="1.5rem" />
                 </Button>
             </Tooltip>
-            <StyledDropdownMenu>
+            <Dropdown.Menu
+                style={{
+                    width: '32rem',
+                    overflow: 'visible',
+                }}
+            >
                 <Inntektskalkulator
                     leggTilBeregnetInntektTekstIBegrunnelse={
                         leggTilBeregnetInntektTekstIBegrunnelse
                     }
-                ></Inntektskalkulator>
-            </StyledDropdownMenu>
+                />
+            </Dropdown.Menu>
         </Dropdown>
     );
 };

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/ForwardedTextField.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/ForwardedTextField.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef } from 'react';
-import { TextField, TextFieldProps } from '@navikt/ds-react'; // Adjust the import path as needed
+import { TextField, TextFieldProps } from '@navikt/ds-react';
 
 const ForwardedTextField = forwardRef<HTMLInputElement, TextFieldProps>((props, ref) => {
     return <TextField {...props} ref={ref} />;

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/InntektsperiodeValg.tsx
@@ -192,8 +192,8 @@ const InntektsperiodeValg: React.FC<Props> = ({
         }
     };
 
-    const leggTilBeregnetInntektTekstIBegrunnelse = (årsinntekt: number) => {
-        const beregnetInntektTekst = genererBeregnetInntektTekst(årsinntekt);
+    const leggTilBeregnetInntektTekstIBegrunnelse = (årsinntekt: number, fraOgMed?: Date) => {
+        const beregnetInntektTekst = genererBeregnetInntektTekst(årsinntekt, fraOgMed);
         inntektBegrunnelseState.setValue((prevState) => prevState + beregnetInntektTekst);
     };
 

--- a/src/frontend/Komponenter/Verktøy/InntektskalkulatorSide.tsx
+++ b/src/frontend/Komponenter/Verktøy/InntektskalkulatorSide.tsx
@@ -13,8 +13,8 @@ const TextAreaLiten = styled(Textarea)`
 
 export const InntektskalkulatorSide: React.FC = () => {
     const inntektBegrunnelseState: FieldState = useFieldState('');
-    const leggTilBeregnetInntektTekstIBegrunnelse = (årsinntekt: number) => {
-        const beregnetInntektTekst = genererBeregnetInntektTekst(årsinntekt);
+    const leggTilBeregnetInntektTekstIBegrunnelse = (årsinntekt: number, fraOgMed?: Date) => {
+        const beregnetInntektTekst = genererBeregnetInntektTekst(årsinntekt, fraOgMed);
         inntektBegrunnelseState.setValue((prevState) => prevState + beregnetInntektTekst);
     };
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

- Lagt til monthpicker som er **valgfri** å bruke.
- Fjernet styled component fra BeregnetInntektKalkulator.
- Gjort litt style endringer - bruker label i stedet for placeholder slik at komponentene blir like.


[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=NAV-25980)

<img width="2784" height="892" alt="image" src="https://github.com/user-attachments/assets/64e402c8-e1bd-4188-93f8-4dbeca915e2d" />

<img width="1568" height="676" alt="image" src="https://github.com/user-attachments/assets/fca368d9-7da2-44c3-8515-c1d403b4fb26" />
