### PR TITLE
Inntektskalkulator glemte to komponenter

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/AvslåVedtak/AvslåVedtakForm.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/AvslåVedtak/AvslåVedtakForm.tsx
@@ -57,8 +57,8 @@ export const AvslåVedtakForm: React.FC<Props> = ({
         !skalVelgeÅrsak && settAvslagÅrsak(EAvslagÅrsak.VILKÅR_IKKE_OPPFYLT);
     }, [skalVelgeÅrsak, settAvslagÅrsak]);
 
-    const leggTilBeregnetInntektTekstIBegrunnelse = (årsinntekt: number) => {
-        const beregnetInntektTekst = genererBeregnetInntektTekst(årsinntekt);
+    const leggTilBeregnetInntektTekstIBegrunnelse = (årsinntekt: number, fraOgMed?: Date) => {
+        const beregnetInntektTekst = genererBeregnetInntektTekst(årsinntekt, fraOgMed);
         settAvslagBegrunnelse((prev: string) => prev + beregnetInntektTekst);
     };
 

--- a/src/frontend/Komponenter/Behandling/Vurdering/InntektVurderingMedKalkulator.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/InntektVurderingMedKalkulator.tsx
@@ -50,8 +50,8 @@ export const InntektVurderingMedKalkulator: FC<InntektVurderingMedKalkualtor> = 
     const begrunnelsetype = vurdering.svar && regel.svarMapping[vurdering.svar].begrunnelseType;
     const visKalkulator = (begrunnelsetype ?? BegrunnelseRegel.UTEN) !== BegrunnelseRegel.UTEN;
 
-    const leggTilBeregnetInntektTekstIBegrunnelse = (årsinntekt: number) => {
-        const beregnetInntektTekst = genererBeregnetInntektTekst(årsinntekt);
+    const leggTilBeregnetInntektTekstIBegrunnelse = (årsinntekt: number, fraOgMed?: Date) => {
+        const beregnetInntektTekst = genererBeregnetInntektTekst(årsinntekt, fraOgMed);
         const eksisterendeTekst = vurdering.begrunnelse || '';
         onChange(eksisterendeTekst + beregnetInntektTekst);
     };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Uten endringen blir dato/fra og med undefined der InntektVurderingMedKalkulator og InntektVurderingMedKalkulator brukes

<img width="3064" height="1714" alt="image" src="https://github.com/user-attachments/assets/bb56ef02-4e99-454b-95ff-3ec37bfa2e37" />
