### PR TITLE
Ikke valider lovvalg for manuell g-omregning

### DIFF
--- a/src/frontend/App/hooks/useRegelendring2026.ts
+++ b/src/frontend/App/hooks/useRegelendring2026.ts
@@ -8,6 +8,8 @@ import {
     RessursSuksess,
 } from '../typer/ressurs';
 import { Stønadstype } from '../typer/behandlingstema';
+import { Behandling } from '../typer/fagsak';
+import { Behandlingsårsak } from '../typer/behandlingsårsak';
 
 interface Regelendring2026Begrunnelse {
     begrunnelse: string;
@@ -17,6 +19,17 @@ export const stønadstyperMedRegelendring2026Begrunnelse: Stønadstype[] = [
     Stønadstype.OVERGANGSSTØNAD,
     Stønadstype.BARNETILSYN,
 ];
+
+// Speiler valideringen i backend (SendTilBeslutterSteg.validerBegrunnelseForRegelveksvalgErSatt).
+// G-omregning er unntatt fordi den normalt kjøres automatisk uten denne vurderingen.
+export const manglerRegelendring2026Begrunnelse = (
+    behandling: Pick<Behandling, 'stønadstype' | 'behandlingsårsak'>,
+    regelendring2026Begrunnelse: Ressurs<Regelendring2026Begrunnelse | undefined>
+): boolean =>
+    stønadstyperMedRegelendring2026Begrunnelse.includes(behandling.stønadstype) &&
+    behandling.behandlingsårsak !== Behandlingsårsak.G_OMREGNING &&
+    (regelendring2026Begrunnelse.status !== RessursStatus.SUKSESS ||
+        !regelendring2026Begrunnelse.data?.begrunnelse.trim());
 
 export const useRegelendring2026 = (
     behandlingId: string

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/SelectVedtaksresultat.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/Felles/SelectVedtaksresultat.tsx
@@ -11,8 +11,7 @@ import { Stønadstype } from '../../../../App/typer/behandlingstema';
 import { NullstillVedtakModalContext } from './NullstillVedtakModalContext';
 import { EnsligFamilieSelect } from '../../../../Felles/Input/EnsligFamilieSelect';
 import { Neutral100 } from '@navikt/ds-tokens/js';
-import { RessursStatus } from '../../../../App/typer/ressurs';
-import { stønadstyperMedRegelendring2026Begrunnelse } from '../../../../App/hooks/useRegelendring2026';
+import { manglerRegelendring2026Begrunnelse } from '../../../../App/hooks/useRegelendring2026';
 
 interface Props {
     behandling: Behandling;
@@ -50,10 +49,10 @@ const SelectVedtaksresultat = (props: Props): ReactNode => {
     const nullUtbetalingPgaKontantstøtte =
         resultatType === EBehandlingResultat.INNVILGE_UTEN_UTBETALING;
 
-    const manglerRegelverkBegrunnelse =
-        stønadstyperMedRegelendring2026Begrunnelse.includes(behandling.stønadstype) &&
-        (regelendring2026Begrunnelse.status !== RessursStatus.SUKSESS ||
-            !regelendring2026Begrunnelse.data?.begrunnelse.trim());
+    const manglerRegelverkBegrunnelse = manglerRegelendring2026Begrunnelse(
+        behandling,
+        regelendring2026Begrunnelse
+    );
 
     const { settVisNullstillVedtakModal } = useContext(NullstillVedtakModalContext);
 

--- a/src/frontend/Komponenter/Behandling/VedtakOgBeregning/VedtakOgBeregningFane.tsx
+++ b/src/frontend/Komponenter/Behandling/VedtakOgBeregning/VedtakOgBeregningFane.tsx
@@ -17,8 +17,7 @@ import { NullstillVedtakModalContext } from './Felles/NullstillVedtakModalContex
 import { AlertError } from '../../../Felles/Visningskomponenter/Alerts';
 import { SmallTextLabel } from '../../../Felles/Visningskomponenter/Tekster';
 import { EBehandlingResultat } from '../../../App/typer/vedtak';
-import { RessursStatus } from '../../../App/typer/ressurs';
-import { stønadstyperMedRegelendring2026Begrunnelse } from '../../../App/hooks/useRegelendring2026';
+import { manglerRegelendring2026Begrunnelse } from '../../../App/hooks/useRegelendring2026';
 
 const Fane = styled.main`
     display: flex;
@@ -51,10 +50,10 @@ export const VedtakOgBeregningFane: FC<Props> = ({ behandling }) => {
         hentVilkår(behandling.id);
     }, [hentVilkår, behandling.id]);
 
-    const manglerRegelendring2026Begrunnelse =
-        stønadstyperMedRegelendring2026Begrunnelse.includes(behandling.stønadstype) &&
-        (regelendring2026Begrunnelse.status !== RessursStatus.SUKSESS ||
-            !regelendring2026Begrunnelse.data?.begrunnelse.trim());
+    const manglerRegelendring2026BegrunnelseVerdi = manglerRegelendring2026Begrunnelse(
+        behandling,
+        regelendring2026Begrunnelse
+    );
 
     return (
         <NullstillVedtakModalContext.Provider
@@ -71,7 +70,7 @@ export const VedtakOgBeregningFane: FC<Props> = ({ behandling }) => {
                                     resultatType={resultatType}
                                     settResultatType={settResultatType}
                                     manglerRegelendring2026Begrunnelse={
-                                        manglerRegelendring2026Begrunnelse
+                                        manglerRegelendring2026BegrunnelseVerdi
                                     }
                                 />
                             );
@@ -83,7 +82,7 @@ export const VedtakOgBeregningFane: FC<Props> = ({ behandling }) => {
                                     resultatType={resultatType}
                                     settResultatType={settResultatType}
                                     manglerRegelendring2026Begrunnelse={
-                                        manglerRegelendring2026Begrunnelse
+                                        manglerRegelendring2026BegrunnelseVerdi
                                     }
                                 />
                             );


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Saksbehandler har ikke mulighet til å navigere videre i behandlingen ved manuell g-omregning av en sak iverksatt før regelendring i 2026. Legger til et unntak i validering av behandling for g-omregning.

Testet OK i dev: https://ensligmorellerfar.ansatt.dev.nav.no/behandling/22c46742-186a-44cc-95ee-99ee28b421fa

Tilhørende PR backend: https://github.com/navikt/familie-ef-sak/pull/3244
