### PR TITLE
Fiks av a-inntekt som henger på forrige bruker

### DIFF
--- a/src/frontend/App/typer/toast.ts
+++ b/src/frontend/App/typer/toast.ts
@@ -13,6 +13,7 @@ export enum EToast {
     BEHANDLING_SATT_PÅ_VENT = 'BEHANDLING_SATT_PÅ_VENT',
     BEHANDLING_TATT_AV_VENT = 'BEHANDLING_TATT_AV_VENT',
     JOURNALFØRING_VELLYKKET = 'JOURNALFØRING_VELLYKKET',
+    AINNTEKT_FEILET = 'AINNTEKT_FEILET',
 }
 
 export const toastTilTekst: Record<EToast, string> = {
@@ -33,4 +34,5 @@ export const toastTilTekst: Record<EToast, string> = {
     BEHANDLING_SATT_PÅ_VENT: 'Oppgaven er oppdatert og behandlingen er satt på vent',
     BEHANDLING_TATT_AV_VENT: 'Behandlingen er tatt av vent. Du er satt som ansvarlig saksbehandler',
     JOURNALFØRING_VELLYKKET: 'Journalføring vellykket',
+    AINNTEKT_FEILET: 'Kunne ikke åpne A-inntekt for riktig person. Prøv igjen.',
 };

--- a/src/frontend/Felles/HeaderMedSøk/Header/HeaderMedSøk.tsx
+++ b/src/frontend/Felles/HeaderMedSøk/Header/HeaderMedSøk.tsx
@@ -8,6 +8,7 @@ import { AxiosRequestCallback } from '../../../App/typer/axiosRequest';
 import { harTilgangTilRolle } from '../../../App/utils/roller';
 import { useToggles } from '../../../App/context/TogglesContext';
 import { ToggleName } from '../../../App/context/toggles';
+import { EToast } from '../../../App/typer/toast';
 import { Sticky } from '../../Visningskomponenter/Sticky';
 import { lagArbeidsverktøyLenker, lagEksterneLenker, lagInterneLenker } from '../utils';
 import { Header, PopoverItem } from './header/Header';
@@ -19,7 +20,9 @@ export interface Props {
     innloggetSaksbehandler: ISaksbehandler;
 }
 export const HeaderMedSøk: React.FunctionComponent<Props> = ({ innloggetSaksbehandler }) => {
-    const { axiosRequest, appEnv, valgtFagsakId, valgtFagsakPersonId, personIdent } = useApp();
+    const { axiosRequest, appEnv, valgtFagsakId, valgtFagsakPersonId, personIdent, settToast } =
+        useApp();
+
     const { toggles } = useToggles();
     const erSaksbehandler = harTilgangTilRolle(appEnv, innloggetSaksbehandler, 'saksbehandler');
     const kanOppretteBehandlingForFerdigstiltJournalpost =
@@ -36,7 +39,8 @@ export const HeaderMedSøk: React.FunctionComponent<Props> = ({ innloggetSaksbeh
                 valgtFagsakId,
                 valgtFagsakPersonId,
                 personIdent,
-                skalViseBeregningsskjemaLenke
+                skalViseBeregningsskjemaLenke,
+                settToast
             ),
         [
             axiosRequest,
@@ -47,6 +51,7 @@ export const HeaderMedSøk: React.FunctionComponent<Props> = ({ innloggetSaksbeh
             valgtFagsakPersonId,
             personIdent,
             skalViseBeregningsskjemaLenke,
+            settToast,
         ]
     );
 
@@ -96,7 +101,8 @@ const lagHeaderLenker = (
     fagsakId: string | undefined,
     fagsakPersonId: string | undefined,
     personIdent: string | undefined,
-    skalViseBeregningsskjemaLenke: boolean
+    skalViseBeregningsskjemaLenke: boolean,
+    settToast: (toast: EToast) => void
 ): PopoverItem[] => {
     const interneLenker = erSaksbehandler
         ? lagInterneLenker(kanOppretteBehandlingForFerdigstiltJournalpost)
@@ -107,7 +113,8 @@ const lagHeaderLenker = (
         appEnv,
         fagsakId,
         fagsakPersonId,
-        personIdent
+        personIdent,
+        settToast
     );
 
     const arbeidsverktøyLenker = lagArbeidsverktøyLenker(

--- a/src/frontend/Felles/HeaderMedSøk/utils.ts
+++ b/src/frontend/Felles/HeaderMedSøk/utils.ts
@@ -3,6 +3,7 @@ import { AppEnv } from '../../App/api/env';
 import { lagAInntektLink } from '../Lenker/Lenker';
 import { LenkeType, PopoverItem } from './Header/header/Header';
 import { Adressebeskyttelsegradering } from './Header/søkeresultat';
+import { EToast } from '../../App/typer/toast';
 
 export const adressebeskyttelsestyper: Record<Adressebeskyttelsegradering, string> = {
     STRENGT_FORTROLIG: 'strengt fortrolig',
@@ -15,7 +16,8 @@ export const lagAInntektLenke = (
     axiosRequest: AxiosRequestCallback,
     appEnv: AppEnv,
     fagsakId: string | undefined,
-    fagsakPersonId: string | undefined
+    fagsakPersonId: string | undefined,
+    settToast: (toast: EToast) => void
 ): PopoverItem => {
     if (!fagsakPersonId && !fagsakId) {
         return {
@@ -30,7 +32,12 @@ export const lagAInntektLenke = (
         name: 'A-inntekt',
         type: LenkeType.EKSTERN,
         onSelect: async () => {
-            window.open(await lagAInntektLink(axiosRequest, appEnv, fagsakId, fagsakPersonId));
+            const aInntektLink = await lagAInntektLink(axiosRequest, fagsakId, fagsakPersonId);
+            if (aInntektLink) {
+                window.open(aInntektLink);
+            } else {
+                settToast(EToast.AINNTEKT_FEILET);
+            }
         },
     };
 };
@@ -148,9 +155,10 @@ export const lagEksterneLenker = (
     appEnv: AppEnv,
     fagsakId: string | undefined,
     fagsakPersonId: string | undefined,
-    personIdent: string | undefined
+    personIdent: string | undefined,
+    settToast: (toast: EToast) => void
 ) => [
-    lagAInntektLenke(axiosRequest, appEnv, fagsakId, fagsakPersonId),
+    lagAInntektLenke(axiosRequest, appEnv, fagsakId, fagsakPersonId, settToast),
     lagGosysLenke(appEnv, personIdent),
     lagModiaLenke(appEnv, personIdent),
     lagHistoriskPensjonLenke(appEnv),

--- a/src/frontend/Felles/Lenker/Lenker.ts
+++ b/src/frontend/Felles/Lenker/Lenker.ts
@@ -1,14 +1,12 @@
 import { AxiosError } from 'axios';
-import { AppEnv } from '../../App/api/env';
 import { Ressurs, RessursStatus } from '../../App/typer/ressurs';
 import { AxiosRequestCallback } from '../../App/typer/axiosRequest';
 
 export const lagAInntektLink = async (
     axiosRequest: AxiosRequestCallback,
-    appEnv: AppEnv,
     fagsakId: string | undefined,
     fagsakPersonId: string | undefined
-): Promise<string> => {
+): Promise<string | null> => {
     const url = fagsakPersonId
         ? `/familie-ef-sak/api/inntekt/fagsak-person/${fagsakPersonId}/generer-url`
         : `/familie-ef-sak/api/inntekt/fagsak/${fagsakId}/generer-url`;
@@ -17,29 +15,36 @@ export const lagAInntektLink = async (
         url: url,
     })
         .then((response: Ressurs<string>) => {
-            return response.status === RessursStatus.SUKSESS ? response.data : appEnv.aInntekt;
+            if (response.status === RessursStatus.SUKSESS) {
+                return response.data;
+            }
+            console.error('Klarte ikke generere A-inntekt-lenke', url, response);
+            return null;
         })
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        .catch((_: AxiosError<string>) => {
-            return appEnv.aInntekt;
+        .catch((error: AxiosError<string>) => {
+            console.error('Klarte ikke generere A-inntekt-lenke', url, error);
+            return null;
         });
 };
 
 export const lagArbeidsforholdLink = async (
     axiosRequest: AxiosRequestCallback,
-    appEnv: AppEnv,
     fagsakId: string | undefined
-): Promise<string> => {
+): Promise<string | null> => {
     const url = `/familie-ef-sak/api/inntekt/fagsak/${fagsakId}/generer-url-arbeidsforhold`;
     return await axiosRequest<string, null>({
         method: 'GET',
         url: url,
     })
         .then((response: Ressurs<string>) => {
-            return response.status === RessursStatus.SUKSESS ? response.data : appEnv.aInntekt;
+            if (response.status === RessursStatus.SUKSESS) {
+                return response.data;
+            }
+            console.error('Klarte ikke generere arbeidsforhold lenke', url, response);
+            return null;
         })
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        .catch((_: AxiosError<string>) => {
-            return appEnv.aInntekt;
+        .catch((error: AxiosError<string>) => {
+            console.error('Klarte ikke generere arbeidsforhold lenke', url, error);
+            return null;
         });
 };

--- a/src/frontend/Komponenter/Behandling/Aktivitet/SagtOppEllerRedusert/SagtOppEllerRedusertInfo.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/SagtOppEllerRedusert/SagtOppEllerRedusertInfo.tsx
@@ -15,6 +15,7 @@ import { InformasjonContainer } from '../../Vilkårpanel/StyledVilkårInnhold';
 import { lagArbeidsforholdLink } from '../../../../Felles/Lenker/Lenker';
 import { useApp } from '../../../../App/context/AppContext';
 import { Link } from '@navikt/ds-react';
+import { EToast } from '../../../../App/typer/toast';
 
 interface Props {
     sagtOppEllerRedusert: ISagtOppEllerRedusertStilling;
@@ -68,7 +69,7 @@ const HarSagtOppEllerRedusertStilling: React.FC<ISagtOppEllerRedusertStilling> =
     const harSagtOpp = sagtOppEllerRedusertStilling === ESagtOppEllerRedusert.sagtOpp;
     const harRedusertStilling =
         sagtOppEllerRedusertStilling === ESagtOppEllerRedusert.redusertStilling;
-    const { axiosRequest, appEnv, valgtFagsakId } = useApp();
+    const { axiosRequest, valgtFagsakId, settToast } = useApp();
     return (
         <>
             <Informasjonsrad
@@ -118,9 +119,15 @@ const HarSagtOppEllerRedusertStilling: React.FC<ISagtOppEllerRedusertStilling> =
                             href="#"
                             onClick={async (e: React.SyntheticEvent) => {
                                 e.preventDefault();
-                                window.open(
-                                    await lagArbeidsforholdLink(axiosRequest, appEnv, valgtFagsakId)
+                                const arbeidsforholdLink = await lagArbeidsforholdLink(
+                                    axiosRequest,
+                                    valgtFagsakId
                                 );
+                                if (arbeidsforholdLink) {
+                                    window.open(arbeidsforholdLink);
+                                } else {
+                                    settToast(EToast.AINNTEKT_FEILET);
+                                }
                             }}
                         >
                             Se arbeidsforhold i arbeidsregisteret


### PR DESCRIPTION
# Fiks av a-inntekt som henger på forrige bruker

### Hvorfor er denne endringen nødvendig? ✨

Når man åpnet a-inntekt fra EF-sak kunne den noen ganger vise forrige bruker, selv om man sto på en ny person. Det kan slå uheldig ut hvis man vurderer inntekt på feil bruker uten å merke det.

Årsaken vi tror på: når kallet som genererer a-inntekt lenken feiler, falt vi før i stillhet tilbake til den generiske a-inntekt forsiden uten ident. Den siden viser da forrige person fra a-inntekt sin egen session, og brukeren fikk ingen feilmelding.

Hva vi gjør nå:

* Vi åpner ikke lenger den generiske siden ved feil.
* I stedet får saksbehandler en toast om at det ikke gikk, og kan prøve på nytt.
* Vi logger feilen i console så den blir synlig (var helt usynlig før).

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-29582).

Denne PRen er en del av en bredre oppgave og depender på denne → [PRen](https://github.com/navikt/familie-ef-sak/pull/3211).

### Verdt å nevne

* Testet normal flyt: klikket A-inntekt på en sak og riktig person åpnes som før.
* Samme fiks er lagt på lenken for arbeidsforhold (aareg), som hadde nøyaktig samme stille fallback.
* Når det ikke finnes en valgt person (for eksempel oppgavebenken) åpner vi fortsatt den generiske forsiden, som er riktig der.
