### PR TITLE
Regelendring 2026 visning aktivitet fane

### DIFF
--- a/src/frontend/App/typer/aktivitetstyper.ts
+++ b/src/frontend/App/typer/aktivitetstyper.ts
@@ -22,6 +22,7 @@ export interface IAktivitet {
     tidligereUtdanninger: ITidligereUtdanning[];
     datoOppstartJobb?: string;
     erIArbeid?: string;
+    inntekter?: Inntekter[];
 }
 
 export interface ISagtOppEllerRedusertStilling {
@@ -30,6 +31,7 @@ export interface ISagtOppEllerRedusertStilling {
     dato?: string;
     dokumentasjon?: IDokumentasjon;
     harAvsluttetArbeidsforholdIRegister: boolean;
+    erRegelendring2026?: boolean;
 }
 
 export interface IArbeidsforhold {
@@ -95,4 +97,11 @@ export interface ISærligeTilsynsbehov {
     erBarnetFødt: boolean;
     fødselTermindato?: string;
     særligeTilsynsbehov?: string;
+}
+
+export interface Inntekter {
+    arbeidstaker?: string;
+    selvstendigNæringsdrivende?: string;
+    annenStønadNav?: string;
+    nei?: string;
 }

--- a/src/frontend/App/typer/aktivitetstyper.ts
+++ b/src/frontend/App/typer/aktivitetstyper.ts
@@ -4,6 +4,7 @@ import { IDokumentasjon } from './felles';
 import { ESagtOppEllerRedusert } from '../../Komponenter/Behandling/Inngangsvilkår/Samliv/typer';
 import {
     EDinSituasjon,
+    Inntekter,
     EStilling,
     EStudieandel,
     EUtdanningsform,
@@ -97,11 +98,4 @@ export interface ISærligeTilsynsbehov {
     erBarnetFødt: boolean;
     fødselTermindato?: string;
     særligeTilsynsbehov?: string;
-}
-
-export interface Inntekter {
-    arbeidstaker?: string;
-    selvstendigNæringsdrivende?: string;
-    annenStønadNav?: string;
-    nei?: string;
 }

--- a/src/frontend/App/typer/fagsak.ts
+++ b/src/frontend/App/typer/fagsak.ts
@@ -26,6 +26,7 @@ export interface Fagsak {
 
 export interface Behandling {
     id: string;
+    erRegelendring2026: boolean;
     forrigeBehandlingId?: string;
     fagsakId: string;
     type: Behandlingstype;

--- a/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/Aktivitet.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/Aktivitet.tsx
@@ -3,6 +3,7 @@ import { VilkårProps } from '../../Inngangsvilkår/vilkårprops';
 import { AktivitetsvilkårType } from '../../Inngangsvilkår/vilkår';
 import VisEllerEndreVurdering from '../../Vurdering/VisEllerEndreVurdering';
 import AktivitetInfo from './AktivitetInfo';
+import AktivitetInfoRegelendring2026 from './AktivitetInfoRegelendring2026';
 import { useBehandling } from '../../../../App/context/BehandlingContext';
 import DataViewer from '../../../../Felles/DataViewer/DataViewer';
 import { Behandlingsårsak } from '../../../../App/typer/behandlingsårsak';
@@ -41,13 +42,21 @@ export const Aktivitet: React.FC<VilkårProps> = ({
                     >
                         <VilkårpanelInnhold>
                             {{
-                                venstre: grunnlag.aktivitet && skalViseSøknadsdata && (
-                                    <AktivitetInfo
-                                        aktivitet={grunnlag.aktivitet}
-                                        stønadstype={behandling.stønadstype}
-                                        dokumentasjon={grunnlag.dokumentasjon}
-                                    />
-                                ),
+                                venstre:
+                                    grunnlag.aktivitet &&
+                                    skalViseSøknadsdata &&
+                                    (behandling.erRegelendring2026 ? (
+                                        <AktivitetInfoRegelendring2026
+                                            aktivitet={grunnlag.aktivitet}
+                                            stønadstype={behandling.stønadstype}
+                                        />
+                                    ) : (
+                                        <AktivitetInfo
+                                            aktivitet={grunnlag.aktivitet}
+                                            stønadstype={behandling.stønadstype}
+                                            dokumentasjon={grunnlag.dokumentasjon}
+                                        />
+                                    )),
                                 høyre: (
                                     <VisEllerEndreVurdering
                                         ikkeVurderVilkår={ikkeVurderVilkår}

--- a/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/AktivitetInfoRegelendring2026.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/AktivitetInfoRegelendring2026.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
-import { IAktivitet, Inntekter } from '../../../../App/typer/aktivitetstyper';
+import { IAktivitet } from '../../../../App/typer/aktivitetstyper';
 import { Søknadsgrunnlag } from '../../../../Felles/Ikoner/DataGrunnlagIkoner';
-import { DinSituasjonTilTekst, InntekterTilTekst, EInntekter } from './typer';
+import { DinSituasjonTilTekst, InntekterTilTekst, Inntekter } from './typer';
 import { Stønadstype } from '../../../../App/typer/behandlingstema';
 import { InformasjonContainer } from '../../Vilkårpanel/StyledVilkårInnhold';
 import Informasjonsrad from '../../Vilkårpanel/Informasjonsrad';
@@ -17,7 +17,7 @@ interface Props {
 }
 
 const hentInntektVerdier = (inntekter: Inntekter[]): string[] =>
-    inntekter.map((nøkkel) => InntekterTilTekst[nøkkel as unknown as EInntekter] ?? nøkkel);
+    inntekter.map((nøkkel) => InntekterTilTekst[nøkkel] ?? nøkkel);
 
 const AktivitetInfoRegelendring2026: FC<Props> = ({ aktivitet, stønadstype }) => {
     const { gjelderDeg, særligeTilsynsbehov, selvstendig } = aktivitet;

--- a/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/AktivitetInfoRegelendring2026.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/AktivitetInfoRegelendring2026.tsx
@@ -1,0 +1,96 @@
+import React, { FC } from 'react';
+import { IAktivitet, Inntekter } from '../../../../App/typer/aktivitetstyper';
+import { Søknadsgrunnlag } from '../../../../Felles/Ikoner/DataGrunnlagIkoner';
+import { DinSituasjonTilTekst, InntekterTilTekst, EInntekter } from './typer';
+import { Stønadstype } from '../../../../App/typer/behandlingstema';
+import { InformasjonContainer } from '../../Vilkårpanel/StyledVilkårInnhold';
+import Informasjonsrad from '../../Vilkårpanel/Informasjonsrad';
+import { InfoSeksjonWrapper } from '../../Vilkårpanel/VilkårInformasjonKomponenter';
+import { BodyShortSmall } from '../../../../Felles/Visningskomponenter/Tekster';
+import { FlexColumnContainer } from '../../Vilkårpanel/StyledVilkårInnhold';
+import { formaterNullableIsoDato } from '../../../../App/utils/formatter';
+import SelvstendigNæringsdrivendeEllerFrilanser from './SelvstendigNæringsdrivendeEllerFrilanser';
+
+interface Props {
+    aktivitet: IAktivitet;
+    stønadstype: Stønadstype;
+}
+
+const hentInntektVerdier = (inntekter: Inntekter[]): string[] =>
+    inntekter.map((nøkkel) => InntekterTilTekst[nøkkel as unknown as EInntekter] ?? nøkkel);
+
+const AktivitetInfoRegelendring2026: FC<Props> = ({ aktivitet, stønadstype }) => {
+    const { gjelderDeg, særligeTilsynsbehov, selvstendig } = aktivitet;
+
+    const harTilsynsbehov = særligeTilsynsbehov && særligeTilsynsbehov.length > 0;
+    const inntektVerdier = aktivitet.inntekter ? hentInntektVerdier(aktivitet.inntekter) : [];
+
+    return (
+        <InformasjonContainer>
+            <InfoSeksjonWrapper ikon={<Søknadsgrunnlag />} undertittel="Hva er situasjonen din?">
+                <Informasjonsrad
+                    label="Valgte svar"
+                    verdiSomString={false}
+                    verdi={
+                        <ul style={{ margin: 0, paddingLeft: '1rem' }}>
+                            {gjelderDeg.map((svar) => (
+                                <li key={svar}>
+                                    <BodyShortSmall>{DinSituasjonTilTekst[svar]}</BodyShortSmall>
+                                </li>
+                            ))}
+                        </ul>
+                    }
+                />
+            </InfoSeksjonWrapper>
+
+            {harTilsynsbehov && (
+                <InfoSeksjonWrapper ikon={<Søknadsgrunnlag />} undertittel="Om tilsynsbehovet">
+                    <FlexColumnContainer $gap={1}>
+                        {særligeTilsynsbehov.map((barnetsBehov) => (
+                            <Informasjonsrad
+                                key={barnetsBehov.id}
+                                label={
+                                    barnetsBehov.navn
+                                        ? `${barnetsBehov.navn}`
+                                        : `Barn ${
+                                              barnetsBehov.erBarnetFødt ? 'født ' : 'termindato '
+                                          }${formaterNullableIsoDato(barnetsBehov.fødselTermindato)}`
+                                }
+                                verdi={barnetsBehov.særligeTilsynsbehov}
+                            />
+                        ))}
+                    </FlexColumnContainer>
+                </InfoSeksjonWrapper>
+            )}
+
+            {inntektVerdier.length > 0 && (
+                <InfoSeksjonWrapper ikon={<Søknadsgrunnlag />} undertittel="Har du inntekt?">
+                    <Informasjonsrad
+                        label="Valgte svar"
+                        verdiSomString={false}
+                        verdi={
+                            <ul style={{ margin: 0, paddingLeft: '1rem' }}>
+                                {inntektVerdier.map((tekst) => (
+                                    <li key={tekst}>
+                                        <BodyShortSmall>{tekst}</BodyShortSmall>
+                                    </li>
+                                ))}
+                            </ul>
+                        }
+                    />
+                </InfoSeksjonWrapper>
+            )}
+
+            {selvstendig &&
+                selvstendig.map((firma, indeks) => (
+                    <SelvstendigNæringsdrivendeEllerFrilanser
+                        key={firma.organisasjonsnummer + indeks}
+                        firma={firma}
+                        stønadstype={stønadstype}
+                    />
+                ))}
+        </InformasjonContainer>
+    );
+};
+
+export default AktivitetInfoRegelendring2026;

--- a/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/typer.ts
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/typer.ts
@@ -8,6 +8,10 @@ export enum EArbeidssituasjon {
     tarUtdanning = 'tarUtdanning',
     harFåttJobbTilbud = 'harFåttJobbTilbud',
     erHverkenIArbeidUtdanningEllerArbeidssøker = 'erHverkenIArbeidUtdanningEllerArbeidssøker',
+    arbeidstaker = 'arbeidstaker',
+    selvstendigNæringsdrivende = 'selvstendigNæringsdrivende',
+    annenStønadNav = 'annenStønadNav',
+    ingenInntekt = 'ingenInntekt',
 }
 export const ArbeidssituasjonTilTekst: Record<EArbeidssituasjon, string> = {
     erHjemmeMedBarnUnderEttÅr: 'Hjemme med barn under 1 år',
@@ -20,6 +24,10 @@ export const ArbeidssituasjonTilTekst: Record<EArbeidssituasjon, string> = {
     tarUtdanning: 'Tar eller skal ta utdanning',
     harFåttJobbTilbud: 'Har fått jobbtilbud',
     erHverkenIArbeidUtdanningEllerArbeidssøker: 'Ikke i arbeid, utdanning eller arbeidssøker',
+    arbeidstaker: 'Arbeidstaker',
+    selvstendigNæringsdrivende: 'Selvstendig næringsdrivende',
+    annenStønadNav: 'Annen stønad fra NAV',
+    ingenInntekt: 'Ingen inntekt',
 };
 
 export enum EErIArbeid {
@@ -32,15 +40,37 @@ export enum EDinSituasjon {
     harSyktBarn = 'harSyktBarn',
     harSøktBarnepassOgVenterEnnå = 'harSøktBarnepassOgVenterEnnå',
     harBarnMedSærligeBehov = 'harBarnMedSærligeBehov',
+    barnSærligTilsyn = 'barnSærligTilsyn',
+    barnUnder14Måneder = 'barnUnder14Måneder',
+    barnSykdomIkkeVarig = 'barnSykdomIkkeVarig',
     nei = 'nei',
 }
+
+const tekstSærligTilsyn =
+    'Jeg har barn som trenger særlig tilsyn på grunn av fysiske, psykiske eller store sosiale problemer';
 
 export const DinSituasjonTilTekst: Record<EDinSituasjon, string> = {
     erSyk: 'Jeg er syk',
     harSyktBarn: 'Barnet mitt er sykt',
+    barnSykdomIkkeVarig: 'Barnet mitt har en sykdom som ikke er varig',
     harSøktBarnepassOgVenterEnnå: 'Jeg har søkt om barnepass, men ikke fått plass enda',
-    harBarnMedSærligeBehov:
-        'Jeg har barn som trenger særlig tilsyn på grunn av fysiske, psykiske eller store sosiale problemer',
+    barnSærligTilsyn: tekstSærligTilsyn,
+    harBarnMedSærligeBehov: tekstSærligTilsyn,
+    barnUnder14Måneder: 'Jeg har barn under 14 måneder',
+    nei: 'Nei',
+};
+
+export enum EInntekter {
+    arbeidstaker = 'arbeidstaker',
+    selvstendigNæringsdrivende = 'selvstendigNæringsdrivende',
+    annenStønadNav = 'annenStønadNav',
+    nei = 'nei',
+}
+
+export const InntekterTilTekst: Record<EInntekter, string> = {
+    arbeidstaker: 'Ja, jeg har inntekt som arbeidstaker',
+    selvstendigNæringsdrivende: 'Ja, jeg har inntekt som selvstendig næringsdrivende',
+    annenStønadNav: 'Ja, jeg får annen stønad fra Nav',
     nei: 'Nei',
 };
 

--- a/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/typer.ts
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/typer.ts
@@ -43,6 +43,7 @@ export enum EDinSituasjon {
     barnSærligTilsyn = 'barnSærligTilsyn',
     barnUnder14Måneder = 'barnUnder14Måneder',
     barnSykdomIkkeVarig = 'barnSykdomIkkeVarig',
+    ingenAvDisseGjelderMeg = 'ingenAvDisseGjelderMeg',
     nei = 'nei',
 }
 
@@ -57,6 +58,7 @@ export const DinSituasjonTilTekst: Record<EDinSituasjon, string> = {
     barnSærligTilsyn: tekstSærligTilsyn,
     harBarnMedSærligeBehov: tekstSærligTilsyn,
     barnUnder14Måneder: 'Jeg har barn under 14 måneder',
+    ingenAvDisseGjelderMeg: 'Ingen av disse gjelder meg',
     nei: 'Nei',
 };
 

--- a/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/typer.ts
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/typer.ts
@@ -62,14 +62,14 @@ export const DinSituasjonTilTekst: Record<EDinSituasjon, string> = {
     nei: 'Nei',
 };
 
-export enum EInntekter {
+export enum Inntekter {
     arbeidstaker = 'arbeidstaker',
     selvstendigNæringsdrivende = 'selvstendigNæringsdrivende',
     annenStønadNav = 'annenStønadNav',
     nei = 'nei',
 }
 
-export const InntekterTilTekst: Record<EInntekter, string> = {
+export const InntekterTilTekst: Record<Inntekter, string> = {
     arbeidstaker: 'Ja, jeg har inntekt som arbeidstaker',
     selvstendigNæringsdrivende: 'Ja, jeg har inntekt som selvstendig næringsdrivende',
     annenStønadNav: 'Ja, jeg får annen stønad fra Nav',

--- a/src/frontend/Komponenter/Behandling/ÅrsakRevurdering/endreÅrsakRevurdering.test.ts
+++ b/src/frontend/Komponenter/Behandling/ÅrsakRevurdering/endreÅrsakRevurdering.test.ts
@@ -94,5 +94,6 @@ const opprettBehandling = (
         steg: Steg.VILKÅR,
         sistEndret: '',
         status: BehandlingStatus.UTREDES,
+        erRegelendring2026: false,
     };
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Behandlinger med ny versjon av overgangsstønad søknad av regelendring 2026 har annen struktur og skal vise felter ulikt. Bruker property 'erRegelendring2026' til å avgjøre hvilken versjon av søknad som er har blitt brukt og bruker komponent som er tilpasset gitt struktur.

- Ny komponent for aktivitet fane når det er os søknad med regelendringer

<img width="1711" height="1317" alt="image" src="https://github.com/user-attachments/assets/81de200c-9b08-4dc5-a70b-ddc3fe2073e1" />
