### PR TITLE
Modal bekreft endring regelverk

### DIFF
--- a/src/frontend/Komponenter/Behandling/Vurdering/BehandleSom2026Regelendring.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/BehandleSom2026Regelendring.tsx
@@ -1,3 +1,4 @@
+import type { FC } from 'react';
 import { useState } from 'react';
 import { useBehandling } from '../../../App/context/BehandlingContext.tsx';
 import { useApp } from '../../../App/context/AppContext.tsx';

--- a/src/frontend/Komponenter/Behandling/Vurdering/BehandleSom2026Regelendring.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/BehandleSom2026Regelendring.tsx
@@ -7,7 +7,7 @@ import { RessursStatus } from '../../../App/typer/ressurs.ts';
 import { useParams } from 'react-router-dom';
 import { BekreftRegelendringModal } from './BekreftRegelendringModal.tsx';
 
-export const BehandleSom2026Regelendring: React.FC = () => {
+export const BehandleSom2026Regelendring: FC = () => {
     const { behandlingId } = useParams<{ behandlingId: string }>();
     const { erRegelendring2026, settErRegelendring2026, behandlingErRedigerbar, hentBehandling } =
         useBehandling();

--- a/src/frontend/Komponenter/Behandling/Vurdering/BehandleSom2026Regelendring.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/BehandleSom2026Regelendring.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { useState } from 'react';
 import { useBehandling } from '../../../App/context/BehandlingContext.tsx';
 import { useApp } from '../../../App/context/AppContext.tsx';

--- a/src/frontend/Komponenter/Behandling/Vurdering/BehandleSom2026Regelendring.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/BehandleSom2026Regelendring.tsx
@@ -1,25 +1,45 @@
 import * as React from 'react';
+import { useState } from 'react';
 import { useBehandling } from '../../../App/context/BehandlingContext.tsx';
 import { useApp } from '../../../App/context/AppContext.tsx';
-import { VStack, Radio, RadioGroup, BodyShort } from '@navikt/ds-react';
+import { BodyShort, Radio, RadioGroup, VStack } from '@navikt/ds-react';
 import { RessursStatus } from '../../../App/typer/ressurs.ts';
 import { useParams } from 'react-router-dom';
+import { BekreftRegelendringModal } from './BekreftRegelendringModal.tsx';
 
 export const BehandleSom2026Regelendring: React.FC = () => {
     const { behandlingId } = useParams<{ behandlingId: string }>();
-    const { erRegelendring2026, settErRegelendring2026, behandlingErRedigerbar } = useBehandling();
+    const { erRegelendring2026, settErRegelendring2026, behandlingErRedigerbar, hentBehandling } =
+        useBehandling();
     const { axiosRequest } = useApp();
 
-    const oppdaterRegelendring = (nyVerdi: boolean) => {
+    const [visBekreftelsesmodal, settVisBekreftelsesmodal] = useState(false);
+    const [pendingVerdi, settNyVerdi] = useState<boolean | null>(null);
+
+    const håndterRegelendring = (nyVerdi: boolean) => {
+        settNyVerdi(nyVerdi);
+        settVisBekreftelsesmodal(true);
+    };
+
+    const bekreftEndring = () => {
+        if (pendingVerdi === null) return;
         axiosRequest<string, { erRegelendring2026: boolean }>({
             method: 'POST',
             url: `/familie-ef-sak/api/behandling/${behandlingId}/regelendring-2026`,
-            data: { erRegelendring2026: nyVerdi },
+            data: { erRegelendring2026: pendingVerdi },
         }).then((res) => {
             if (res.status === RessursStatus.SUKSESS) {
-                settErRegelendring2026(nyVerdi);
+                settErRegelendring2026(pendingVerdi);
+                hentBehandling.rerun();
             }
         });
+        settVisBekreftelsesmodal(false);
+        settNyVerdi(null);
+    };
+
+    const avbrytEndring = () => {
+        settVisBekreftelsesmodal(false);
+        settNyVerdi(null);
     };
 
     return (
@@ -31,12 +51,19 @@ export const BehandleSom2026Regelendring: React.FC = () => {
                 legend="Behandle etter nytt regelverk (2026)"
                 hideLegend
                 value={erRegelendring2026}
-                onChange={oppdaterRegelendring}
+                onChange={håndterRegelendring}
                 readOnly={!behandlingErRedigerbar}
             >
                 <Radio value={true}>Nytt regelverk (fra 01.07.2026)</Radio>
                 <Radio value={false}>Gammelt regelverk</Radio>
             </RadioGroup>
+
+            <BekreftRegelendringModal
+                open={visBekreftelsesmodal}
+                nyVerdi={pendingVerdi}
+                onBekreft={bekreftEndring}
+                onAvbryt={avbrytEndring}
+            />
         </VStack>
     );
 };

--- a/src/frontend/Komponenter/Behandling/Vurdering/BehandleSom2026Regelendring.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/BehandleSom2026Regelendring.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import React, { FC } from 'react';
 import { useState } from 'react';
 import { useBehandling } from '../../../App/context/BehandlingContext.tsx';
 import { useApp } from '../../../App/context/AppContext.tsx';

--- a/src/frontend/Komponenter/Behandling/Vurdering/BekreftRegelendringModal.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/BekreftRegelendringModal.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { FC } from 'react';
 import { BodyLong, Button, Modal } from '@navikt/ds-react';
 
 interface Props {

--- a/src/frontend/Komponenter/Behandling/Vurdering/BekreftRegelendringModal.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/BekreftRegelendringModal.tsx
@@ -8,12 +8,7 @@ interface Props {
     onAvbryt: () => void;
 }
 
-export const BekreftRegelendringModal: React.FC<Props> = ({
-    open,
-    nyVerdi,
-    onBekreft,
-    onAvbryt,
-}) => {
+export const BekreftRegelendringModal: FC<Props> = ({ open, nyVerdi, onBekreft, onAvbryt }) => {
     const regelverkLabel = nyVerdi ? 'nytt regelverk (fra 01.07.2026)' : 'gammelt regelverk';
 
     return (

--- a/src/frontend/Komponenter/Behandling/Vurdering/BekreftRegelendringModal.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/BekreftRegelendringModal.tsx
@@ -1,4 +1,4 @@
-import type { FC } from 'react';
+import React, { FC } from 'react';
 import { BodyLong, Button, Modal } from '@navikt/ds-react';
 
 interface Props {

--- a/src/frontend/Komponenter/Behandling/Vurdering/BekreftRegelendringModal.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/BekreftRegelendringModal.tsx
@@ -1,0 +1,37 @@
+import * as React from 'react';
+import { BodyLong, Button, Modal } from '@navikt/ds-react';
+
+interface Props {
+    open: boolean;
+    nyVerdi: boolean | null;
+    onBekreft: () => void;
+    onAvbryt: () => void;
+}
+
+export const BekreftRegelendringModal: React.FC<Props> = ({
+    open,
+    nyVerdi,
+    onBekreft,
+    onAvbryt,
+}) => {
+    const regelverkLabel = nyVerdi ? 'nytt regelverk (fra 01.07.2026)' : 'gammelt regelverk';
+
+    return (
+        <Modal open={open} onClose={onAvbryt} header={{ heading: 'Bekreft endring av regelverk' }}>
+            <Modal.Body>
+                <BodyLong>Er du sikker på at du vil bytte til {regelverkLabel}?</BodyLong>
+                <BodyLong>
+                    Dette vil fjerne data du allerede har fylt inn i senere behandlingssteg.
+                </BodyLong>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button type="button" onClick={onBekreft}>
+                    Ja, bytt regelverk
+                </Button>
+                <Button type="button" variant="secondary" onClick={onAvbryt}>
+                    Avbryt
+                </Button>
+            </Modal.Footer>
+        </Modal>
+    );
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Lagt til modal for å bekrefte om du har lyst til å bytte regelverk for behandling. Dette for å advare saksbehandler om at dette vil fjerne det saksbehandler tidligere har fylt inn.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-29506)

<img width="557" height="222" alt="bilde" src="https://github.com/user-attachments/assets/f37b50e8-62d9-4e92-8b6d-d31dc522d4a7" />
