### PR TITLE
Regelendring 2026 - rydde toggle - automatisk brev

### DIFF
--- a/src/frontend/App/context/BehandlingContext.tsx
+++ b/src/frontend/App/context/BehandlingContext.tsx
@@ -24,12 +24,9 @@ import { useHentVedtak } from '../hooks/useHentVedtak';
 import { useHentFagsak } from '../hooks/useHentFagsak';
 import { useSamværsavtale } from '../hooks/useSamværsavtale';
 import { useRegelendring2026 } from '../hooks/useRegelendring2026';
-import { useToggles } from './TogglesContext';
-import { ToggleName } from './toggles';
 
 const [BehandlingProvider, useBehandling] = constate(() => {
     const { innloggetSaksbehandler } = useApp();
-    const { toggles } = useToggles();
 
     const behandlingId = useParams<{ behandlingId: string }>().behandlingId as string;
 
@@ -82,13 +79,8 @@ const [BehandlingProvider, useBehandling] = constate(() => {
         hentPersonopplysninger(behandlingId);
         hentUtestengelserForBehandling(behandlingId);
         hentFagsak(behandlingId);
+        hentBegrunnelse();
     }, [behandlingId]);
-
-    useEffect(() => {
-        if (toggles[ToggleName.regelendringer2026]) {
-            hentBegrunnelse();
-        }
-    }, [toggles[ToggleName.regelendringer2026], behandlingId]);
 
     useEffect(() => {
         if (behandling.status === RessursStatus.SUKSESS) {

--- a/src/frontend/App/context/toggles.ts
+++ b/src/frontend/App/context/toggles.ts
@@ -22,5 +22,4 @@ export enum ToggleName {
     brukErrorAlertMedKopierKnapp = 'familie.ef.sak.frontend-alert-error-med-copy-button',
     visAutomatiskInntektsendring = 'familie.ef.sak.frontend-vis-automatisk-inntektsendring',
     visBeregningsskjema = 'familie.ef.sak.frontend-vis-beregningsskjema',
-    regelendringer2026 = 'familie.ef.soknad.overgangsstonad-regelendringer-2026',
 }

--- a/src/frontend/Komponenter/Behandling/Inngangsvilkår/InngangsvilkårFane.tsx
+++ b/src/frontend/Komponenter/Behandling/Inngangsvilkår/InngangsvilkårFane.tsx
@@ -16,8 +16,6 @@ import { useApp } from '../../../App/context/AppContext';
 import { InngangsvilkårHeader } from './InngangsvilkårHeader';
 import { formaterIsoDatoTidMedSekunder } from '../../../App/utils/formatter';
 import { Stønadstype } from '../../../App/typer/behandlingstema';
-import { useToggles } from '../../../App/context/TogglesContext';
-import { ToggleName } from '../../../App/context/toggles';
 import { BehandleSom2026Regelendring } from '../Vurdering/BehandleSom2026Regelendring';
 import { Box } from '@navikt/ds-react';
 
@@ -28,7 +26,7 @@ interface Props {
 export const InngangsvilkårFane: FC<Props> = ({ behandling }) => {
     const { behandlingErRedigerbar, vilkårState, samværsavtaleState } = useBehandling();
     const { erSaksbehandler } = useApp();
-    const { toggles } = useToggles();
+
     const {
         vilkår,
         hentVilkår,
@@ -41,9 +39,7 @@ export const InngangsvilkårFane: FC<Props> = ({ behandling }) => {
     const { samværsavtaler, hentSamværsavtaler, lagreSamværsavtale, slettSamværsavtale } =
         samværsavtaleState;
 
-    const visRegelendringSwitch =
-        behandling.stønadstype === Stønadstype.BARNETILSYN &&
-        toggles[ToggleName.regelendringer2026];
+    const visRegelendringSwitch = behandling.stønadstype === Stønadstype.BARNETILSYN;
 
     React.useEffect(() => {
         hentVilkår(behandling.id);

--- a/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/TidligereVedtaksperioderFane.tsx
+++ b/src/frontend/Komponenter/Behandling/TidligereVedtaksperioder/TidligereVedtaksperioderFane.tsx
@@ -9,8 +9,6 @@ import VilkårIkkeOpprettetAlert from '../Vurdering/VilkårIkkeOpprettet';
 import { Behandling } from '../../../App/typer/fagsak';
 import { Box } from '@navikt/ds-react';
 import { BehandleSom2026Regelendring } from '../Vurdering/BehandleSom2026Regelendring.tsx';
-import { useToggles } from '../../../App/context/TogglesContext';
-import { ToggleName } from '../../../App/context/toggles';
 import { Vilkårpanel } from '../Vilkårpanel/Vilkårpanel';
 import { VilkårpanelInnhold } from '../Vilkårpanel/VilkårpanelInnhold';
 
@@ -19,7 +17,6 @@ interface Props {
 }
 
 export const TidligereVedtaksperioderFane: React.FC<Props> = ({ behandling }) => {
-    const { toggles } = useToggles();
     const { vilkårState } = useBehandling();
     const {
         hentVilkår,
@@ -78,11 +75,10 @@ export const TidligereVedtaksperioderFane: React.FC<Props> = ({ behandling }) =>
                                 }}
                             </VilkårpanelInnhold>
                         </Vilkårpanel>
-                        {toggles[ToggleName.regelendringer2026] && (
-                            <Box background="neutral-soft" style={{ margin: '0 2rem 2rem 2rem' }}>
-                                <BehandleSom2026Regelendring />
-                            </Box>
-                        )}
+
+                        <Box background="neutral-soft" style={{ margin: '0 2rem 2rem 2rem' }}>
+                            <BehandleSom2026Regelendring />
+                        </Box>
                     </Box>
                 );
             }}

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/AutomatiskBrev.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/AutomatiskBrev.tsx
@@ -14,8 +14,7 @@ const automatiskBrevAlternativer: AutomatiskBrevValg[] = Object.values(Automatis
 export const AutomatiskBrev: FC<{
     automatiskBrev: AutomatiskBrevValg[];
     settAutomatiskBrev: React.Dispatch<React.SetStateAction<AutomatiskBrevValg[]>>;
-    erOvergangsregel?: boolean;
-}> = ({ automatiskBrev, settAutomatiskBrev, erOvergangsregel }) => {
+}> = ({ automatiskBrev, settAutomatiskBrev }) => {
     return (
         <CheckboxGroup
             legend="Send brev automatisk når vedtaket er godkjent:"
@@ -24,9 +23,7 @@ export const AutomatiskBrev: FC<{
         >
             {automatiskBrevAlternativer.map((valg) => (
                 <Checkbox key={valg} value={valg}>
-                    {automatiskBrevValgTekst[valg]}
-                    {erOvergangsregel &&
-                        ' – Kun saker etter tidligere regelverk skal ha dette brevet.'}
+                    {`${automatiskBrevValgTekst[valg]} – Kun saker etter tidligere regelverk skal ha dette brevet.`}
                 </Checkbox>
             ))}
         </CheckboxGroup>

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/ModalSendTilBeslutter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/ModalSendTilBeslutter.tsx
@@ -16,8 +16,6 @@ import { harBarnMellomSeksOgTolvMåneder, utledAutomatiskBrev } from './utils';
 import { Stønadstype } from '../../../App/typer/behandlingstema';
 import { Oppfølgingsoppgave } from '../../../App/hooks/useHentOppfølgingsoppgave';
 import { Oppgaveprioritet } from './Oppgaveprioritet';
-import { useToggles } from '../../../App/context/TogglesContext';
-import { ToggleName } from '../../../App/context/toggles';
 
 export const ModalSendTilBeslutter: FC<{
     behandling: Behandling;
@@ -55,9 +53,6 @@ export const ModalSendTilBeslutter: FC<{
     avslagValg,
     oppfølgingsoppgave,
 }) => {
-    const { toggles } = useToggles();
-    const erOvergangsregel = toggles[ToggleName.regelendringer2026] || false;
-
     const [
         årForInntektskontrollSelvstendigNæringsdrivende,
         settÅrForInntektskontrollSelvstendigNæringsdrivende,
@@ -76,12 +71,7 @@ export const ModalSendTilBeslutter: FC<{
     } = avslagValg;
 
     const [automatiskBrev, settAutomatiskBrev] = useState<AutomatiskBrevValg[]>(
-        utledAutomatiskBrev(
-            oppfølgingsoppgave?.automatiskBrev,
-            erInnvilgelseOvergangsstønad,
-            vilkår,
-            erOvergangsregel
-        )
+        utledAutomatiskBrev(oppfølgingsoppgave?.automatiskBrev, erInnvilgelseOvergangsstønad)
     );
 
     const handleSettOppgaverSomSkalFerdigstilles = (oppgaveId: number) =>
@@ -128,20 +118,9 @@ export const ModalSendTilBeslutter: FC<{
 
     useEffect(() => {
         settAutomatiskBrev(
-            utledAutomatiskBrev(
-                oppfølgingsoppgave?.automatiskBrev,
-                erInnvilgelseOvergangsstønad,
-                vilkår,
-                erOvergangsregel
-            )
+            utledAutomatiskBrev(oppfølgingsoppgave?.automatiskBrev, erInnvilgelseOvergangsstønad)
         );
-    }, [
-        behandling,
-        erInnvilgelseOvergangsstønad,
-        erOvergangsregel,
-        oppfølgingsoppgave?.automatiskBrev,
-        vilkår,
-    ]);
+    }, [behandling, erInnvilgelseOvergangsstønad, oppfølgingsoppgave?.automatiskBrev, vilkår]);
 
     return (
         <DataViewer response={{ oppgaverForAutomatiskFerdigstilling }}>
@@ -203,7 +182,6 @@ export const ModalSendTilBeslutter: FC<{
                                                 <AutomatiskBrev
                                                     automatiskBrev={automatiskBrev}
                                                     settAutomatiskBrev={settAutomatiskBrev}
-                                                    erOvergangsregel={erOvergangsregel}
                                                 />
                                                 <VannrettDivider />
                                             </>

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.test.ts
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { harBarnMellomSeksOgTolvMåneder, utledAutomatiskBrev } from './utils';
 import { IVilkår, InngangsvilkårType, Vilkårsresultat } from '../Inngangsvilkår/vilkår';
-import { AutomatiskBrevValg } from './AutomatiskBrev';
 
 describe('Har barn mellom seks og tolv måneder', () => {
     const toÅrGammel = new Date(new Date().setMonth(new Date().getMonth() - 24)).toISOString();
@@ -69,51 +68,8 @@ describe('Har barn mellom seks og tolv måneder', () => {
 });
 
 describe('utledAutomatiskBrev', () => {
-    const åtteMånederGammel = new Date();
-    åtteMånederGammel.setMonth(åtteMånederGammel.getMonth() - 8);
-
-    const lagVilkårMedBarn = (fødselsdato: string) =>
-        ({
-            vurderinger: [
-                {
-                    vilkårType: InngangsvilkårType.ALENEOMSORG,
-                    resultat: Vilkårsresultat.OPPFYLT,
-                    barnId: '1',
-                },
-            ],
-            grunnlag: {
-                barnMedSamvær: [
-                    {
-                        barnId: '1',
-                        registergrunnlag: { fødselsdato },
-                    },
-                ],
-            },
-        }) as unknown as IVilkår;
-
-    const vilkårMedBarnMellom6Og12Mnd = lagVilkårMedBarn(åtteMånederGammel.toISOString());
-
-    it('skal auto-avhuke varsel om aktivitetsplikt når barn er mellom 6 og 12 måneder og toggle er av', () => {
-        const resultat = utledAutomatiskBrev(undefined, true, vilkårMedBarnMellom6Og12Mnd, false);
-        expect(resultat).toContain(AutomatiskBrevValg.VARSEL_OM_AKTIVITETSPLIKT);
-    });
-
-    it('skal ikke auto-avhuke varsel om aktivitetsplikt når overgangsregel-toggle er på', () => {
-        const resultat = utledAutomatiskBrev(undefined, true, vilkårMedBarnMellom6Og12Mnd, true);
-        expect(resultat).not.toContain(AutomatiskBrevValg.VARSEL_OM_AKTIVITETSPLIKT);
-    });
-
-    it('skal ikke auto-avhuke når overgangsregel-toggle er av men barn er utenfor aldersgrensen', () => {
-        const toÅrGammel = new Date();
-        toÅrGammel.setFullYear(toÅrGammel.getFullYear() - 2);
-        const vilkår = lagVilkårMedBarn(toÅrGammel.toISOString());
-
-        const resultat = utledAutomatiskBrev(undefined, true, vilkår, false);
-        expect(resultat).not.toContain(AutomatiskBrevValg.VARSEL_OM_AKTIVITETSPLIKT);
-    });
-
     it('skal returnere tom liste når det ikke er innvilgelse overgangsstønad', () => {
-        const resultat = utledAutomatiskBrev(undefined, false, vilkårMedBarnMellom6Og12Mnd, false);
+        const resultat = utledAutomatiskBrev(undefined, false);
         expect(resultat).toHaveLength(0);
     });
 });

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.ts
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/utils.ts
@@ -38,15 +38,11 @@ export const harBarnMellomSeksOgTolvMåneder = (vilkår: IVilkår) => {
 
 export const utledAutomatiskBrev = (
     lagretAutomatiskBrev: AutomatiskBrevValg[] | undefined,
-    erInnvilgelseOvergangsstønad: boolean,
-    vilkår?: IVilkår,
-    erOvergangsregel?: boolean
+    erInnvilgelseOvergangsstønad: boolean
 ) => {
     if (!erInnvilgelseOvergangsstønad) {
         return [];
     }
-
-    const harBarnMellomSeksOgTolvMnder = vilkår && harBarnMellomSeksOgTolvMåneder(vilkår);
 
     const automatiskBrev: Set<AutomatiskBrevValg> = new Set();
 
@@ -54,12 +50,6 @@ export const utledAutomatiskBrev = (
         lagretAutomatiskBrev.forEach((brev) => {
             automatiskBrev.add(brev as AutomatiskBrevValg);
         });
-    }
-
-    if (harBarnMellomSeksOgTolvMnder && !erOvergangsregel) {
-        automatiskBrev.add(AutomatiskBrevValg.VARSEL_OM_AKTIVITETSPLIKT);
-    } else {
-        automatiskBrev.delete(AutomatiskBrevValg.VARSEL_OM_AKTIVITETSPLIKT);
     }
 
     return Array.from(automatiskBrev);

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/SelectVedtaksresultat.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/SelectVedtaksresultat.tsx
@@ -13,8 +13,6 @@ import { EnsligFamilieSelect } from '../../../../Felles/Input/EnsligFamilieSelec
 import { Neutral100 } from '@navikt/ds-tokens/js';
 import { RessursStatus } from '../../../../App/typer/ressurs';
 import { stønadstyperMedRegelendring2026Begrunnelse } from '../../../../App/hooks/useRegelendring2026';
-import { useToggles } from '../../../../App/context/TogglesContext';
-import { ToggleName } from '../../../../App/context/toggles';
 
 interface Props {
     behandling: Behandling;
@@ -46,7 +44,6 @@ const Container = styled.section`
 const SelectVedtaksresultat = (props: Props): ReactNode => {
     const { behandlingErRedigerbar, regelendring2026Begrunnelse } = useBehandling();
     const { settIkkePersistertKomponent } = useApp();
-    const { toggles } = useToggles();
     const { resultatType, settResultatType, alleVilkårOppfylt, behandling } = props;
     const opphørMulig =
         behandling.type === Behandlingstype.REVURDERING && behandling.forrigeBehandlingId;
@@ -54,7 +51,6 @@ const SelectVedtaksresultat = (props: Props): ReactNode => {
         resultatType === EBehandlingResultat.INNVILGE_UTEN_UTBETALING;
 
     const manglerRegelverkBegrunnelse =
-        toggles[ToggleName.regelendringer2026] &&
         stønadstyperMedRegelendring2026Begrunnelse.includes(behandling.stønadstype) &&
         (regelendring2026Begrunnelse.status !== RessursStatus.SUKSESS ||
             !regelendring2026Begrunnelse.data?.begrunnelse.trim());

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/Vilkårsvurdering.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/Vilkårsvurdering.tsx
@@ -11,8 +11,6 @@ import { stønadstyperMedRegelendring2026Begrunnelse } from '../../../../App/hoo
 import { VilkårsresultatIkon } from '../../../../Felles/Ikoner/VilkårsresultatIkon';
 import { Vilkårsresultat } from '../../Inngangsvilkår/vilkår';
 import { BodyShortSmall } from '../../../../Felles/Visningskomponenter/Tekster';
-import { useToggles } from '../../../../App/context/TogglesContext';
-import { ToggleName } from '../../../../App/context/toggles';
 
 const Container = styled.div`
     padding: 1rem;
@@ -25,13 +23,11 @@ export const Vilkårsvurdering: React.FC<{
     const inngangsvilkår = sorterUtInngangsvilkår(vilkår);
     const aktivitetsvilkår = sorterUtAktivitetsvilkår(vilkår);
     const { regelendring2026Begrunnelse, behandling } = useBehandling();
-    const { toggles } = useToggles();
 
     const stønadstype =
         behandling.status === RessursStatus.SUKSESS ? behandling.data.stønadstype : undefined;
 
     const skalViseRegelverkBegrunnelse =
-        toggles[ToggleName.regelendringer2026] &&
         stønadstype !== undefined &&
         stønadstyperMedRegelendring2026Begrunnelse.includes(stønadstype);
 

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/VedtakOgBeregningFane.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/VedtakOgBeregningFane.tsx
@@ -19,8 +19,6 @@ import { SmallTextLabel } from '../../../Felles/Visningskomponenter/Tekster';
 import { EBehandlingResultat } from '../../../App/typer/vedtak';
 import { RessursStatus } from '../../../App/typer/ressurs';
 import { stønadstyperMedRegelendring2026Begrunnelse } from '../../../App/hooks/useRegelendring2026';
-import { useToggles } from '../../../App/context/TogglesContext';
-import { ToggleName } from '../../../App/context/toggles';
 
 const Fane = styled.main`
     display: flex;
@@ -40,7 +38,6 @@ interface Props {
 
 export const VedtakOgBeregningFane: FC<Props> = ({ behandling }) => {
     const { vilkårState, regelendring2026Begrunnelse } = useBehandling();
-    const { toggles } = useToggles();
 
     const [visNullstillVedtakModal, settVisNullstillVedtakModal] = useState(false);
     const { vilkår, hentVilkår } = vilkårState;
@@ -55,7 +52,6 @@ export const VedtakOgBeregningFane: FC<Props> = ({ behandling }) => {
     }, [hentVilkår, behandling.id]);
 
     const manglerRegelendring2026Begrunnelse =
-        toggles[ToggleName.regelendringer2026] &&
         stønadstyperMedRegelendring2026Begrunnelse.includes(behandling.stønadstype) &&
         (regelendring2026Begrunnelse.status !== RessursStatus.SUKSESS ||
             !regelendring2026Begrunnelse.data?.begrunnelse.trim());


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

- Fjerner toggle, da det er på i prod.
- Skal aldri automatisk huke av for varsel om aktivitetsplikt.

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-29892)
