### PR TITLE
Bugfix: Viser egen ansatt tag riktig avhengig av om det er liten eller stor skjerm

### DIFF
--- a/src/frontend/Felles/PersonHeader/PersonTags.tsx
+++ b/src/frontend/Felles/PersonHeader/PersonTags.tsx
@@ -69,12 +69,12 @@ const PersonTags: React.FC<Props> = ({
             )}
             {egenAnsatt && (
                 <>
-                    <TagLitenSkjerm variant={'warning'} size={'small'}>
-                        Egen ansatt
-                    </TagLitenSkjerm>
                     <TagStorSkjerm variant={'warning'} size={'small'}>
-                        E..
+                        Egen ansatt
                     </TagStorSkjerm>
+                    <TagLitenSkjerm variant={'warning'} size={'small'}>
+                        E..
+                    </TagLitenSkjerm>
                 </>
             )}
             {fullmakt.some(


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Feil meldt på teams.

Testet i preprod med testbruker: 09500269909
