### PR TITLE
Opphør 12 år bak i tid

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/OpphøreVedtak/OpphøreVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/OpphøreVedtak/OpphøreVedtak.tsx
@@ -83,7 +83,7 @@ export const OpphøreVedtak: React.FC<{
         }
     };
 
-    const årBakITid = 12; // alle skal kunne opphøre bakover i tid (11 år)
+    const årBakITid = 12;
 
     return (
         <Form onSubmit={lagreVedtak}>

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/OpphøreVedtak/OpphøreVedtak.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/OpphøreVedtak/OpphøreVedtak.tsx
@@ -83,7 +83,7 @@ export const OpphøreVedtak: React.FC<{
         }
     };
 
-    const årBakITid = 11; // alle skal kunne opphøre bakover i tid (11 år)
+    const årBakITid = 12; // alle skal kunne opphøre bakover i tid (11 år)
 
     return (
         <Form onSubmit={lagreVedtak}>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Sammensatte saker har behov for å opphøre tilbake til 2014. Vi gjør et forsøk og sjekker om simulering blir riktig så langt tilbake. I 2025. La vi inn muilighet til å opphøre 11 år bak i tid. Da mener vi at det skal bli likt om vi opphører 12 år nå (2026)

<img width="1340" height="139" alt="image" src="https://github.com/user-attachments/assets/2378685f-858f-46ad-a2a7-66e651918b8d" />


