### PR TITLE
Regelendring 2026 hva er situasjon hjelpetekst

### DIFF
--- a/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/AktivitetInfoRegelendring2026.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/AktivitetInfoRegelendring2026.tsx
@@ -10,6 +10,7 @@ import { BodyShortSmall } from '../../../../Felles/Visningskomponenter/Tekster';
 import { FlexColumnContainer } from '../../Vilkårpanel/StyledVilkårInnhold';
 import { formaterNullableIsoDato } from '../../../../App/utils/formatter';
 import SelvstendigNæringsdrivendeEllerFrilanser from './SelvstendigNæringsdrivendeEllerFrilanser';
+import { BodyLong, HelpText, HStack, List } from '@navikt/ds-react';
 
 interface Props {
     aktivitet: IAktivitet;
@@ -27,7 +28,17 @@ const AktivitetInfoRegelendring2026: FC<Props> = ({ aktivitet, stønadstype }) =
 
     return (
         <InformasjonContainer>
-            <InfoSeksjonWrapper ikon={<Søknadsgrunnlag />} undertittel="Hva er situasjonen din?">
+            <InfoSeksjonWrapper
+                ikon={<Søknadsgrunnlag />}
+                undertittel={
+                    <HStack gap="space-16" className="førsteDataKolonne">
+                        Hva er situasjonen din?
+                        <HelpText placement="top-start">
+                            {HjelpetekstAlternativerHvaErSituasjonen}
+                        </HelpText>
+                    </HStack>
+                }
+            >
                 <Informasjonsrad
                     label="Valgte svar"
                     verdiSomString={false}
@@ -94,3 +105,18 @@ const AktivitetInfoRegelendring2026: FC<Props> = ({ aktivitet, stønadstype }) =
 };
 
 export default AktivitetInfoRegelendring2026;
+
+const HjelpetekstAlternativerHvaErSituasjonen = (
+    <>
+        <BodyLong weight="semibold">Mulig alternativer i søknadsdialog:</BodyLong>
+        <List size="small">
+            <List.Item>Jeg har barn under 14 måneder</List.Item>
+            <List.Item>
+                Jeg har barn som trenger særlig tilsyn på grunn av fysiske, psykiske eller store
+                sosiale problemer
+            </List.Item>
+            <List.Item>Barnet mitt har en sykdom som ikke er varig</List.Item>
+            <List.Item>Ingen av disse gjelder meg</List.Item>
+        </List>
+    </>
+);

--- a/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/Annet.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/Annet.tsx
@@ -3,26 +3,26 @@ import { ISærligeTilsynsbehov } from '../../../../App/typer/aktivitetstyper';
 import { Søknadsgrunnlag } from '../../../../Felles/Ikoner/DataGrunnlagIkoner';
 import { DinSituasjonTilTekst, EDinSituasjon } from './typer';
 import { formaterNullableIsoDato } from '../../../../App/utils/formatter';
-import { BodyLong, HelpText, HStack } from '@navikt/ds-react';
+import { BodyLong, HelpText, HStack, List } from '@navikt/ds-react';
 import { BodyShortSmall } from '../../../../Felles/Visningskomponenter/Tekster';
 import { InfoSeksjonWrapper } from '../../Vilkårpanel/VilkårInformasjonKomponenter';
 import Informasjonsrad from '../../Vilkårpanel/Informasjonsrad';
 import { FlexColumnContainer } from '../../Vilkårpanel/StyledVilkårInnhold';
 
 const hjelpetekst = (
-    <ul>
-        <BodyLong>
-            Mulig alternativer i søknadsdialog:
-            <li>Jeg er syk</li>
-            <li>Barnet mitt er sykt</li>
-            <li>Jeg har søkt om barnepass, men ikke fått plass enda</li>
-            <li>
+    <>
+        <BodyLong weight="semibold">Mulig alternativer i søknadsdialog:</BodyLong>
+        <List size="small">
+            <List.Item>Jeg er syk</List.Item>
+            <List.Item>Barnet mitt er sykt</List.Item>
+            <List.Item>Jeg har søkt om barnepass, men ikke fått plass enda</List.Item>
+            <List.Item>
                 Jeg har barn som trenger særlig tilsyn på grunn av fysiske, psykiske eller store
                 sosiale problemer
-            </li>
-            <li>Nei</li>
-        </BodyLong>
-    </ul>
+            </List.Item>
+            <List.Item>Nei</List.Item>
+        </List>
+    </>
 );
 
 interface Props {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Legger til hjelpetekst med alternativer fra søknad på spørsmålet 'hva er situasjonen din'. Refaktorerer hjelpetekst i Annet til å bruke komponenter fra Aksel, og bruke BodyLong korrekt, gjør spørsmålstekst fet slik at det blir lettere å lese.

<img width="2796" height="1232" alt="image" src="https://github.com/user-attachments/assets/16d28c9c-0e74-44dc-ab39-55112412ab1b" />

[Tilbakemelding på Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-28466)