### PR TITLE
Tag regelverk + tag forbedring + endre tekst

### DIFF
--- a/src/frontend/App/typer/behandlingstype.ts
+++ b/src/frontend/App/typer/behandlingstype.ts
@@ -19,15 +19,15 @@ export const behandlingstypeTilTekstKort: Record<Behandlingstype, string> = {
     KLAGE: 'K',
 };
 
-export type RegelverkType = 'NYTT_REGELVERK' | 'GAMMELT_REGELVERK';
+export type RegelverkType = 'NYTT_REGELVERK' | 'TIDLIGERE_REGELVERK';
 
 export const regelverkLabel = {
     NYTT_REGELVERK: {
-        tekst: 'Nytt regelverk (fra 01.07.2026)',
+        tekst: 'Nytt regelverk fra 01.07.2026',
         kortTekst: 'Regelverk 2026',
     },
-    GAMMELT_REGELVERK: {
-        tekst: 'Gammelt regelverk',
-        kortTekst: 'Gamle regler',
+    TIDLIGERE_REGELVERK: {
+        tekst: 'Tidligere regelverk før 01.07.2026',
+        kortTekst: 'Tidligere regelverk',
     },
 } satisfies Record<RegelverkType, { tekst: string; kortTekst: string }>;

--- a/src/frontend/App/typer/behandlingstype.ts
+++ b/src/frontend/App/typer/behandlingstype.ts
@@ -18,3 +18,16 @@ export const behandlingstypeTilTekstKort: Record<Behandlingstype, string> = {
     TILBAKEKREVING: 'T',
     KLAGE: 'K',
 };
+
+export type RegelverkType = 'NYTT_REGELVERK' | 'GAMMELT_REGELVERK';
+
+export const regelverkLabel = {
+    NYTT_REGELVERK: {
+        tekst: 'Nytt regelverk (fra 01.07.2026)',
+        kortTekst: 'Regelverk 2026',
+    },
+    GAMMELT_REGELVERK: {
+        tekst: 'Gammelt regelverk',
+        kortTekst: 'Gamle regler',
+    },
+} satisfies Record<RegelverkType, { tekst: string; kortTekst: string }>;

--- a/src/frontend/Felles/PersonHeader/BehandlingTags.tsx
+++ b/src/frontend/Felles/PersonHeader/BehandlingTags.tsx
@@ -1,33 +1,40 @@
 import { Behandling, BehandlingKategori, kategoriTilTekst } from '../../App/typer/fagsak';
-import { Tag } from '@navikt/ds-react';
+import { Hide, Tag } from '@navikt/ds-react';
 import { stønadstypeTilTekst, stønadstypeTilTekstKort } from '../../App/typer/behandlingstema';
 import {
     behandlingstypeTilTekst,
     behandlingstypeTilTekstKort,
+    regelverkLabel,
+    RegelverkType,
 } from '../../App/typer/behandlingstype';
 import { Behandlingsårsak, behandlingsårsakTilTekst } from '../../App/typer/behandlingsårsak';
 import React from 'react';
-import styled from 'styled-components';
-
-const TagLitenSkjerm = styled(Tag)`
-    @media screen and (min-width: 1190px) {
-        display: none;
-    }
-
-    @media screen and (max-width: 805px) {
-        display: none;
-    }
-`;
-
-const TagStorSkjerm = styled(Tag)`
-    @media screen and (max-width: 1189px) {
-        display: none;
-    }
-`;
 
 interface Props {
     behandling: Behandling;
 }
+
+interface ResponsivTagProps extends Omit<React.ComponentProps<typeof Tag>, 'children' | 'size'> {
+    kortTekst: string;
+    tekst: string;
+}
+
+const ResponsivTag: React.FC<ResponsivTagProps> = ({ kortTekst, tekst, ...tagProps }) => {
+    return (
+        <>
+            <Hide below="md" above="xl" asChild>
+                <Tag {...tagProps} size={'small'}>
+                    {kortTekst}
+                </Tag>
+            </Hide>
+            <Hide below="xl" asChild>
+                <Tag {...tagProps} size={'small'}>
+                    {tekst}
+                </Tag>
+            </Hide>
+        </>
+    );
+};
 
 const utledBehandlingsårsakKortTekst = (behandlingÅrsak: Behandlingsårsak) => {
     switch (behandlingÅrsak) {
@@ -41,10 +48,19 @@ const utledBehandlingsårsakKortTekst = (behandlingÅrsak: Behandlingsårsak) =>
 };
 
 const BehandlingTags: React.FC<Props> = ({ behandling }) => {
-    const { behandlingsårsak, kategori, stønadstype, type } = behandling;
+    const { behandlingsårsak, kategori, stønadstype, type, erRegelendring2026, status } =
+        behandling;
     const skalViseBehandlingsårsak =
         behandlingsårsak === Behandlingsårsak.PAPIRSØKNAD ||
         behandlingsårsak === Behandlingsårsak.MANUELT_OPPRETTET;
+
+    const erBehandlingFerdigstilt = status === 'FERDIGSTILT';
+
+    const regelverkNøkkel: RegelverkType = erRegelendring2026
+        ? 'NYTT_REGELVERK'
+        : 'GAMMELT_REGELVERK';
+
+    const valgtRegelverkLabel = regelverkLabel[regelverkNøkkel];
 
     return (
         <>
@@ -53,27 +69,29 @@ const BehandlingTags: React.FC<Props> = ({ behandling }) => {
                     {kategoriTilTekst[kategori]}
                 </Tag>
             )}
-            <TagLitenSkjerm variant={'success'} size={'small'}>
-                {stønadstypeTilTekstKort[stønadstype]}
-            </TagLitenSkjerm>
-            <TagStorSkjerm variant={'success'} size={'small'}>
-                {stønadstypeTilTekst[stønadstype]}
-            </TagStorSkjerm>
-            <TagLitenSkjerm variant={'info'} size={'small'}>
-                {behandlingstypeTilTekstKort[type]}
-            </TagLitenSkjerm>
-            <TagStorSkjerm variant={'info'} size={'small'}>
-                {behandlingstypeTilTekst[type]}
-            </TagStorSkjerm>
+            <ResponsivTag
+                variant={'success'}
+                kortTekst={stønadstypeTilTekstKort[stønadstype]}
+                tekst={stønadstypeTilTekst[stønadstype]}
+            />
+            <ResponsivTag
+                variant={'info'}
+                kortTekst={behandlingstypeTilTekstKort[type]}
+                tekst={behandlingstypeTilTekst[type]}
+            />
+            {erBehandlingFerdigstilt && (
+                <ResponsivTag
+                    data-color="meta-purple"
+                    kortTekst={valgtRegelverkLabel.kortTekst}
+                    tekst={valgtRegelverkLabel.tekst}
+                />
+            )}
             {skalViseBehandlingsårsak && (
-                <>
-                    <TagLitenSkjerm variant={'warning'} size={'small'}>
-                        {utledBehandlingsårsakKortTekst(behandlingsårsak)}
-                    </TagLitenSkjerm>
-                    <TagStorSkjerm variant={'warning'} size={'small'}>
-                        {behandlingsårsakTilTekst[behandlingsårsak]}
-                    </TagStorSkjerm>
-                </>
+                <ResponsivTag
+                    variant={'warning'}
+                    kortTekst={utledBehandlingsårsakKortTekst(behandlingsårsak)}
+                    tekst={behandlingsårsakTilTekst[behandlingsårsak]}
+                />
             )}
         </>
     );

--- a/src/frontend/Felles/PersonHeader/BehandlingTags.tsx
+++ b/src/frontend/Felles/PersonHeader/BehandlingTags.tsx
@@ -58,7 +58,7 @@ const BehandlingTags: React.FC<Props> = ({ behandling }) => {
 
     const regelverkNøkkel: RegelverkType = erRegelendring2026
         ? 'NYTT_REGELVERK'
-        : 'GAMMELT_REGELVERK';
+        : 'TIDLIGERE_REGELVERK';
 
     const valgtRegelverkLabel = regelverkLabel[regelverkNøkkel];
 

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/AutomatiskBrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/AutomatiskBrev.tsx
@@ -26,7 +26,7 @@ export const AutomatiskBrev: FC<{
                 <Checkbox key={valg} value={valg}>
                     {automatiskBrevValgTekst[valg]}
                     {erOvergangsregel &&
-                        ' – Kun saker etter gammelt regelverk skal ha dette brevet.'}
+                        ' – Kun saker etter tidligere regelverk skal ha dette brevet.'}
                 </Checkbox>
             ))}
         </CheckboxGroup>

--- a/src/frontend/Komponenter/Behandling/Vurdering/BehandleSom2026Regelendring.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/BehandleSom2026Regelendring.tsx
@@ -6,6 +6,7 @@ import { BodyShort, Radio, RadioGroup, VStack } from '@navikt/ds-react';
 import { RessursStatus } from '../../../App/typer/ressurs.ts';
 import { useParams } from 'react-router-dom';
 import { BekreftRegelendringModal } from './BekreftRegelendringModal.tsx';
+import { regelverkLabel } from '../../../App/typer/behandlingstype.ts';
 
 export const BehandleSom2026Regelendring: FC = () => {
     const { behandlingId } = useParams<{ behandlingId: string }>();
@@ -60,8 +61,8 @@ export const BehandleSom2026Regelendring: FC = () => {
                 onChange={håndterRegelendring}
                 readOnly={!behandlingErRedigerbar}
             >
-                <Radio value={true}>Nytt regelverk (fra 01.07.2026)</Radio>
-                <Radio value={false}>Gammelt regelverk</Radio>
+                <Radio value={true}> {regelverkLabel.NYTT_REGELVERK.tekst}</Radio>
+                <Radio value={false}>{regelverkLabel.GAMMELT_REGELVERK.tekst}</Radio>
             </RadioGroup>
 
             <BekreftRegelendringModal

--- a/src/frontend/Komponenter/Behandling/Vurdering/BehandleSom2026Regelendring.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/BehandleSom2026Regelendring.tsx
@@ -52,7 +52,7 @@ export const BehandleSom2026Regelendring: FC = () => {
     return (
         <VStack>
             <BodyShort>
-                Ønsker du å behandle denne saken etter nytt eller gammelt regelverk?
+                Ønsker du å behandle denne saken etter nytt eller tidligere regelverk?
             </BodyShort>
             <RadioGroup
                 legend="Behandle etter nytt regelverk (2026)"
@@ -62,7 +62,7 @@ export const BehandleSom2026Regelendring: FC = () => {
                 readOnly={!behandlingErRedigerbar}
             >
                 <Radio value={true}> {regelverkLabel.NYTT_REGELVERK.tekst}</Radio>
-                <Radio value={false}>{regelverkLabel.GAMMELT_REGELVERK.tekst}</Radio>
+                <Radio value={false}>{regelverkLabel.TIDLIGERE_REGELVERK.tekst}</Radio>
             </RadioGroup>
 
             <BekreftRegelendringModal

--- a/src/frontend/Komponenter/Behandling/Vurdering/BekreftRegelendringModal.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/BekreftRegelendringModal.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 import { BodyLong, Button, Modal } from '@navikt/ds-react';
+import { regelverkLabel } from '../../../App/typer/behandlingstype';
 
 interface Props {
     open: boolean;
@@ -9,12 +10,14 @@ interface Props {
 }
 
 export const BekreftRegelendringModal: FC<Props> = ({ open, nyVerdi, onBekreft, onAvbryt }) => {
-    const regelverkLabel = nyVerdi ? 'nytt regelverk (fra 01.07.2026)' : 'gammelt regelverk';
+    const valgtRegelverkLabel = (
+        nyVerdi ? regelverkLabel.NYTT_REGELVERK.tekst : regelverkLabel.GAMMELT_REGELVERK.tekst
+    ).toLowerCase();
 
     return (
         <Modal open={open} onClose={onAvbryt} header={{ heading: 'Bekreft endring av regelverk' }}>
             <Modal.Body>
-                <BodyLong>Er du sikker på at du vil bytte til {regelverkLabel}?</BodyLong>
+                <BodyLong>Er du sikker på at du vil bytte til {valgtRegelverkLabel}?</BodyLong>
                 <BodyLong>
                     Dette vil fjerne data du allerede har fylt inn i senere behandlingssteg.
                 </BodyLong>

--- a/src/frontend/Komponenter/Behandling/Vurdering/BekreftRegelendringModal.tsx
+++ b/src/frontend/Komponenter/Behandling/Vurdering/BekreftRegelendringModal.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 export const BekreftRegelendringModal: FC<Props> = ({ open, nyVerdi, onBekreft, onAvbryt }) => {
     const valgtRegelverkLabel = (
-        nyVerdi ? regelverkLabel.NYTT_REGELVERK.tekst : regelverkLabel.GAMMELT_REGELVERK.tekst
+        nyVerdi ? regelverkLabel.NYTT_REGELVERK.tekst : regelverkLabel.TIDLIGERE_REGELVERK.tekst
     ).toLowerCase();
 
     return (


### PR DESCRIPTION
- Legger til tag som viser regelverk når en behandling er ferdigstilt, for å gjøre det enklere og raskere å se.
- Laget en konstant av tekst for nytt/gammelt regelverk, samme tekst ble brukt flere steder, er nå enklere å endre på sikt og holde lik.
- Refaktorert TagLitenSkjerm/TagStorSkjerm for å redusere duplikat kode og skrive oss bort fra styled components
- Fått tilbakemeldinger fra fag om å endre ordlyd på gammelt regelverk til tidligere regelverk

<img width="1717" height="1108" alt="image" src="https://github.com/user-attachments/assets/9c7193bf-0e09-4335-8959-ebd1f5bc5f83" />
