### PR TITLE
Ikke huk av varsel for aktivitetsplikt automatisk dersom overgangsregel toggle er på.

### DIFF
--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -22,4 +22,5 @@ export enum ToggleName {
     brukErrorAlertMedKopierKnapp = 'familie.ef.sak.frontend-alert-error-med-copy-button',
     visAutomatiskInntektsendring = 'familie.ef.sak.frontend-vis-automatisk-inntektsendring',
     visBeregningsskjema = 'familie.ef.sak.frontend-vis-beregningsskjema',
+    overgangsregel = 'familie.ef.soknad.overgangsstonad-regelendringer-2026',
 }

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/AutomatiskBrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/AutomatiskBrev.tsx
@@ -14,7 +14,8 @@ const automatiskBrevAlternativer: AutomatiskBrevValg[] = Object.values(Automatis
 export const AutomatiskBrev: FC<{
     automatiskBrev: AutomatiskBrevValg[];
     settAutomatiskBrev: React.Dispatch<React.SetStateAction<AutomatiskBrevValg[]>>;
-}> = ({ automatiskBrev, settAutomatiskBrev }) => {
+    erOvergangsregel?: boolean;
+}> = ({ automatiskBrev, settAutomatiskBrev, erOvergangsregel }) => {
     return (
         <CheckboxGroup
             legend="Send brev automatisk når vedtaket er godkjent:"
@@ -24,6 +25,8 @@ export const AutomatiskBrev: FC<{
             {automatiskBrevAlternativer.map((valg) => (
                 <Checkbox key={valg} value={valg}>
                     {automatiskBrevValgTekst[valg]}
+                    {erOvergangsregel &&
+                        ' – Kun saker etter gammelt regelverk skal ha dette brevet.'}
                 </Checkbox>
             ))}
         </CheckboxGroup>

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/ModalSendTilBeslutter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/ModalSendTilBeslutter.tsx
@@ -16,6 +16,8 @@ import { harBarnMellomSeksOgTolvMåneder, utledAutomatiskBrev } from './utils';
 import { Stønadstype } from '../../../App/typer/behandlingstema';
 import { Oppfølgingsoppgave } from '../../../App/hooks/useHentOppfølgingsoppgave';
 import { Oppgaveprioritet } from './Oppgaveprioritet';
+import { useToggles } from '../../../App/context/TogglesContext';
+import { ToggleName } from '../../../App/context/toggles';
 
 export const ModalSendTilBeslutter: FC<{
     behandling: Behandling;
@@ -53,6 +55,9 @@ export const ModalSendTilBeslutter: FC<{
     avslagValg,
     oppfølgingsoppgave,
 }) => {
+    const { toggles } = useToggles();
+    const erOvergangsregel = toggles[ToggleName.overgangsregel] || false;
+
     const [
         årForInntektskontrollSelvstendigNæringsdrivende,
         settÅrForInntektskontrollSelvstendigNæringsdrivende,
@@ -74,7 +79,8 @@ export const ModalSendTilBeslutter: FC<{
         utledAutomatiskBrev(
             oppfølgingsoppgave?.automatiskBrev,
             erInnvilgelseOvergangsstønad,
-            vilkår
+            vilkår,
+            erOvergangsregel
         )
     );
 
@@ -125,10 +131,17 @@ export const ModalSendTilBeslutter: FC<{
             utledAutomatiskBrev(
                 oppfølgingsoppgave?.automatiskBrev,
                 erInnvilgelseOvergangsstønad,
-                vilkår
+                vilkår,
+                erOvergangsregel
             )
         );
-    }, [behandling, erInnvilgelseOvergangsstønad, oppfølgingsoppgave?.automatiskBrev, vilkår]);
+    }, [
+        behandling,
+        erInnvilgelseOvergangsstønad,
+        erOvergangsregel,
+        oppfølgingsoppgave?.automatiskBrev,
+        vilkår,
+    ]);
 
     return (
         <DataViewer response={{ oppgaverForAutomatiskFerdigstilling }}>
@@ -190,6 +203,7 @@ export const ModalSendTilBeslutter: FC<{
                                                 <AutomatiskBrev
                                                     automatiskBrev={automatiskBrev}
                                                     settAutomatiskBrev={settAutomatiskBrev}
+                                                    erOvergangsregel={erOvergangsregel}
                                                 />
                                                 <VannrettDivider />
                                             </>

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.test.ts
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
-import { harBarnMellomSeksOgTolvMåneder } from './utils';
+import { harBarnMellomSeksOgTolvMåneder, utledAutomatiskBrev } from './utils';
 import { IVilkår, InngangsvilkårType, Vilkårsresultat } from '../Inngangsvilkår/vilkår';
+import { AutomatiskBrevValg } from './AutomatiskBrev';
 
 describe('Har barn mellom seks og tolv måneder', () => {
     const toÅrGammel = new Date(new Date().setMonth(new Date().getMonth() - 24)).toISOString();
@@ -64,5 +65,55 @@ describe('Har barn mellom seks og tolv måneder', () => {
         const vilkår = lagVilkår(null);
 
         expect(harBarnMellomSeksOgTolvMåneder(vilkår as IVilkår)).toBe(false);
+    });
+});
+
+describe('utledAutomatiskBrev', () => {
+    const åtteMånederGammel = new Date();
+    åtteMånederGammel.setMonth(åtteMånederGammel.getMonth() - 8);
+
+    const lagVilkårMedBarn = (fødselsdato: string) =>
+        ({
+            vurderinger: [
+                {
+                    vilkårType: InngangsvilkårType.ALENEOMSORG,
+                    resultat: Vilkårsresultat.OPPFYLT,
+                    barnId: '1',
+                },
+            ],
+            grunnlag: {
+                barnMedSamvær: [
+                    {
+                        barnId: '1',
+                        registergrunnlag: { fødselsdato },
+                    },
+                ],
+            },
+        }) as unknown as IVilkår;
+
+    const vilkårMedBarnMellom6Og12Mnd = lagVilkårMedBarn(åtteMånederGammel.toISOString());
+
+    it('skal auto-avhuke varsel om aktivitetsplikt når barn er mellom 6 og 12 måneder og toggle er av', () => {
+        const resultat = utledAutomatiskBrev(undefined, true, vilkårMedBarnMellom6Og12Mnd, false);
+        expect(resultat).toContain(AutomatiskBrevValg.VARSEL_OM_AKTIVITETSPLIKT);
+    });
+
+    it('skal ikke auto-avhuke varsel om aktivitetsplikt når overgangsregel-toggle er på', () => {
+        const resultat = utledAutomatiskBrev(undefined, true, vilkårMedBarnMellom6Og12Mnd, true);
+        expect(resultat).not.toContain(AutomatiskBrevValg.VARSEL_OM_AKTIVITETSPLIKT);
+    });
+
+    it('skal ikke auto-avhuke når overgangsregel-toggle er av men barn er utenfor aldersgrensen', () => {
+        const toÅrGammel = new Date();
+        toÅrGammel.setFullYear(toÅrGammel.getFullYear() - 2);
+        const vilkår = lagVilkårMedBarn(toÅrGammel.toISOString());
+
+        const resultat = utledAutomatiskBrev(undefined, true, vilkår, false);
+        expect(resultat).not.toContain(AutomatiskBrevValg.VARSEL_OM_AKTIVITETSPLIKT);
+    });
+
+    it('skal returnere tom liste når det ikke er innvilgelse overgangsstønad', () => {
+        const resultat = utledAutomatiskBrev(undefined, false, vilkårMedBarnMellom6Og12Mnd, false);
+        expect(resultat).toHaveLength(0);
     });
 });

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.ts
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.ts
@@ -39,7 +39,8 @@ export const harBarnMellomSeksOgTolvMåneder = (vilkår: IVilkår) => {
 export const utledAutomatiskBrev = (
     lagretAutomatiskBrev: AutomatiskBrevValg[] | undefined,
     erInnvilgelseOvergangsstønad: boolean,
-    vilkår?: IVilkår
+    vilkår?: IVilkår,
+    erOvergangsregel?: boolean
 ) => {
     if (!erInnvilgelseOvergangsstønad) {
         return [];
@@ -55,7 +56,7 @@ export const utledAutomatiskBrev = (
         });
     }
 
-    if (harBarnMellomSeksOgTolvMnder) {
+    if (harBarnMellomSeksOgTolvMnder && !erOvergangsregel) {
         automatiskBrev.add(AutomatiskBrevValg.VARSEL_OM_AKTIVITETSPLIKT);
     } else {
         automatiskBrev.delete(AutomatiskBrevValg.VARSEL_OM_AKTIVITETSPLIKT);


### PR DESCRIPTION
Det gir bare mening å sende brev om aktivitetsplikt for gammelt regelverk.

Koden før denne endringen huker av for aktivitetsplikt automatisk dersom barn er mellom halvt år og ett år. Nå hukes den ikke av lenger dersom featuretoggle er på, samt at teksten legges til på checkbox: "Kun saker etter gammelt regelverk skal ha dette brevet"

<img width="1776" height="968" alt="Screenshot 2026-06-02 at 10 14 32" src="https://github.com/user-attachments/assets/e1db5e05-c501-487e-8566-39ece70da81f" />

Tekst justeres etter innspill fra funksjonelle.
