### PR TITLE
Rename av variabel for lettere forståelse

### DIFF
--- a/src/frontend/App/hooks/useHentOppgaverForAutomatiskFerdigstilling.ts
+++ b/src/frontend/App/hooks/useHentOppgaverForAutomatiskFerdigstilling.ts
@@ -5,21 +5,21 @@ import { IOppgaverResponse } from './useHentOppgaver';
 
 export const useHentOppgaverForAutomatiskFerdigstilling = () => {
     const { axiosRequest } = useApp();
-    const [oppgaverForAutomatiskFerdigstilling, settOppgaverForAutomatiskFerdigstilling] =
+    const [oppgaverSomKanAutomatiskFerdigstilles, settOppgaverSomKanAutomatiskFerdigstilles] =
         useState<Ressurs<IOppgaverResponse>>(byggTomRessurs());
 
-    const hentOppgaverForAutomatiskFerdigstilling = useCallback(
+    const hentOppgaverSomKanAutomatiskFerdigstilles = useCallback(
         (behandlingId: string) => {
-            settOppgaverForAutomatiskFerdigstilling(byggHenterRessurs());
+            settOppgaverSomKanAutomatiskFerdigstilles(byggHenterRessurs());
             axiosRequest<IOppgaverResponse, { behandlingId: string }>({
                 method: 'GET',
                 url: `/familie-ef-sak/api/oppgave/oppgaver-for-automatisk-ferdigstilling/${behandlingId}`,
             }).then((res: Ressurs<IOppgaverResponse>) => {
-                settOppgaverForAutomatiskFerdigstilling(res);
+                settOppgaverSomKanAutomatiskFerdigstilles(res);
             });
         },
         [axiosRequest]
     );
 
-    return { hentOppgaverForAutomatiskFerdigstilling, oppgaverForAutomatiskFerdigstilling };
+    return { hentOppgaverSomKanAutomatiskFerdigstilles, oppgaverSomKanAutomatiskFerdigstilles };
 };

--- a/src/frontend/App/hooks/useHentOppgaverSomKanAutomatiskFerdigstilles.ts
+++ b/src/frontend/App/hooks/useHentOppgaverSomKanAutomatiskFerdigstilles.ts
@@ -3,7 +3,7 @@ import { useApp } from '../context/AppContext';
 import { useCallback, useState } from 'react';
 import { IOppgaverResponse } from './useHentOppgaver';
 
-export const useHentOppgaverForAutomatiskFerdigstilling = () => {
+export const useHentOppgaverSomKanAutomatiskFerdigstilles = () => {
     const { axiosRequest } = useApp();
     const [oppgaverSomKanAutomatiskFerdigstilles, settOppgaverSomKanAutomatiskFerdigstilles] =
         useState<Ressurs<IOppgaverResponse>>(byggTomRessurs());

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/ModalSendTilBeslutter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/ModalSendTilBeslutter.tsx
@@ -23,7 +23,7 @@ export const ModalSendTilBeslutter: FC<{
     open: boolean;
     setOpen: (open: boolean) => void;
     sendTilBeslutter: (data: SendTilBeslutterRequest) => void;
-    oppgaverForAutomatiskFerdigstilling: Ressurs<IOppgaverResponse>;
+    oppgaverSomKanAutomatiskFerdigstilles: Ressurs<IOppgaverResponse>;
     oppgavetyperSomKanOpprettes: OppgaveTypeForOpprettelse[] | undefined;
     oppgavetyperSomSkalOpprettes: OppgaveTypeForOpprettelse[];
     settOppgavetyperSomSkalOpprettes: React.Dispatch<
@@ -44,7 +44,7 @@ export const ModalSendTilBeslutter: FC<{
     open,
     setOpen,
     sendTilBeslutter,
-    oppgaverForAutomatiskFerdigstilling,
+    oppgaverSomKanAutomatiskFerdigstilles,
     oppgavetyperSomKanOpprettes,
     oppgavetyperSomSkalOpprettes,
     settOppgavetyperSomSkalOpprettes,
@@ -82,8 +82,8 @@ export const ModalSendTilBeslutter: FC<{
         );
 
     const harOppgaver =
-        oppgaverForAutomatiskFerdigstilling.status === RessursStatus.SUKSESS &&
-        oppgaverForAutomatiskFerdigstilling.data.oppgaver.length > 0;
+        oppgaverSomKanAutomatiskFerdigstilles.status === RessursStatus.SUKSESS &&
+        oppgaverSomKanAutomatiskFerdigstilles.data.oppgaver.length > 0;
 
     const kanVelgeMellomFlereOppgavetyper = (oppgavetyperSomKanOpprettes ?? []).length > 1;
     const harValgtAnnetEnnInntektskontroll =
@@ -123,8 +123,8 @@ export const ModalSendTilBeslutter: FC<{
     }, [behandling, erInnvilgelseOvergangsstønad, oppfølgingsoppgave?.automatiskBrev, vilkår]);
 
     return (
-        <DataViewer response={{ oppgaverForAutomatiskFerdigstilling }}>
-            {({ oppgaverForAutomatiskFerdigstilling }) => {
+        <DataViewer response={{ oppgaverSomKanAutomatiskFerdigstilles }}>
+            {({ oppgaverSomKanAutomatiskFerdigstilles }) => {
                 return (
                     <Modal
                         open={open}
@@ -158,8 +158,8 @@ export const ModalSendTilBeslutter: FC<{
                                                 <>
                                                     <VannrettDivider />
                                                     <TabellFerdigstilleOppgaver
-                                                        oppgaverForAutomatiskFerdigstilling={
-                                                            oppgaverForAutomatiskFerdigstilling
+                                                        oppgaverSomKanAutomatiskFerdigstilles={
+                                                            oppgaverSomKanAutomatiskFerdigstilles
                                                         }
                                                         oppgaverSomSkalAutomatiskFerdigstilles={
                                                             oppgaverSomSkalAutomatiskFerdigstilles

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutter.tsx
@@ -79,7 +79,7 @@ const SendTilBeslutter: React.FC<{
         hentBehandlingshistorikk,
         settNyEierModalState,
     } = useBehandling();
-    const { hentOppgaverForAutomatiskFerdigstilling, oppgaverForAutomatiskFerdigstilling } =
+    const { hentOppgaverSomKanAutomatiskFerdigstilles, oppgaverSomKanAutomatiskFerdigstilles } =
         useHentOppgaverForAutomatiskFerdigstilling();
     const oppgavetyperSomKanOpprettesOvergangsstønad =
         oppfølgingsoppgave?.oppgaverForOpprettelse?.oppgavetyperSomKanOpprettes;
@@ -147,8 +147,8 @@ const SendTilBeslutter: React.FC<{
     const skalViseKnappForModal = behandling.stønadstype != Stønadstype.SKOLEPENGER;
 
     useEffect(() => {
-        hentOppgaverForAutomatiskFerdigstilling(behandling.id);
-    }, [behandling.id, hentOppgaverForAutomatiskFerdigstilling]);
+        hentOppgaverSomKanAutomatiskFerdigstilles(behandling.id);
+    }, [behandling.id, hentOppgaverSomKanAutomatiskFerdigstilles]);
 
     useEffect(() => {
         settOppgavetyperSomSkalOpprettes(
@@ -218,7 +218,7 @@ const SendTilBeslutter: React.FC<{
                 oppgavetyperSomKanOpprettes={oppgavetyperSomKanOpprettesOvergangsstønad}
                 oppgavetyperSomSkalOpprettes={oppgavetyperSomSkalOpprettes}
                 settOppgavetyperSomSkalOpprettes={settOppgavetyperSomSkalOpprettes}
-                oppgaverForAutomatiskFerdigstilling={oppgaverForAutomatiskFerdigstilling}
+                oppgaverSomKanAutomatiskFerdigstilles={oppgaverSomKanAutomatiskFerdigstilles}
                 oppgaverSomSkalAutomatiskFerdigstilles={oppgaverSomSkalAutomatiskFerdigstilles}
                 settOppgaverSomSkalAutomatiskFerdigstilles={
                     settOppgaverSomSkalAutomatiskFerdigstilles

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutter.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/SendTilBeslutter.tsx
@@ -19,7 +19,7 @@ import { AutomatiskBrevValg } from './AutomatiskBrev';
 import { IVilkår } from '../Inngangsvilkår/vilkår';
 import { IVedtak } from '../../../App/typer/vedtak';
 import { utledAvslagValg } from '../VedtakOgBeregning/Felles/utils';
-import { useHentOppgaverForAutomatiskFerdigstilling } from '../../../App/hooks/useHentOppgaverForAutomatiskFerdigstilling';
+import { useHentOppgaverSomKanAutomatiskFerdigstilles } from '../../../App/hooks/useHentOppgaverSomKanAutomatiskFerdigstilles.ts';
 import { Stønadstype } from '../../../App/typer/behandlingstema';
 
 const FlexBox = styled.div`
@@ -80,7 +80,7 @@ const SendTilBeslutter: React.FC<{
         settNyEierModalState,
     } = useBehandling();
     const { hentOppgaverSomKanAutomatiskFerdigstilles, oppgaverSomKanAutomatiskFerdigstilles } =
-        useHentOppgaverForAutomatiskFerdigstilling();
+        useHentOppgaverSomKanAutomatiskFerdigstilles();
     const oppgavetyperSomKanOpprettesOvergangsstønad =
         oppfølgingsoppgave?.oppgaverForOpprettelse?.oppgavetyperSomKanOpprettes;
     const [laster, settLaster] = useState<boolean>(false);

--- a/src/frontend/Komponenter/Behandling/Totrinnskontroll/TabellFerdigstilleOppgaver.tsx
+++ b/src/frontend/Komponenter/Behandling/Totrinnskontroll/TabellFerdigstilleOppgaver.tsx
@@ -15,11 +15,11 @@ const StyledBodyLong = styled(BodyLong)`
 `;
 
 export const TabellFerdigstilleOppgaver: FC<{
-    oppgaverForAutomatiskFerdigstilling: IOppgaverResponse;
+    oppgaverSomKanAutomatiskFerdigstilles: IOppgaverResponse;
     oppgaverSomSkalAutomatiskFerdigstilles: number[];
     handleSettOppgaverSomSkalFerdigstilles: (oppgaveId: number) => void;
 }> = ({
-    oppgaverForAutomatiskFerdigstilling,
+    oppgaverSomKanAutomatiskFerdigstilles,
     oppgaverSomSkalAutomatiskFerdigstilles,
     handleSettOppgaverSomSkalFerdigstilles,
 }) => {
@@ -41,7 +41,7 @@ export const TabellFerdigstilleOppgaver: FC<{
                     </Table.Row>
                 </Table.Header>
                 <Table.Body>
-                    {oppgaverForAutomatiskFerdigstilling.oppgaver.map(
+                    {oppgaverSomKanAutomatiskFerdigstilles.oppgaver.map(
                         (
                             {
                                 id,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Rename av "hentOppgaverForAutomatiskFerdigstilling" til "hentOppgaverSomKanAutomatiskFerdigstilles" for å gjøre det lettere å forstå hva som foregår og for å følge samme mønster som "kanOpprettes" og skalOpprettes"