### PR TITLE
Filtrer bort brevmal-valg som er irrelavant for regelverket som behan…

### DIFF
--- a/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevTyper.ts
@@ -101,7 +101,14 @@ export interface DokumentNavn {
     overgangsstonad?: boolean;
     barnetilsyn?: boolean;
     skolepenger?: boolean;
+    regelverkVersjon?: RegelverkVersjon;
     frittstaendeBrev?: { tittelDokumentoversikt: string; valgtSomFrittstaendeBrev?: boolean };
+}
+
+export enum RegelverkVersjon {
+    NYTT_REGELVERK = 'nytt_regelverk',
+    GAMMELT_REGELVERK = 'gammelt_regelverk',
+    BEGGE_REGELVERK = 'begge_regelverk',
 }
 
 export type FrittståendeSanitybrevDto = {

--- a/src/frontend/Komponenter/Behandling/Brev/BrevmalSelect.tsx
+++ b/src/frontend/Komponenter/Behandling/Brev/BrevmalSelect.tsx
@@ -1,10 +1,11 @@
 import { Ressurs, RessursStatus } from '../../../App/typer/ressurs';
-import { DokumentNavn } from './BrevTyper';
+import { DokumentNavn, RegelverkVersjon } from './BrevTyper';
 import React, { Dispatch, SetStateAction } from 'react';
 import DataViewer from '../../../Felles/DataViewer/DataViewer';
 import { Select } from '@navikt/ds-react';
 import { visBrevmal } from './BrevUtils';
 import { Stønadstype } from '../../../App/typer/behandlingstema';
+import { useBehandling } from '../../../App/context/BehandlingContext.tsx';
 
 type BrevmalSelectProps = {
     dokumentnavn: Ressurs<DokumentNavn[]>;
@@ -20,8 +21,20 @@ export const BrevmalSelect: React.FC<BrevmalSelectProps> = ({
     stønanadstype,
     frittstående,
 }) => {
+    const { erRegelendring2026 } = useBehandling();
     const filtrerBrevmaler = (dokumentnanvn: DokumentNavn[]) => {
-        return dokumentnanvn?.filter((mal) => visBrevmal(mal, stønanadstype, frittstående));
+        const stønadsFiltrert = dokumentnanvn?.filter((mal) =>
+            visBrevmal(mal, stønanadstype, frittstående)
+        );
+        if (frittstående || erRegelendring2026 == null) return stønadsFiltrert;
+        return stønadsFiltrert.filter((mal) => {
+            if (mal.regelverkVersjon == null) return true;
+            return erRegelendring2026
+                ? mal.regelverkVersjon === RegelverkVersjon.NYTT_REGELVERK ||
+                      mal.regelverkVersjon === RegelverkVersjon.BEGGE_REGELVERK
+                : mal.regelverkVersjon === RegelverkVersjon.GAMMELT_REGELVERK ||
+                      mal.regelverkVersjon === RegelverkVersjon.BEGGE_REGELVERK;
+        });
     };
 
     const sorterPåPrioriteringsnummerDeretterAlfabetisk = (dokumentnanvn: DokumentNavn[]) => {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Lagt til mulighet for å tagge brev med hvilket regelverk det skal være mulig å velge de på.
Saker som har regelverkVersjon = null (ikke huket av i sanity) eller "begge" vises i begge for bakoverkompatabilitet frem til man tar en avgjørelse på hver brevmal.

For behandlinger som behandles etter nytt regelverk vises derfor brev tagget med "begge_regelverk", "nytt_regelverk" og de som ikke er tagget

For behandlinger som behandles etter gammelt regelverk vises derfor brev tagget med "begge_regelverk", "gammelt_regelverk" og de som ikke er tagget

Testet ved å lage 3 nye brev med valgene av regelverk enten "begge_regelverk", "gammelt_regelverk" eller "nytt_regelverk", og sjekket at de dukker opp i riktig flyt som beskrevet over