### PR TITLE
Legger til muligheten for opphør som periode i ny flyt

### DIFF
--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/VedtakperiodeSelect.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Overgangsstønad/InnvilgeVedtak/VedtakperiodeSelect.tsx
@@ -33,6 +33,7 @@ const valgbarePeriodetyper2026Regelendring = [
     EPeriodetype.BARN_UNDER_14_MÅNEDER,
     EPeriodetype.SÆRLIG_TILSYNSKREVENDE_BARN,
     EPeriodetype.FORBIGÅENDE_SYKDOM_HOS_BARNET,
+    EPeriodetype.MIDLERTIDIG_OPPHØR,
 ];
 
 const VedtakperiodeSelect: FC<VedtakperiodeSelectProps> = ({


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Legger til mulighet for opphør i ny flyt. Gjenbruker gammel periodeType, og logikken er derfor den samme som gammelt regelverk

<img width="1079" height="410" alt="image" src="https://github.com/user-attachments/assets/66a37df4-adb1-4100-b99f-6ff21741696e" />
