### PR TITLE
Legger til "regelverk" for årsak underkjent ved beslutting av vedtak

### DIFF
--- a/src/frontend/App/typer/totrinnskontroll.ts
+++ b/src/frontend/App/typer/totrinnskontroll.ts
@@ -52,5 +52,5 @@ export const årsakUnderkjentTilTekst: Record<ÅrsakUnderkjent, string> = {
     VEDTAKSBREV: 'Vedtaksbrev',
     RETUR_ETTER_ØNSKE_FRA_SAKSBEHANDLER: 'Retur etter ønske fra saksbehandler',
     SIMULERING_ENDRET: 'Simulering endret',
-    REGELVERK: 'Kontroller regelverksvalg',
+    REGELVERK: 'Regelverksvalg',
 };

--- a/src/frontend/App/typer/totrinnskontroll.ts
+++ b/src/frontend/App/typer/totrinnskontroll.ts
@@ -38,6 +38,7 @@ export enum ÅrsakUnderkjent {
     VEDTAKSBREV = 'VEDTAKSBREV',
     RETUR_ETTER_ØNSKE_FRA_SAKSBEHANDLER = 'RETUR_ETTER_ØNSKE_FRA_SAKSBEHANDLER',
     SIMULERING_ENDRET = 'SIMULERING_ENDRET',
+    REGELVERK = 'REGELVERK',
 }
 
 export const årsakUnderkjentTilTekst: Record<ÅrsakUnderkjent, string> = {
@@ -51,4 +52,5 @@ export const årsakUnderkjentTilTekst: Record<ÅrsakUnderkjent, string> = {
     VEDTAKSBREV: 'Vedtaksbrev',
     RETUR_ETTER_ØNSKE_FRA_SAKSBEHANDLER: 'Retur etter ønske fra saksbehandler',
     SIMULERING_ENDRET: 'Simulering endret',
+    REGELVERK: 'Kontroller regelverksvalg',
 };


### PR DESCRIPTION
# Legger til "regelverk" for årsak underkjent ved beslutting av vedtak

### Hvorfor er denne endringen nødvendig? ✨ 

Saksbehandler meldte inn at de ønsker regelverk endring som årsak til underkjennelse av vedtak. Legger derfor til "regelverksvalg" som årsak for underkjennelse av vedtak. 

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-29918).

Denne PRen er en del av en bredre oppgave og depender på denne → [PRen](https://github.com/navikt/familie-ef-sak/pull/3241).

### Verdt å nevne

* Har snakket med vår fagressurs LI og fikk forslaget "regelverksvalg" for utledning av årsak. Dette virker bra og noe som er konkrekt, konsist og tydelig. 
* Har testet i dev der man har sendt en behandling til beslutter, fått den underkjent med årsak "kontroller regelverk", tatt opp behandlingen igjen og sett at det blir riktig. 

<table>
  <tr>
    <th style="text-align:center">Underkjenning</th>
    <th style="text-align:center">Etter underkjenning</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/6f2dd3ad-887b-4992-b5ca-fa323fbea323" alt="Underkjenn" width="400"/></td>
    <td><img src="https://github.com/user-attachments/assets/dd7e9e35-af4a-4c27-be55-cd3fe572776a" alt="Etter underkjenning" width="400"/></td>
  </tr>