### PR TITLE
Sett lik memory request og limit

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -41,7 +41,7 @@ spec:
     limits:
       memory: 512Mi
     requests:
-      memory: 256Mi
+      memory: 512Mi
       cpu: 50m
   accessPolicy:
     outbound:

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -40,7 +40,7 @@ spec:
     limits:
       memory: 768Mi
     requests:
-      memory: 256Mi
+      memory: 768Mi
       cpu: 100m
   accessPolicy:
     outbound:


### PR DESCRIPTION
## Hva
Setter `resources.requests.memory` lik `resources.limits.memory` i nais.yaml-filene.

## Hvorfor
Anbefalt praksis for Kubernetes-ressurser er å ha requests og limits like for minne, se
https://www.flexera.com/blog/finops/kubernetes-limits-vs-requests-key-differences-and-how-they-work/#s5

Ingen CPU-limit er satt i denne appen, så det er ikke gjort endringer der.
