### PR TITLE
Aktivitet info basert på erSøknadRegelendring2026 fra søknad

### DIFF
--- a/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/Aktivitet.tsx
+++ b/src/frontend/Komponenter/Behandling/Aktivitet/Aktivitet/Aktivitet.tsx
@@ -10,6 +10,13 @@ import { Behandlingsårsak } from '../../../../App/typer/behandlingsårsak';
 import { AlertError } from '../../../../Felles/Visningskomponenter/Alerts';
 import { Vilkårpanel } from '../../Vilkårpanel/Vilkårpanel';
 import { VilkårpanelInnhold } from '../../Vilkårpanel/VilkårpanelInnhold';
+import { Tag } from '@navikt/ds-react';
+
+const søknadsversjonTag = (erSøknadRegelendring2026: boolean) => (
+    <Tag variant={erSøknadRegelendring2026 ? 'alt1' : 'neutral'} size="xsmall">
+        {erSøknadRegelendring2026 ? 'Søknad: Nytt regelverk' : 'Søknad: Tidligere regelverk'}
+    </Tag>
+);
 
 export const Aktivitet: React.FC<VilkårProps> = ({
     vurderinger,
@@ -33,19 +40,25 @@ export const Aktivitet: React.FC<VilkårProps> = ({
         <DataViewer response={{ behandling }}>
             {({ behandling }) => {
                 const skalViseSøknadsdata = behandling.behandlingsårsak === Behandlingsårsak.SØKNAD;
+                const erSøknadRegelendring2026 = grunnlag.erSøknadRegelendring2026;
 
                 return (
                     <Vilkårpanel
                         tittel="Aktivitet"
                         vilkårsresultat={vurdering.resultat}
                         vilkår={vurdering.vilkårType}
+                        ekstraTittelInnhold={
+                            skalViseSøknadsdata
+                                ? søknadsversjonTag(erSøknadRegelendring2026)
+                                : undefined
+                        }
                     >
                         <VilkårpanelInnhold>
                             {{
                                 venstre:
                                     grunnlag.aktivitet &&
                                     skalViseSøknadsdata &&
-                                    (behandling.erRegelendring2026 ? (
+                                    (erSøknadRegelendring2026 ? (
                                         <AktivitetInfoRegelendring2026
                                             aktivitet={grunnlag.aktivitet}
                                             stønadstype={behandling.stønadstype}

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/vilkår.ts
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/vilkår.ts
@@ -30,6 +30,7 @@ export interface IVilkårGrunnlag {
     harKontantstøttePerioder?: boolean; // gjelder historiske behandlinger
     kontantstøttePerioder: KontantstøttePeriode[];
     behandlingOpprettet?: string;
+    erSøknadRegelendring2026: boolean;
 }
 
 export interface KontantstøttePeriode {

--- a/src/frontend/Komponenter/Behandling/Vilkårpanel/Vilkårpanel.tsx
+++ b/src/frontend/Komponenter/Behandling/Vilkårpanel/Vilkårpanel.tsx
@@ -15,6 +15,7 @@ interface Props {
     vilkårsresultat: Vilkårsresultat;
     children: ReactNode;
     vilkår: VilkårType;
+    ekstraTittelInnhold?: ReactNode;
 }
 
 export const Vilkårpanel: FC<Props> = ({
@@ -23,6 +24,7 @@ export const Vilkårpanel: FC<Props> = ({
     vilkårsresultat,
     children,
     vilkår,
+    ekstraTittelInnhold,
 }) => {
     const { ekspanderteVilkår, toggleEkspandertTilstand } = useEkspanderbareVilkårpanelContext();
 
@@ -39,6 +41,7 @@ export const Vilkårpanel: FC<Props> = ({
                             {paragrafTittel}
                         </BodyShortSmall>
                     )}
+                    {ekstraTittelInnhold}
                 </HStack>
                 <Button
                     size="medium"


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Bruker nytt flagg fra backend 'erSøknadRegelendring2026' til å bestemme hvilken variant av aktivitet komponent som skal vises frem. Lagt til en Tag som viser hvilken versjon søknad ble sendt inn på


[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-29860)

[Tilhørende PR](https://github.com/navikt/familie-ef-sak/pull/3234)

<img width="3450" height="1696" alt="image" src="https://github.com/user-attachments/assets/dc54ec5b-0f60-40ba-9eab-7e4f11672dab" />
